### PR TITLE
Remove maxcount shacl

### DIFF
--- a/shacl/register.ttl
+++ b/shacl/register.ttl
@@ -159,26 +159,20 @@ reg:SchemaDatasetNameProperty a sh:PropertyShape ;
 
 reg:SchemaDistributionNameProperty a sh:PropertyShape ;
     sh:path schema:name ;
-    sh:minCount 0 ;
     sh:datatype xsd:string ;
     sh:name "Naam van de distributie"@nl, "Name of the distributie"@en ;
-    sh:message "Een distributie mag maximaal een naam te bevatten"@nl, "A dataset distributie can have one or no name"@en ;
 .
 
 reg:SchemaAlternateNameProperty a sh:PropertyShape ;
     sh:path schema:alternateName ;
-    sh:minCount 0 ;
     sh:datatype xsd:string ;
     sh:name "Alternatieve naam van de dataset"@nl, "Alternative name of the dataset"@en ;
-    sh:message "Een datasetbeschrijving kan meerdere alternatieve naam te bevatten"@nl, "A dataset description can contain multiple alternative names"@en ;
 .
 
 reg:SchemaDescriptionProperty a sh:PropertyShape ;
     sh:path schema:description ;
-    sh:minCount 0 ;
     sh:datatype xsd:string ;
     sh:name "Beschrijving van de dataset"@nl, "Description of the dataset"@en ;
-    sh:message "Een datasetbeschrijving kan een beschrijving bevatten"@nl, "A dataset description should have a description"@en ;
 .
 
 reg:SchemaDateCreatedProperty a sh:PropertyShape ;
@@ -246,7 +240,6 @@ reg:SchemaDistributionLicenseProperty a sh:PropertyShape ;
 
 reg:SchemaDistributionProperty a sh:PropertyShape ;
     sh:class schema:DataDownload ;
-    sh:minCount 0 ;
     sh:node reg:DistributionShape ;
     sh:path schema:distribution ;
     sh:name "Distributies van een dataset"@nl ;
@@ -266,10 +259,8 @@ dcat:DatasetShape
         sh:minCount 1 ;
         sh:path dc:title
     ], [
-        sh:minCount 0 ;
         sh:path dc:alternative
     ], [
-        sh:minCount 0 ;
         sh:path dc:description
     ], [
         sh:minCount 1 ;
@@ -293,7 +284,6 @@ dcat:DatasetShape
     ],
     [
         sh:path dcat:distribution ;
-        sh:minCount 0 ;
         sh:class dcat:Distribution ;
         sh:node dcat:DistributionShape
     ] ;

--- a/shacl/register.ttl
+++ b/shacl/register.ttl
@@ -6,6 +6,7 @@
 @prefix dc: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix reg: <http://terms.netwerkdigitaalerfgoed.nl/ns/register#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 ##
 ## Schema.org
@@ -112,7 +113,10 @@ reg:DateTimeShape
 reg:SchemaCatalogNameProperty a sh:PropertyShape ;
     sh:path schema:name ;
     sh:minCount 1 ;
-    sh:datatype xsd:string ;
+        sh:or (
+		[ sh:datatype xsd:string ]
+		[ sh:datatype rdf:langString ]
+	);
     sh:name "Naam van de datacatalogus"@nl, "Name of the data catalog"@en ;
     sh:message "Een datacatalogus dient een naam te bevatten"@nl, "A data catalog should have a name"@en ;
 .
@@ -152,26 +156,38 @@ reg:SchemaDatasetProperty a sh:PropertyShape ;
 reg:SchemaDatasetNameProperty a sh:PropertyShape ;
     sh:path schema:name ;
     sh:minCount 1 ;
-    sh:datatype xsd:string ;
+    sh:or (
+		[ sh:datatype xsd:string ]
+		[ sh:datatype rdf:langString ]
+	);
     sh:name "Naam van de dataset"@nl, "Name of the dataset"@en ;
     sh:message "Een datasetbeschrijving dient een naam te bevatten"@nl, "A dataset description should have a name"@en ;
 .
 
 reg:SchemaDistributionNameProperty a sh:PropertyShape ;
     sh:path schema:name ;
-    sh:datatype xsd:string ;
+    sh:or (
+		[ sh:datatype xsd:string ]
+		[ sh:datatype rdf:langString ]
+	);
     sh:name "Naam van de distributie"@nl, "Name of the distributie"@en ;
 .
 
 reg:SchemaAlternateNameProperty a sh:PropertyShape ;
     sh:path schema:alternateName ;
-    sh:datatype xsd:string ;
+    sh:or (
+		[ sh:datatype xsd:string ]
+		[ sh:datatype rdf:langString ]
+	);
     sh:name "Alternatieve naam van de dataset"@nl, "Alternative name of the dataset"@en ;
 .
 
 reg:SchemaDescriptionProperty a sh:PropertyShape ;
     sh:path schema:description ;
-    sh:datatype xsd:string ;
+    sh:or (
+		[ sh:datatype xsd:string ]
+		[ sh:datatype rdf:langString ]
+	);
     sh:name "Beschrijving van de dataset"@nl, "Description of the dataset"@en ;
 .
 

--- a/shacl/register.ttl
+++ b/shacl/register.ttl
@@ -113,7 +113,7 @@ reg:DateTimeShape
 reg:SchemaCatalogNameProperty a sh:PropertyShape ;
     sh:path schema:name ;
     sh:minCount 1 ;
-        sh:or (
+    sh:or (
 		[ sh:datatype xsd:string ]
 		[ sh:datatype rdf:langString ]
 	);
@@ -124,6 +124,10 @@ reg:SchemaCatalogNameProperty a sh:PropertyShape ;
 reg:OrganizationNameProperty a sh:PropertyShape ;
     sh:minCount 1 ;
     sh:path schema:name ;
+    sh:or (
+		[ sh:datatype xsd:string ]
+		[ sh:datatype rdf:langString ]
+	);
     sh:message "Een organisatie moet een naam hebben"@nl, "An organization must contain a name"@en ;
 .
 

--- a/shacl/register.ttl
+++ b/shacl/register.ttl
@@ -112,7 +112,6 @@ reg:DateTimeShape
 reg:SchemaCatalogNameProperty a sh:PropertyShape ;
     sh:path schema:name ;
     sh:minCount 1 ;
-    sh:maxCount 1 ;
     sh:datatype xsd:string ;
     sh:name "Naam van de datacatalogus"@nl, "Name of the data catalog"@en ;
     sh:message "Een datacatalogus dient een naam te bevatten"@nl, "A data catalog should have a name"@en ;
@@ -120,7 +119,6 @@ reg:SchemaCatalogNameProperty a sh:PropertyShape ;
 
 reg:OrganizationNameProperty a sh:PropertyShape ;
     sh:minCount 1 ;
-    sh:maxCount 1 ;
     sh:path schema:name ;
     sh:message "Een organisatie moet een naam hebben"@nl, "An organization must contain a name"@en ;
 .
@@ -154,7 +152,6 @@ reg:SchemaDatasetProperty a sh:PropertyShape ;
 reg:SchemaDatasetNameProperty a sh:PropertyShape ;
     sh:path schema:name ;
     sh:minCount 1 ;
-    sh:maxCount 1 ;
     sh:datatype xsd:string ;
     sh:name "Naam van de dataset"@nl, "Name of the dataset"@en ;
     sh:message "Een datasetbeschrijving dient een naam te bevatten"@nl, "A dataset description should have a name"@en ;
@@ -163,7 +160,6 @@ reg:SchemaDatasetNameProperty a sh:PropertyShape ;
 reg:SchemaDistributionNameProperty a sh:PropertyShape ;
     sh:path schema:name ;
     sh:minCount 0 ;
-    sh:maxCount 1 ;
     sh:datatype xsd:string ;
     sh:name "Naam van de distributie"@nl, "Name of the distributie"@en ;
     sh:message "Een distributie mag maximaal een naam te bevatten"@nl, "A dataset distributie can have one or no name"@en ;
@@ -180,7 +176,6 @@ reg:SchemaAlternateNameProperty a sh:PropertyShape ;
 reg:SchemaDescriptionProperty a sh:PropertyShape ;
     sh:path schema:description ;
     sh:minCount 0 ;
-    sh:maxCount 1 ;
     sh:datatype xsd:string ;
     sh:name "Beschrijving van de dataset"@nl, "Description of the dataset"@en ;
     sh:message "Een datasetbeschrijving kan een beschrijving bevatten"@nl, "A dataset description should have a description"@en ;
@@ -269,15 +264,12 @@ dcat:DatasetShape
     a sh:NodeShape ;
     sh:property [
         sh:minCount 1 ;
-        sh:maxCount 1 ;
         sh:path dc:title
     ], [
         sh:minCount 0 ;
-        sh:maxCount 1 ;
         sh:path dc:alternative
     ], [
         sh:minCount 0 ;
-        sh:maxCount 1 ;
         sh:path dc:description
     ], [
         sh:minCount 1 ;
@@ -336,7 +328,6 @@ dcat:OrganizationShape
     a sh:NodeShape ;
     sh:property [
         sh:minCount 1 ;
-        sh:maxCount 1 ;
         sh:path foaf:name
     ] ;
 .

--- a/test/datasets/dataset-schema-kb-valid.jsonld
+++ b/test/datasets/dataset-schema-kb-valid.jsonld
@@ -1,0 +1,44 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "name": [ 
+     { "@value":"Alba amicorum van de Koninklijke Bibliotheek", "@language": "nl"},
+	 { "@value":"Alba amicorum of the Dutch Royal Library", "@language":"en"} 
+  ],
+  "description": { "@value":"Alba amicorum van de Koninklijke Bibliotheek, een dataset gedefinieerd voor het Europeana Rise of Literacy project.", "@language": "nl" },
+  "url": "https://www.kb.nl/bronnen-zoekwijzers/kb-collecties/moderne-handschriften-vanaf-ca-1550/alba-amicorum",
+  "identifier": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "keywords": [
+    "alba amicorum"
+  ],
+  "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "publisher": {
+    "@id": "https://www.kb.nl/",
+    "@type": "Organization",
+    "name": "Koninklijke Bibliotheek",
+    "sameAs": "https://ror.org/02w4jbg70"
+  },
+  "distribution": [
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "application/rdf+xml",
+      "contentUrl": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf"
+    },
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "text/turtle",
+      "contentUrl": "http://data.bibliotheken.nl/id/dataset/rise-alba.ttl"
+    },
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "application/n-triples",
+      "contentUrl": "http://data.bibliotheken.nl/id/dataset/rise-alba.nt"
+    },
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "application/ld+json",
+      "contentUrl": "http://data.bibliotheken.nl/id/dataset/rise-alba.json"
+    }
+  ]
+}

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -28,6 +28,13 @@ describe('Validator', () => {
     expect(report.state).toEqual('valid');
   });
 
+  it('accepts valid Schema.org dataset language selectors', async () => {
+    const report = await validate(
+      'dataset-schema-kb-valid.jsonld'
+    );
+    expect(report.state).toEqual('valid');
+  });
+
   it('reports invalid Schema.org dataset', async () => {
     const report = await validate('dataset-schema-org-invalid.jsonld');
     expect(report.state).toBe('invalid');


### PR DESCRIPTION
Fix for https://github.com/netwerk-digitaal-erfgoed/dataset-register/issues/242
removed all sh:minCount sh:maxCount rules from string-type properties and allowed for strings with language selector.