### PR TITLE
Simplify Comunica error handling

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['json-summary', 'text'],
   coverageThreshold: {
     global: {
-      lines: 90.84,
-      statements: 91.04,
-      branches: 73.77,
-      functions: 94.83,
+      lines: 92.57,
+      statements: 92.73,
+      branches: 80.33,
+      functions: 95,
     },
   },
 };

--- a/src/crawler.ts
+++ b/src/crawler.ts
@@ -1,6 +1,6 @@
 import {Registration, RegistrationStore} from './registration';
 import {DatasetStore, extractIris} from './dataset';
-import {fetch, NoDatasetFoundAtUrl, UrlNotFound} from './fetch';
+import {fetch, HttpError, NoDatasetFoundAtUrl} from './fetch';
 import DatasetExt from 'rdf-ext/lib/Dataset';
 import {Logger} from 'pino';
 
@@ -21,15 +21,16 @@ export class Crawler {
     for (const registration of registrations) {
       this.logger.info(`Crawling registration URL ${registration.url}`);
       let datasets: DatasetExt[] = [];
-      let statusCode: number;
+      let statusCode = 200;
 
       try {
         datasets = await fetch(registration.url);
         this.datasetStore.store(datasets);
-        statusCode = 200;
       } catch (e) {
-        if (e instanceof UrlNotFound || e instanceof NoDatasetFoundAtUrl) {
-          statusCode = parseInt(e.message);
+        if (e instanceof HttpError) {
+          statusCode = e.statusCode;
+        } else if (e instanceof NoDatasetFoundAtUrl) {
+          // Request was successful, but no datasets exist any longer at the URL, so ignore.
         } else {
           throw e;
         }

--- a/test/crawler.test.ts
+++ b/test/crawler.test.ts
@@ -19,23 +19,36 @@ describe('Crawler', () => {
   });
 
   it('stores error HTTP response status code', async () => {
-    nock('https://example.com').head('/registered-url').reply(404);
+    storeRegistrationFixture(new URL('https://example.com/registered-url'));
 
-    const registration = new Registration(
-      new URL('https://example.com/registered-url'),
-      new Date()
-    );
-    registration.read(
-      [new URL('https://example.com/dataset1')],
-      200,
-      new Date('2000-01-01')
-    );
-    registrationStore.store(registration);
-
+    nock('https://example.com').get('/registered-url').reply(404);
     await crawler.crawl(new Date('3000-01-01'));
 
     const readRegistration = registrationStore.all()[0];
     expect(readRegistration.statusCode).toBe(404);
     expect(readRegistration.datasets).toEqual([]); // Any datasets previously read at the URL are emptied.
   });
+
+  it('ignores datasets no longer available', async () => {
+    storeRegistrationFixture(new URL('https://example.com/no-more-datasets'));
+
+    nock('https://example.com')
+      .get('/no-more-datasets')
+      .reply(200, 'no datasets');
+    await crawler.crawl(new Date('3000-01-01'));
+
+    const readRegistration = registrationStore.all()[0];
+    expect(readRegistration.statusCode).toBe(200);
+    expect(readRegistration.datasets).toEqual([]); // Any datasets previously read at the URL are emptied.
+  });
 });
+
+function storeRegistrationFixture(url: URL) {
+  const registration = new Registration(url, new Date());
+  registration.read(
+    [new URL('https://example.com/dataset1')],
+    200,
+    new Date('2000-01-01')
+  );
+  registrationStore.store(registration);
+}

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -52,6 +52,19 @@ describe('Server', () => {
     expect(response.statusCode).toEqual(404);
   });
 
+  it('rejects validation requests that point to URL with empty response', async () => {
+    nock('https://example.com/').get('/200').reply(200, '');
+    const response = await httpServer.inject({
+      method: 'PUT',
+      url: '/datasets/validate',
+      headers: {'Content-Type': 'application/ld+json'},
+      payload: JSON.stringify({
+        '@id': 'https://example.com/200',
+      }),
+    });
+    expect(response.statusCode).toEqual(406);
+  });
+
   it('responds with 200 to valid dataset requests', async () => {
     const {nockDone} = await nock.back('valid-dataset.json');
     const response = await httpServer.inject({


### PR DESCRIPTION
* Fix #282.
* Remove HEAD request that is no longer needed.
* Re-use Comunica error parsing in both query() and dereference() call
  sites.
