### PR TITLE
Encode dataset graph URL

### DIFF
--- a/src/graphdb.ts
+++ b/src/graphdb.ts
@@ -271,7 +271,7 @@ export class GraphDbDatasetStore implements DatasetStore {
     await getWriter(dataset.toArray()).end(async (error, result) => {
       await this.client.request(
         'PUT',
-        '/rdf-graphs/service?graph=' + graphIri.toString(),
+        '/rdf-graphs/service?graph=' + encodeURIComponent(graphIri.toString()),
         result
       );
     });


### PR DESCRIPTION
Fix #282.

Fix GraphDB error when storing graphs URLs that
contained characters such as `+` (space).
