### PR TITLE
Store registration URL validity during crawl

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Datasets are fetched from this URL on registration and when [crawling](#crawler)
 | [`schema:datePosted`](https://schema.org/datePosted) | When the URL was registered. |
 | [`schema:dateRead`](https://schema.org/dateRead) | When the URL was last read by the application. The [crawler](#crawler) updates this value when fetching descriptions. |
 | [`schema:status`](https://schema.org/status) | The HTTP status code last encountered when fetching the URL. |
+| [`schema:validUntil`](https://schema.org/validUntil) | If the URL has become [invalid](#validate-dataset-descriptions), the date at which it did so. |
 | [`schema:about`](https://schema.org/about) | The set of [`schema:Dataset`s](#schemadataset) that the URL contains. The [crawler](#crawler) updates this value when fetching descriptions. |
 
 ### `schema:Dataset`

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,10 +6,10 @@ module.exports = {
   coverageReporters: ['json-summary', 'text'],
   coverageThreshold: {
     global: {
-      lines: 92.14,
-      statements: 92.3,
-      branches: 79.24,
-      functions: 95.23,
+      lines: 94.82,
+      statements: 94.94,
+      branches: 81.13,
+      functions: 98.46,
     },
   },
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,9 +27,14 @@ const client = new GraphDbClient(
   const registrationStore = new GraphDbRegistrationStore(client);
   const allowedRegistrationDomainStore =
     new GraphDbAllowedRegistrationDomainStore(client);
-  const crawler = new Crawler(registrationStore, datasetStore, logger);
   const shacl = await readUrl('shacl/register.ttl');
   const validator = new ShaclValidator(shacl);
+  const crawler = new Crawler(
+    registrationStore,
+    datasetStore,
+    validator,
+    logger
+  );
 
   // Schedule crawler to check every hour for CRAWLER_INTERVAL that have expired their REGISTRATION_URL_TTL.
   const ttl = ((process.env.REGISTRATION_URL_TTL || 86400) as number) * 1000;

--- a/src/registration.ts
+++ b/src/registration.ts
@@ -2,6 +2,12 @@ import {URL} from 'url';
 
 export class Registration {
   private _dateRead?: Date;
+
+  /**
+   * If the Registration has become invalid, the date at which it did so.
+   */
+  private _validUntil?: Date;
+
   private _statusCode?: number;
   private _datasets: URL[] = [];
 
@@ -10,10 +16,18 @@ export class Registration {
   /**
    * Mark the Registration as read at a date.
    */
-  public read(datasets: URL[], statusCode: number, date: Date = new Date()) {
+  public read(
+    datasets: URL[],
+    statusCode: number,
+    valid: boolean,
+    date: Date = new Date()
+  ) {
     this._datasets = datasets;
     this._statusCode = statusCode;
     this._dateRead = date;
+    if (!valid) {
+      this._validUntil = date;
+    }
   }
 
   get dateRead() {
@@ -24,12 +38,19 @@ export class Registration {
     return this._statusCode;
   }
 
+  get validUntil() {
+    return this._validUntil;
+  }
+
   get datasets() {
     return this._datasets;
   }
 }
 
 export interface RegistrationStore {
+  /**
+   * Store a {@see Registration}, replacing any Registrations with the same URL.
+   */
   store(registration: Registration): void;
   findRegistrationsReadBefore(date: Date): Promise<Registration[]>;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -164,7 +164,7 @@ export async function server(
         await datasetStore.store(datasets);
 
         // Update registration with dataset descriptions that we found.
-        registration.read([...extractIris(datasets).keys()], 200);
+        registration.read([...extractIris(datasets).keys()], 200, true);
         await registrationStore.store(registration);
       }
     }

--- a/test/crawler.test.ts
+++ b/test/crawler.test.ts
@@ -1,12 +1,21 @@
 import {Registration} from '../src/registration';
 import {Crawler} from '../src/crawler';
 import {URL} from 'url';
-import {MockDatasetStore, MockRegistrationStore} from './mock';
+import {file, MockDatasetStore, MockRegistrationStore} from './mock';
 import nock from 'nock';
 import Pino from 'pino';
+import {Validator} from '../src/validator';
+import factory from 'rdf-ext';
 
 let registrationStore: MockRegistrationStore;
 let crawler: Crawler;
+const validator = (isValid: boolean): Validator => ({
+  validate: () =>
+    Promise.resolve({
+      state: isValid ? 'valid' : 'invalid',
+      errors: factory.dataset(),
+    }),
+});
 
 describe('Crawler', () => {
   beforeEach(async () => {
@@ -14,8 +23,27 @@ describe('Crawler', () => {
     crawler = new Crawler(
       registrationStore,
       new MockDatasetStore(),
+      validator(true),
       Pino({enabled: false})
     );
+  });
+
+  it('crawls valid URLs', async () => {
+    storeRegistrationFixture(new URL('https://example.com/valid'));
+
+    const response = await file('dataset-schema-org-valid.jsonld');
+    nock('https://example.com')
+      .defaultReplyHeaders({'Content-Type': 'application/ld+json'})
+      .get('/valid')
+      .times(2)
+      .reply(200, response);
+    await crawler.crawl(new Date('3000-01-01'));
+
+    const readRegistration = registrationStore.all()[0];
+    expect(readRegistration.statusCode).toBe(200);
+    expect(readRegistration.datasets).toEqual([
+      new URL('http://data.bibliotheken.nl/id/dataset/rise-alba'),
+    ]);
   });
 
   it('stores error HTTP response status code', async () => {
@@ -41,6 +69,25 @@ describe('Crawler', () => {
     expect(readRegistration.statusCode).toBe(200);
     expect(readRegistration.datasets).toEqual([]); // Any datasets previously read at the URL are emptied.
   });
+
+  it('logs URLs that no longer validate', async () => {
+    crawler = new Crawler(
+      registrationStore,
+      new MockDatasetStore(),
+      validator(false),
+      Pino({enabled: false})
+    );
+    storeRegistrationFixture(new URL('https://example.com/invalid'));
+
+    nock('https://example.com')
+      .defaultReplyHeaders({'Content-Type': 'application/ld+json'})
+      .get('/invalid')
+      .reply(200);
+    await crawler.crawl(new Date('3000-01-01'));
+
+    const readRegistration = registrationStore.all()[0];
+    expect(readRegistration.validUntil).not.toBeUndefined();
+  });
 });
 
 function storeRegistrationFixture(url: URL) {
@@ -48,6 +95,7 @@ function storeRegistrationFixture(url: URL) {
   registration.read(
     [new URL('https://example.com/dataset1')],
     200,
+    true,
     new Date('2000-01-01')
   );
   registrationStore.store(registration);

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,9 +1,9 @@
 import {URL} from 'url';
 import {fetch, HttpError, NoDatasetFoundAtUrl} from '../src/fetch';
 import nock from 'nock';
-import fs from 'fs';
 import {dcat, dct, rdf} from '../src/query';
 import factory from 'rdf-ext';
+import {file} from './mock';
 
 describe('Fetch', () => {
   it('must accept valid DCAT dataset descriptions', async () => {
@@ -159,6 +159,3 @@ describe('Fetch', () => {
     }
   });
 });
-
-const file = async (filename: string) =>
-  await fs.promises.readFile(`test/datasets/${filename}`, 'utf-8');

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -6,6 +6,7 @@ import {
 import {URL} from 'url';
 import {DatasetStore} from '../src/dataset';
 import DatasetExt from 'rdf-ext/lib/Dataset';
+import fs from 'fs';
 
 export class MockRegistrationStore implements RegistrationStore {
   private readonly registrations: Map<URL, Registration> = new Map();
@@ -45,9 +46,12 @@ export class MockAllowedRegistrationDomainStore
 }
 
 export class MockDatasetStore implements DatasetStore {
-  private readonly datasets = [];
+  private datasets: DatasetExt[] = [];
 
   store(datasets: DatasetExt[]): void {
-    datasets.push(...datasets);
+    this.datasets.push(...datasets);
   }
 }
+
+export const file = async (filename: string) =>
+  await fs.promises.readFile(`test/datasets/${filename}`, 'utf-8');


### PR DESCRIPTION
* Validate before querying the URL during crawl.
* Document property.
* Simplify Registration quad creation.
* Fix #112.
