### PR TITLE
Fix distribution query optionals

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -125,6 +125,15 @@ export const selectQuery = `
         ${distribution} a dcat:Distribution ;
           dcat:accessURL ${distributionUrl} ;
           dct:format ${distributionFormat} .
+          
+        OPTIONAL { ${distribution} dcat:mediaType ${distributionMediaType} }
+        OPTIONAL { ${distribution} dct:issued ${distributionDatePublished} }
+        OPTIONAL { ${distribution} dct:modified ${distributionDateModified} }
+        OPTIONAL { ${distribution} dct:description ${distributionDescription} }
+        OPTIONAL { ${distribution} dct:language ${distributionLanguage} }
+        OPTIONAL { ${distribution} dct:license ${distributionLicense} }
+        OPTIONAL { ${distribution} dct:title ${distributionName} }
+        OPTIONAL { ${distribution} dcat:byteSize ${distributionSize} }
       }
         
       OPTIONAL { ${dataset} dct:description ${description} }
@@ -138,15 +147,6 @@ export const selectQuery = `
       OPTIONAL { ${dataset} dcat:keyword ${keyword} }
       OPTIONAL { ${dataset} owl:versionInfo ${version} }
       OPTIONAL { ${dataset} dcat:landingPage ${mainEntityOfPage} }
-      
-      OPTIONAL { ${distribution} dcat:mediaType ${distributionMediaType} }
-      OPTIONAL { ${distribution} dct:issued ${distributionDatePublished} }
-      OPTIONAL { ${distribution} dct:modified ${distributionDateModified} }
-      OPTIONAL { ${distribution} dct:description ${distributionDescription} }
-      OPTIONAL { ${distribution} dct:language ${distributionLanguage} }
-      OPTIONAL { ${distribution} dct:license ${distributionLicense} }
-      OPTIONAL { ${distribution} dct:title ${distributionName} }
-      OPTIONAL { ${distribution} dcat:byteSize ${distributionSize} }
     }
   } LIMIT ${sparqlLimit}`;
 
@@ -255,6 +255,15 @@ function schemaOrgQuery(prefix: string): string {
       ${distribution} a ${prefix}:DataDownload ;
         ${prefix}:contentUrl ${distributionUrl} ;
         ${prefix}:encodingFormat ${distributionFormat} .
+        
+      OPTIONAL { ${distribution} ${prefix}:fileFormat ${distributionMediaType} }
+      OPTIONAL { ${distribution} ${prefix}:datePublished ${distributionDatePublished} }
+      OPTIONAL { ${distribution} ${prefix}:dateModified ${distributionDateModified} }
+      OPTIONAL { ${distribution} ${prefix}:description ${distributionDescription} }
+      OPTIONAL { ${distribution} ${prefix}:inLanguage ${distributionLanguage} }
+      OPTIONAL { ${distribution} ${prefix}:license ${distributionLicense} }
+      OPTIONAL { ${distribution} ${prefix}:name ${distributionName} }
+      OPTIONAL { ${distribution} ${prefix}:contentSize ${distributionSize} }
     } 
      
     OPTIONAL { ${dataset} ${prefix}:description ${description} } 
@@ -269,14 +278,5 @@ function schemaOrgQuery(prefix: string): string {
     OPTIONAL { ${dataset} ${prefix}:keywords ${keyword} }
     OPTIONAL { ${dataset} ${prefix}:version ${version} }
     OPTIONAL { ${dataset} ${prefix}:mainEntityOfPage ${mainEntityOfPage} }
-    
-    OPTIONAL { ${distribution} ${prefix}:fileFormat ${distributionMediaType} }
-    OPTIONAL { ${distribution} ${prefix}:datePublished ${distributionDatePublished} }
-    OPTIONAL { ${distribution} ${prefix}:dateModified ${distributionDateModified} }
-    OPTIONAL { ${distribution} ${prefix}:description ${distributionDescription} }
-    OPTIONAL { ${distribution} ${prefix}:inLanguage ${distributionLanguage} }
-    OPTIONAL { ${distribution} ${prefix}:license ${distributionLicense} }
-    OPTIONAL { ${distribution} ${prefix}:name ${distributionName} }
-    OPTIONAL { ${distribution} ${prefix}:contentSize ${distributionSize} }
 `;
 }

--- a/test/datasets/dataset-schema-org-valid.jsonld
+++ b/test/datasets/dataset-schema-org-valid.jsonld
@@ -15,7 +15,6 @@
   "description": {
     "@value": "en",
     "@language": "Description only in English"
-
   },
   "url": "https://www.kb.nl/bronnen-zoekwijzers/kb-collecties/moderne-handschriften-vanaf-ca-1550/alba-amicorum",
   "identifier": "http://data.bibliotheken.nl/id/dataset/rise-alba",
@@ -43,5 +42,17 @@
   "dateCreated": {
     "@type": "http://www.w3.org/2001/XMLSchema#date",
     "@value": "2021-05-27"
-  }
+  },
+  "distribution": [
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "application/rdf+xml",
+      "contentUrl": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf"
+    },
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "application/ld+json",
+      "contentUrl": "http://data.bibliotheken.nl/id/dataset/rise-alba.jsonld"
+    }
+  ]
 }

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -44,7 +44,7 @@ describe('Fetch', () => {
 
     expect(datasets).toHaveLength(1);
     const dataset = datasets[0];
-    expect(dataset.size).toBe(8);
+    expect(dataset.size).toBe(6);
   });
 
   it('accepts valid Schema.org dataset description', async () => {
@@ -60,7 +60,7 @@ describe('Fetch', () => {
 
     expect(datasets).toHaveLength(1);
     const dataset = datasets[0];
-    expect(dataset.size).toBe(19);
+    expect(dataset.size).toBe(25);
     expect(
       dataset.includes(
         factory.quad(
@@ -83,6 +83,14 @@ describe('Fetch', () => {
         )
       )
     ).toBe(true);
+    expect(
+      dataset.match(
+        factory.namedNode('http://data.bibliotheken.nl/id/dataset/rise-alba'),
+        dcat('distribution'),
+        null,
+        factory.namedNode('http://data.bibliotheken.nl/id/dataset/rise-alba')
+      )
+    ).toHaveLength(2);
   });
 
   it('accepts valid Schema.org dataset in Turtle', async () => {


### PR DESCRIPTION
* It seems the `?distribution` query variable is not global to the whole
  query but only within its `OPTIONAL`. As a result of this, and because
  datasets and distributions share some properties (such as
  `schema:datePublished`), datasets were sometimes seen as
  distributions too.
* Solve the issue by moving the `OPTIONAL`s inside the main distribution
  `OPTIONAL`.
