### PR TITLE
Recommend description

### DIFF
--- a/shacl/register.ttl
+++ b/shacl/register.ttl
@@ -27,7 +27,8 @@ reg:DatacatalogShape
         reg:SchemaCatalogNameProperty,
         reg:SchemaPublisherProperty,
         # Recommended properties
-        reg:SchemaDescriptionProperty ;
+        reg:SchemaDescriptionProperty,
+        reg:SchemaDescriptionPropertyShouldExist ;
 .
 
 reg:DatasetShape
@@ -37,7 +38,6 @@ reg:DatasetShape
     sh:pattern "^https?://" ;
     rdfs:label "Datasetbeschrijving"@nl, "Dataset description"@en ;
     rdfs:comment "Een datasetbeschrijving bestaat uit een elementen die de dataset beschrijft"@nl, "A dataset description consists of elements that describe the dataset"@en ;
-    sh:targetClass schema:Dataset ;
 
     sh:property
         # Required properties
@@ -46,6 +46,7 @@ reg:DatasetShape
         reg:SchemaPublisherProperty,
         # Recommended properties
         reg:SchemaDescriptionProperty,
+        reg:SchemaDescriptionPropertyShouldExist,
         reg:SchemaDistributionProperty,
         reg:SchemaCreatorProperty,
         reg:SchemaDateCreatedProperty,
@@ -69,6 +70,7 @@ reg:DistributionShape
         # Recommended properties
         reg:SchemaDistributionNameProperty,
         reg:SchemaDescriptionProperty,
+        reg:SchemaDescriptionPropertyShouldExist,
         reg:SchemaDatePublishedProperty,
         reg:SchemaDateModifiedProperty,
         reg:SchemaDistributionLicenseProperty ;
@@ -193,8 +195,15 @@ reg:SchemaDescriptionProperty a sh:PropertyShape ;
         [ sh:datatype xsd:string ]
         [ sh:datatype rdf:langString ]
     );
-    sh:name "Beschrijving van de dataset"@nl, "Description of the dataset"@en ;
-    sh:message "Een datasetbeschrijving kan een beschrijving bevatten"@nl, "A dataset description should have a description"@en ;
+    sh:maxCount 1 ;
+    sh:message "Moet precies één beschrijving hebben van type string of langString"@nl, "Must have a single description of type string or langString"@en ;
+.
+
+reg:SchemaDescriptionPropertyShouldExist a sh:PropertyShape ;
+  sh:path schema:description ;
+  sh:minCount 1 ;
+  sh:severity sh:Info ;
+  sh:message "Kan een beschrijving hebben"@nl, "Should have a description"@en ;
 .
 
 reg:SchemaDateCreatedProperty a sh:PropertyShape ;
@@ -261,8 +270,9 @@ reg:SchemaDistributionLicenseProperty a sh:PropertyShape ;
 
 reg:SchemaDistributionProperty a sh:PropertyShape ;
     sh:class schema:DataDownload ;
-    sh:minCount 0 ;
+    sh:minCount 1 ;
     sh:node reg:DistributionShape ;
+    sh:severity sh:Info ;
     sh:path schema:distribution ;
     sh:name "Distributies van een dataset"@nl ;
 .

--- a/test/datasets/dataset-http-schema-org-valid.ttl
+++ b/test/datasets/dataset-http-schema-org-valid.ttl
@@ -10,7 +10,7 @@
   schema:description "Combinatie van kadastrale perceelnummers uit 1832 met Verpondingsnummers uit het verpondingsregister 1875 en de plaatselijke aanduiding uit het verpondingsregister." ;
   schema:license "http://creativecommons.org/publicdomain/zero/1.0/deed.nl"@nl ;
   schema:publisher <https://www.goudatijdmachine.nl/data/api/items/232> ;
-    schema:distribution <https://www.goudatijdmachine.nl/data/api/items/144> .
+  schema:distribution <https://www.goudatijdmachine.nl/data/api/items/144> .
 
 <https://www.goudatijdmachine.nl/data/api/items/232>
   a schema:Organization ;

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -20,8 +20,12 @@ describe('Validator', () => {
   });
 
   it('accepts minimal valid Schema.org dataset', async () => {
-    const report = await validate('dataset-schema-org-valid-minimal.jsonld');
+    const report = (await validate(
+      'dataset-schema-org-valid-minimal.jsonld'
+    )) as Valid;
     expect(report.state).toEqual('valid');
+    expectViolations(report, ['https://schema.org/description']);
+    expectViolations(report, ['https://schema.org/distribution']);
   });
 
   it('accepts minimal valid Schema.org dataset in Turtle', async () => {
@@ -167,7 +171,10 @@ const dataset = async (filename: string, parser?: Transform) => {
   );
 };
 
-const expectViolations = (report: InvalidDataset, violationPaths: string[]) =>
+const expectViolations = (
+  report: InvalidDataset | Valid,
+  violationPaths: string[]
+) =>
   violationPaths.forEach(violationPath =>
     expect(
       report.errors.match(


### PR DESCRIPTION
* Use severity level `sh:Info` for recommendations.
* Split into two property shapes: one for description existence
  (`sh:Info`) and one for validating the description if it exists
  (`sh:Violation`).
* Lower `SchemaDistributionProperty` to `sh:Info` to support
  distributions that have no description, which is optional.
* Ref #366.
