### PR TITLE
fix: Empty HTTP responses

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -187,11 +187,12 @@ export async function server(
           process.memoryUsage().rss / 1024 / 1024
         )} MB memory`
       );
+      return reply;
     }
   );
 
   server.get('/shacl', rdfSerializerConfig, async (request, reply) => {
-    reply.send(shacl);
+    return reply.send(shacl);
   });
 
   /**

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -78,6 +78,7 @@ describe('Server', () => {
     });
     nockDone();
     expect(response.statusCode).toEqual(200);
+    expect(response.payload).not.toEqual('');
   });
 
   it('responds with validation errors to invalid dataset requests', async () => {
@@ -85,14 +86,15 @@ describe('Server', () => {
     const response = await httpServer.inject({
       method: 'PUT',
       url: '/datasets/validate',
-      headers: {'Content-Type': 'application/ld+json'},
+      headers: {'Content-Type': 'application/ld+json', Accept: 'text/turtle'},
       payload: JSON.stringify({
         '@id': 'https://demo.netwerkdigitaalerfgoed.nl/datasets/kb/2a.html',
       }),
     });
     nockDone();
     expect(response.statusCode).toEqual(400);
-    expect(response.headers['content-type']).toEqual('application/ld+json');
+    expect(response.headers['content-type']).toEqual('text/turtle');
+    expect(response.payload).not.toEqual('');
   });
 
   it('ignores UTF-8 BOMs', async () => {
@@ -150,6 +152,7 @@ describe('Server', () => {
     });
     nockDone();
     expect(response.statusCode).toEqual(202);
+    expect(response.payload).not.toEqual('');
   });
 
   it('stores registration even if fetching datasets fails', async () => {
@@ -180,5 +183,6 @@ describe('Server', () => {
       headers: {'Content-Type': 'text/turtle'},
     });
     expect(response.statusCode).toEqual(200);
+    expect(response.payload).not.toEqual('');
   });
 });


### PR DESCRIPTION
With the automated upgrade to Fastify 4, the routes `/datasets/validate`
and `/shacl` returned empty HTTP responses. Follow the Fastify docs and
make sure to `return reply`. Add tests to prevent this in the future.
