### PR TITLE
feat: Validate dataset in request body

### DIFF
--- a/assets/api.yaml
+++ b/assets/api.yaml
@@ -17,7 +17,7 @@ servers:
 paths:
   /datasets:
     post:
-      summary: Dataset Register dataset descriptions
+      summary: Add dataset description to the Dataset Register
       description: |-
         Submit dataset description(s) to the Dataset Register. Each dataset description will be validated before it is added to the Dataset Register.
 
@@ -54,8 +54,40 @@ paths:
         406:
           description: The URL can be resolved but it contains no datasets.
   /datasets/validate:
+    post:
+      summary: Validate dataset description(s) in the request body
+      description: |-
+        Validate dataset description(s) according to the <a href="https://netwerk-digitaal-erfgoed.github.io/requirements-datasets/">Requirements for Datasets</a>.
+      operationId: validate-body
+      requestBody:
+        content:
+          application/ld+json:
+            schema:
+              type: object
+            examples:
+              valid:
+                summary: A valid dataset in the request body
+                value:
+                  {
+                    "@context": "https://schema.org/",
+                    "@type": "Dataset",
+                    "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+                    "name": "Alba amicorum van de Koninklijke Bibliotheek",
+                    "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+                    "publisher": {
+                      "@type": "Organization",
+                      "@id": "https://example.com/publisher",
+                      "name": "Koninklijke Bibliotheek"
+                    }
+                  }
+      responses:
+        200:
+          $ref: '#/components/responses/Valid'
+        400:
+          $ref: '#/components/responses/Invalid'
+
     put:
-      summary: Validate dataset descriptions
+      summary: Validate dataset description(s)s at a URL
       description: |-
         Validate dataset description(s) according to the <a href="https://netwerk-digitaal-erfgoed.github.io/requirements-datasets/">Requirements for Datasets</a> that are available at the submitted URL. That URL may resolve:
 
@@ -83,76 +115,9 @@ paths:
                 value: {"@id": "https://demo.netwerkdigitaalerfgoed.nl/datasets/kb/2a.html"}
       responses:
         200:
-          description:
-            All dataset descriptions are valid according to the <a href="https://netwerk-digitaal-erfgoed.github.io/requirements-datasets/">Requirements for Datasets</a>.
-          content:
-            application/ld+json:
-              example:
-                - '@id': '_:report'
-                  '@type':
-                    - 'http://www.w3.org/ns/shacl#ValidationReport'
-                  'http://www.w3.org/ns/shacl#conforms':
-                    - '@value': "true"
-                      '@type': 'http://www.w3.org/2001/XMLSchema#boolean'
-            text/turtle:
-              example: |-
-                _:report a <http://www.w3.org/ns/shacl#ValidationReport>;
-                  <http://www.w3.org/ns/shacl#conforms> true.
+          $ref: '#/components/responses/Valid'
         400:
-          description: One or more dataset descriptions are invalid according to the <a href="https://netwerk-digitaal-erfgoed.github.io/requirements-datasets/">Requirements for Datasets</a>. The response body contains a list of [SHACL](https://www.w3.org/TR/shacl/) violations.
-          content:
-            application/ld+json:
-              example:
-                - '@id': '_:b7'
-                  '@type':
-                    - 'http://www.w3.org/ns/shacl#ValidationResult'
-                  'http://www.w3.org/ns/shacl#resultSeverity':
-                    - '@id': 'http://www.w3.org/ns/shacl#Violation'
-                  'http://www.w3.org/ns/shacl#sourceConstraintComponent':
-                    - '@id': 'http://www.w3.org/ns/shacl#MinCountConstraintComponent'
-                  'http://www.w3.org/ns/shacl#sourceShape':
-                    - '@id': '_:df_28_15'
-                - '@id': '_:df_28_15'
-                  'http://www.w3.org/ns/shacl#path':
-                    - '@id': 'http://schema.org/publisher'
-                  'http://www.w3.org/ns/shacl#minCount':
-                    - '@value': '1'
-                      '@type': 'http://www.w3.org/2001/XMLSchema#integer'
-                  'http://www.w3.org/ns/shacl#class':
-                    - '@id': 'http://schema.org/Organization'
-                  'http://www.w3.org/ns/shacl#node':
-                    - '@value': 'schema:PublisherShape'
-                - '@id': '_:b7'
-                  'http://www.w3.org/ns/shacl#focusNode':
-                    - '@id': 'http://data.bibliotheken.nl/id/dataset/rise-alba'
-                  'http://www.w3.org/ns/shacl#resultPath':
-                    - '@id': 'http://schema.org/publisher'
-                  'http://www.w3.org/ns/shacl#resultMessage':
-                    - '@value': Less than 1 values
-                - '@id': '_:report'
-                  '@type':
-                    - 'http://www.w3.org/ns/shacl#ValidationReport'
-                  'http://www.w3.org/ns/shacl#conforms':
-                    - '@value': 'false'
-                      '@type': 'http://www.w3.org/2001/XMLSchema#boolean'
-                  'http://www.w3.org/ns/shacl#result':
-                    - '@id': '_:b10'
-            text/turtle:
-              example: |-
-                _:b11 a <http://www.w3.org/ns/shacl#ValidationResult>;
-                  <http://www.w3.org/ns/shacl#resultSeverity> <http://www.w3.org/ns/shacl#Violation>;
-                  <http://www.w3.org/ns/shacl#sourceConstraintComponent> <http://www.w3.org/ns/shacl#MinCountConstraintComponent>;
-                  <http://www.w3.org/ns/shacl#sourceShape> _:df_28_15.
-                _:df_28_15 <http://www.w3.org/ns/shacl#path> <http://schema.org/publisher>;
-                  <http://www.w3.org/ns/shacl#minCount> 1;
-                  <http://www.w3.org/ns/shacl#class> <http://schema.org/Organization>;
-                  <http://www.w3.org/ns/shacl#node> "schema:PublisherShape".
-                _:b11 <http://www.w3.org/ns/shacl#focusNode> <http://data.bibliotheken.nl/id/dataset/rise-alba>;
-                  <http://www.w3.org/ns/shacl#resultPath> <http://schema.org/publisher>;
-                  <http://www.w3.org/ns/shacl#resultMessage> "Less than 1 values".
-                _:report a <http://www.w3.org/ns/shacl#ValidationReport>;
-                  <http://www.w3.org/ns/shacl#conforms> false;
-                  <http://www.w3.org/ns/shacl#result> _:b11.
+          $ref: '#/components/responses/Invalid'
         404:
           description: The URL cannot be resolved.
         406:
@@ -194,3 +159,77 @@ paths:
                     <http://www.w3.org/ns/shacl#targetClass> <http://schema.org/Dataset>;
                     <http://www.w3.org/ns/shacl#nodeKind> <http://www.w3.org/ns/shacl#IRI>;
                     <http://www.w3.org/ns/shacl#property> <http://terms.netwerkdigitaalerfgoed.nl/ns/register#SchemaNameProperty>, <http://terms.netwerkdigitaalerfgoed.nl/ns/register#SchemaLicenseProperty>, <http://terms.netwerkdigitaalerfgoed.nl/ns/register#SchemaDescriptionProperty>, <http://terms.netwerkdigitaalerfgoed.nl/ns/register#SchemaPublisherPrope
+
+components:
+  responses:
+    Valid:
+      description:
+        All dataset descriptions are valid according to the <a href="https://netwerk-digitaal-erfgoed.github.io/requirements-datasets/">Requirements for Datasets</a>.
+      content:
+        application/ld+json:
+          example:
+            - '@id': '_:report'
+              '@type':
+                - 'http://www.w3.org/ns/shacl#ValidationReport'
+              'http://www.w3.org/ns/shacl#conforms':
+                - '@value': "true"
+                  '@type': 'http://www.w3.org/2001/XMLSchema#boolean'
+        text/turtle:
+          example: |-
+            _:report a <http://www.w3.org/ns/shacl#ValidationReport>;
+              <http://www.w3.org/ns/shacl#conforms> true.
+    Invalid:
+      description: One or more dataset descriptions are invalid according to the <a href="https://netwerk-digitaal-erfgoed.github.io/requirements-datasets/">Requirements for Datasets</a>. The response body contains a list of [SHACL](https://www.w3.org/TR/shacl/) violations.
+      content:
+        application/ld+json:
+          example:
+            - '@id': '_:b7'
+              '@type':
+                - 'http://www.w3.org/ns/shacl#ValidationResult'
+              'http://www.w3.org/ns/shacl#resultSeverity':
+                - '@id': 'http://www.w3.org/ns/shacl#Violation'
+              'http://www.w3.org/ns/shacl#sourceConstraintComponent':
+                - '@id': 'http://www.w3.org/ns/shacl#MinCountConstraintComponent'
+              'http://www.w3.org/ns/shacl#sourceShape':
+                - '@id': '_:df_28_15'
+            - '@id': '_:df_28_15'
+              'http://www.w3.org/ns/shacl#path':
+                - '@id': 'http://schema.org/publisher'
+              'http://www.w3.org/ns/shacl#minCount':
+                - '@value': '1'
+                  '@type': 'http://www.w3.org/2001/XMLSchema#integer'
+              'http://www.w3.org/ns/shacl#class':
+                - '@id': 'http://schema.org/Organization'
+              'http://www.w3.org/ns/shacl#node':
+                - '@value': 'schema:PublisherShape'
+            - '@id': '_:b7'
+              'http://www.w3.org/ns/shacl#focusNode':
+                - '@id': 'http://data.bibliotheken.nl/id/dataset/rise-alba'
+              'http://www.w3.org/ns/shacl#resultPath':
+                - '@id': 'http://schema.org/publisher'
+              'http://www.w3.org/ns/shacl#resultMessage':
+                - '@value': Less than 1 values
+            - '@id': '_:report'
+              '@type':
+                - 'http://www.w3.org/ns/shacl#ValidationReport'
+              'http://www.w3.org/ns/shacl#conforms':
+                - '@value': 'false'
+                  '@type': 'http://www.w3.org/2001/XMLSchema#boolean'
+              'http://www.w3.org/ns/shacl#result':
+                - '@id': '_:b10'
+        text/turtle:
+          example: |-
+            _:b11 a <http://www.w3.org/ns/shacl#ValidationResult>;
+              <http://www.w3.org/ns/shacl#resultSeverity> <http://www.w3.org/ns/shacl#Violation>;
+              <http://www.w3.org/ns/shacl#sourceConstraintComponent> <http://www.w3.org/ns/shacl#MinCountConstraintComponent>;
+              <http://www.w3.org/ns/shacl#sourceShape> _:df_28_15.
+            _:df_28_15 <http://www.w3.org/ns/shacl#path> <http://schema.org/publisher>;
+              <http://www.w3.org/ns/shacl#minCount> 1;
+              <http://www.w3.org/ns/shacl#class> <http://schema.org/Organization>;
+              <http://www.w3.org/ns/shacl#node> "schema:PublisherShape".
+            _:b11 <http://www.w3.org/ns/shacl#focusNode> <http://data.bibliotheken.nl/id/dataset/rise-alba>;
+              <http://www.w3.org/ns/shacl#resultPath> <http://schema.org/publisher>;
+              <http://www.w3.org/ns/shacl#resultMessage> "Less than 1 values".
+            _:report a <http://www.w3.org/ns/shacl#ValidationReport>;
+              <http://www.w3.org/ns/shacl#conforms> false;
+              <http://www.w3.org/ns/shacl#result> _:b11.

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,10 +10,10 @@ export default {
   coverageReporters: ['json-summary', 'text'],
   coverageThreshold: {
     global: {
-      lines: 69.78,
-      statements: 69.66,
-      branches: 61.06,
-      functions: 68.75,
+      lines: 71.59,
+      statements: 71.54,
+      branches: 63.77,
+      functions: 72.52,
     },
   },
   transform: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,9 @@
 import fastify, {
+  FastifyContextConfig,
+  FastifyError,
   FastifyInstance,
   FastifyReply,
+  FastifyRequest,
   FastifyServerOptions,
 } from 'fastify';
 import {Validator} from './validator';
@@ -13,8 +16,8 @@ import {
   Registration,
   RegistrationStore,
 } from './registration';
-import {DatasetStore, extractIris} from './dataset';
-import {Server} from 'http';
+import {DatasetStore, extractIris, load} from './dataset';
+import {IncomingMessage, Server} from 'http';
 import * as psl from 'psl';
 import {rdfSerializer} from './rdf';
 import fastifySwagger from '@fastify/swagger';
@@ -64,17 +67,15 @@ export async function server(
     });
 
   const rdfSerializerConfig = {
-    config: {
-      default: 'application/ld+json',
-      serializers: [
-        ...(await rdfSerializer.getContentTypes()).map(contentType => {
-          return {
-            regex: new RegExp(contentType.replace('+', '\\+')),
-            serializer: serializer(contentType),
-          };
-        }),
-      ],
-    },
+    default: 'application/ld+json',
+    serializers: [
+      ...(await rdfSerializer.getContentTypes()).map(contentType => {
+        return {
+          regex: new RegExp(contentType.replace('+', '\\+')),
+          serializer: serializer(contentType),
+        };
+      }),
+    ],
   };
 
   const datasetsRequest = {
@@ -89,13 +90,12 @@ export async function server(
     },
   };
 
-  async function validate(
+  async function resolveDataset(
     url: URL,
     reply: FastifyReply
   ): Promise<DatasetExt | null> {
-    let dataset: DatasetExt;
     try {
-      dataset = await dereference(url);
+      return await dereference(url);
     } catch (e) {
       if (e instanceof HttpError) {
         reply.log.info(
@@ -117,7 +117,9 @@ export async function server(
 
       return null;
     }
+  }
 
+  async function validate(dataset: DatasetExt, reply: FastifyReply) {
     const validation = await validator.validate(dataset);
     switch (validation.state) {
       case 'valid':
@@ -147,7 +149,7 @@ export async function server(
 
   server.post(
     '/datasets',
-    {...datasetsRequest, ...rdfSerializerConfig},
+    {...datasetsRequest, config: rdfSerializerConfig},
     async (request, reply) => {
       const url = new URL((request.body as {'@id': string})['@id']);
       if (!(await domainIsAllowed(url))) {
@@ -156,7 +158,8 @@ export async function server(
       }
 
       reply.code(202); // The validate function will reply.send() with any validation warnings.
-      if (await validate(url, reply)) {
+      const dataset = await resolveDataset(url, reply);
+      if (dataset && (await validate(dataset, reply))) {
         // The URL has validated, so any problems with processing the dataset are now ours. Therefore, make sure to
         // store the registration so we can come back to that when crawling, even if fetching the datasets fails.
         // Store first rather than wrapping in a try/catch to cope with OOMs.
@@ -186,11 +189,14 @@ export async function server(
 
   server.put(
     '/datasets/validate',
-    {...datasetsRequest, ...rdfSerializerConfig},
+    {...datasetsRequest, config: rdfSerializerConfig},
     async (request, reply) => {
       const url = new URL((request.body as {'@id': string})['@id']);
       request.log.info(url.toString());
-      await validate(url, reply);
+      const dataset = await resolveDataset(url, reply);
+      if (dataset) {
+        await validate(dataset, reply);
+      }
       request.log.info(
         `Validated at ${Math.round(
           process.memoryUsage().rss / 1024 / 1024
@@ -200,18 +206,59 @@ export async function server(
     }
   );
 
-  server.get('/shacl', rdfSerializerConfig, async (request, reply) => {
-    return reply.send(shacl);
-  });
+  server.post(
+    '/datasets/validate',
+    {config: {...rdfSerializerConfig, parseRdf: true}},
+    async (request, reply) => {
+      await validate(request.body as DatasetExt, reply);
+    }
+  );
+
+  server.get(
+    '/shacl',
+    {config: rdfSerializerConfig},
+    async (request, reply) => {
+      return reply.send(shacl);
+    }
+  );
 
   /**
-   * Make Fastify accept JSON-LD payloads.
+   * If a route has enabled `parseRdf`, parse RDF into a DatasetExt object. If not, parse as JSON.
    */
   server.addContentTypeParser(
-    'application/ld+json',
-    {parseAs: 'string'},
-    server.getDefaultJsonParser('ignore', 'ignore')
+    ['application/ld+json', 'text/turtle', 'text/n3', 'application/trig'],
+    async (request: FastifyRequest, payload: IncomingMessage) => {
+      if ((request.routeConfig as CustomConfig).parseRdf ?? false) {
+        try {
+          return await load(
+            request.raw,
+            request.headers['content-type'] ?? 'application/ld+json'
+          );
+        } catch (e) {
+          (e as FastifyError).statusCode = 400;
+          return new Promise((resolve, error) => error(e));
+        }
+      }
+
+      // Parse simple JSON-LD as JSON.
+      return new Promise(resolve => {
+        let data = '';
+        payload.on('data', chunk => {
+          data += chunk;
+        });
+        payload.on('end', () => {
+          resolve(JSON.parse(data));
+        });
+      });
+    }
   );
 
   return server;
+}
+
+export interface CustomConfig extends FastifyContextConfig {
+  /**
+   * If enabled, the RDF request body will be parsed into a DatasetExt object by the content parser.
+   */
+  parseRdf: boolean;
 }

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -4,6 +4,7 @@ import {Server} from 'http';
 import {server} from '../src/server';
 import {readUrl, ShaclValidator} from '../src/validator';
 import {
+  file,
   MockAllowedRegistrationDomainStore,
   MockDatasetStore,
   MockRegistrationStore,
@@ -21,7 +22,9 @@ describe('Server', () => {
       registrationStore,
       new MockAllowedRegistrationDomainStore(),
       new ShaclValidator(shacl),
-      shacl
+      shacl,
+      '/',
+      {logger: true}
     );
 
     nock.back.fixtures = dirname(fileURLToPath(import.meta.url)) + '/http';
@@ -95,6 +98,50 @@ describe('Server', () => {
     nockDone();
     expect(response.statusCode).toEqual(200);
     expect(response.payload).not.toEqual('');
+  });
+
+  it('validates JSON-LD dataset description in request body', async () => {
+    nock.restore(); // Nock not needed in this test.
+    const response = await httpServer.inject({
+      method: 'POST',
+      url: '/datasets/validate',
+      headers: {'Content-Type': 'application/ld+json'},
+      payload: await file('dataset-schema-org-invalid.jsonld'),
+    });
+    expect(response.statusCode).toEqual(400);
+  });
+
+  it('validates Turtle dataset description in request body', async () => {
+    nock.restore(); // Nock not needed in this test.
+    const response = await httpServer.inject({
+      method: 'POST',
+      url: '/datasets/validate',
+      headers: {'Content-Type': 'text/turtle'},
+      payload: await file('dataset-schema-org-valid.ttl'),
+    });
+    expect(response.statusCode).toEqual(200);
+  });
+
+  it('handles invalid JSON-LD in request body', async () => {
+    nock.restore(); // Nock not needed in this test.
+    const response = await httpServer.inject({
+      method: 'POST',
+      url: '/datasets/validate',
+      headers: {'Content-Type': 'application/ld+json'},
+      payload: 'This is not JSON-LD',
+    });
+    expect(response.statusCode).toEqual(400);
+  });
+
+  it('handles invalid Turtle in request body', async () => {
+    nock.restore(); // Nock not needed in this test.
+    const response = await httpServer.inject({
+      method: 'POST',
+      url: '/datasets/validate',
+      headers: {'Content-Type': 'text/turtle'},
+      payload: 'This is not Turtle',
+    });
+    expect(response.statusCode).toEqual(400);
   });
 
   it('responds with validation errors to invalid dataset requests', async () => {


### PR DESCRIPTION
* Refactor OpenAPI docs to re-use components.
* Allow Fastify route handlers to expect RDF dataset from request body
  by setting `parseRdf: true`.

Fix #740