### PR TITLE
fix: Rate multiple distribution formats

### DIFF
--- a/shacl/register.ttl
+++ b/shacl/register.ttl
@@ -459,12 +459,10 @@ dcat:DistributionShape
     sh:or (
         [ sh:property [
             sh:minCount 1 ;
-            sh:maxCount 1 ;
             sh:path dcat:mediaType
         ] ]
         [ sh:property [
             sh:minCount 1 ;
-            sh:maxCount 1 ;
             sh:path dc:format
         ] ]
     ) .

--- a/test/datasets/dataset-dcat-valid.jsonld
+++ b/test/datasets/dataset-dcat-valid.jsonld
@@ -29,7 +29,7 @@
   "dcat:distribution": [
     {
       "@type": "dcat:Distribution",
-      "dcat:mediaType": "application/rdf+xml",
+      "dct:format": ["application/rdf+xml", "text/turtle"],
       "dcat:accessURL": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf"
     }
   ]

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -39,7 +39,7 @@ describe('Fetch', () => {
       dataset.has(
         factory.quad(
           distributions[0].object as BlankNode,
-          dcat('mediaType'),
+          dct('format'),
           factory.literal('application/rdf+xml'),
           datasetUri
         )


### PR DESCRIPTION
Both the Schema.org SHACl and the requirements already allow 
more than one format, so apply this to the DCAT SHACL too.