### PR TITLE
feat: Convert dates to xsd:date/xsd:dateTime

### DIFF
--- a/src/literal.ts
+++ b/src/literal.ts
@@ -1,0 +1,15 @@
+const dateTimeRegex = '^\\\\d{4}-\\\\d{2}-\\\\d{2}T';
+
+/**
+ * Convert a date value to xsd:date or xsd:dateTime, depending on its pattern.
+ *
+ * This is needed because:
+ *
+ * 1. in the query result, values for a predicate with range schema:Date/schema:DateTime always have schema:Date if no
+ *    type is specified in the data;
+ * 2. some datasets have values such as "2024-01-01T01:09:00+01:00"^^<http://schema.org/Date>, which we want to correct
+ *    to xsd:dateTime.
+ */
+export const convertToXsdDate = (variable: string) =>
+  `?${variable}Raw ;
+        BIND(STRDT(STR(?${variable}Raw), IF(REGEX(STR(?${variable}Raw), "${dateTimeRegex}"), xsd:dateTime, xsd:date)) as ?${variable})`;

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,6 +1,7 @@
 import {BlankNode, NamedNode, Quad, Quad_Object, Term} from 'rdf-js';
 import factory from 'rdf-ext';
 import {BlankNodeScoped} from '@comunica/data-factory';
+import {convertToXsdDate} from './literal.js';
 
 const dataset = 'dataset';
 const identifier = 'identifier';
@@ -109,6 +110,7 @@ export const selectQuery = `
   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
   PREFIX schema: <https://schema.org/>
   PREFIX httpSchema: <http://schema.org/>
+  PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
   SELECT * WHERE {
     {
       ${schemaOrgQuery('schema')}
@@ -139,8 +141,12 @@ export const selectQuery = `
           
         OPTIONAL { ?${distribution} dct:format ?${distributionFormat} }
         OPTIONAL { ?${distribution} dcat:mediaType ?${distributionMediaType} }
-        OPTIONAL { ?${distribution} dct:issued ?${distributionDatePublished} }
-        OPTIONAL { ?${distribution} dct:modified ?${distributionDateModified} }
+        OPTIONAL { ?${distribution} dct:issued ${convertToXsdDate(
+  distributionDatePublished
+)} }
+        OPTIONAL { ?${distribution} dct:modified ${convertToXsdDate(
+  distributionDateModified
+)} }
         OPTIONAL { ?${distribution} dct:description ?${distributionDescription} }
         OPTIONAL { ?${distribution} dct:language ?${distributionLanguage} }
         OPTIONAL { ?${distribution} dct:license ?${distributionLicense} }
@@ -151,9 +157,9 @@ export const selectQuery = `
       OPTIONAL { ?${dataset} dct:description ?${description} }
       OPTIONAL { ?${dataset} dct:identifier ?${identifier} }
       OPTIONAL { ?${dataset} dct:alternative ?${alternateName} }
-      OPTIONAL { ?${dataset} dct:created ?${dateCreated} }
-      OPTIONAL { ?${dataset} dct:issued ?${datePublished} }
-      OPTIONAL { ?${dataset} dct:modified ?${dateModified} }
+      OPTIONAL { ?${dataset} dct:created ${convertToXsdDate(dateCreated)} }
+      OPTIONAL { ?${dataset} dct:issued ${convertToXsdDate(datePublished)} }
+      OPTIONAL { ?${dataset} dct:modified ${convertToXsdDate(dateModified)} }
       OPTIONAL { ?${dataset} dct:language ?${language} }
       OPTIONAL { ?${dataset} dct:source ?${source} }
       OPTIONAL { ?${dataset} dcat:keyword ?${keyword} }
@@ -286,8 +292,12 @@ function schemaOrgQuery(prefix: string): string {
         ${prefix}:encodingFormat ?${distributionFormat} .
         
       OPTIONAL { ?${distribution} ${prefix}:fileFormat ?${distributionMediaType} }
-      OPTIONAL { ?${distribution} ${prefix}:datePublished ?${distributionDatePublished} }
-      OPTIONAL { ?${distribution} ${prefix}:dateModified ?${distributionDateModified} }
+      OPTIONAL { ?${distribution} ${prefix}:datePublished ${convertToXsdDate(
+    distributionDatePublished
+  )} }
+      OPTIONAL { ?${distribution} ${prefix}:dateModified ${convertToXsdDate(
+    distributionDateModified
+  )} }
       OPTIONAL { ?${distribution} ${prefix}:description ?${distributionDescription} }
       OPTIONAL { ?${distribution} ${prefix}:inLanguage ?${distributionLanguage} }
       OPTIONAL { ?${distribution} ${prefix}:license ?${distributionLicense} }
@@ -298,9 +308,15 @@ function schemaOrgQuery(prefix: string): string {
     OPTIONAL { ?${dataset} ${prefix}:description ?${description} } 
     OPTIONAL { ?${dataset} ${prefix}:identifier ?${identifier} }
     OPTIONAL { ?${dataset} ${prefix}:alternateName ?${alternateName} }
-    OPTIONAL { ?${dataset} ${prefix}:dateCreated ?${dateCreated} }
-    OPTIONAL { ?${dataset} ${prefix}:datePublished ?${datePublished} }
-    OPTIONAL { ?${dataset} ${prefix}:dateModified ?${dateModified} }
+    OPTIONAL { ?${dataset} ${prefix}:dateCreated ${convertToXsdDate(
+    dateCreated
+  )} }
+    OPTIONAL { ?${dataset} ${prefix}:datePublished ${convertToXsdDate(
+    datePublished
+  )} }
+    OPTIONAL { ?${dataset} ${prefix}:dateModified ${convertToXsdDate(
+    dateModified
+  )} }
     OPTIONAL { ?${dataset} ${prefix}:inLanguage ?${language} }
     OPTIONAL { ?${dataset} ${prefix}:isBasedOn ?${source} }
     OPTIONAL { ?${dataset} ${prefix}:isBasedOnUrl ?${source} } 

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -93,6 +93,45 @@ describe('Fetch', () => {
       dataset.has(
         factory.quad(
           factory.namedNode('http://data.bibliotheken.nl/id/dataset/rise-alba'),
+          dct('created'),
+          factory.literal(
+            '2021-05-27',
+            factory.namedNode('http://www.w3.org/2001/XMLSchema#date')
+          ),
+          factory.namedNode('http://data.bibliotheken.nl/id/dataset/rise-alba')
+        )
+      )
+    ).toBe(true);
+    expect(
+      dataset.has(
+        factory.quad(
+          factory.namedNode('http://data.bibliotheken.nl/id/dataset/rise-alba'),
+          dct('issued'),
+          factory.literal(
+            '2021-05-28',
+            factory.namedNode('http://www.w3.org/2001/XMLSchema#date')
+          ),
+          factory.namedNode('http://data.bibliotheken.nl/id/dataset/rise-alba')
+        )
+      )
+    ).toBe(true);
+    expect(
+      dataset.has(
+        factory.quad(
+          factory.namedNode('http://data.bibliotheken.nl/id/dataset/rise-alba'),
+          dct('modified'),
+          factory.literal(
+            '2021-05-27T09:56:21.370767',
+            factory.namedNode('http://www.w3.org/2001/XMLSchema#dateTime')
+          ),
+          factory.namedNode('http://data.bibliotheken.nl/id/dataset/rise-alba')
+        )
+      )
+    ).toBe(true);
+    expect(
+      dataset.has(
+        factory.quad(
+          factory.namedNode('http://data.bibliotheken.nl/id/dataset/rise-alba'),
           dct('publisher'),
           factory.namedNode('https://example.com/publisher'),
           factory.namedNode('http://data.bibliotheken.nl/id/dataset/rise-alba')


### PR DESCRIPTION
* Because we follow the approach that logic should be written in SPARQL
  instead of TypeScript where possible, do so for the date conversion too.
* We still need a template function in TypeScript for re-usability.

Fix #846
