### PR TITLE
refactor: Use CONSTRUCT

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,10 +10,10 @@ export default {
   coverageReporters: ['json-summary', 'text'],
   coverageThreshold: {
     global: {
-      lines: 72,
-      statements: 72.2,
-      branches: 64.02,
-      functions: 69.15,
+      lines: 70.02,
+      statements: 70.25,
+      branches: 65.18,
+      functions: 66.32,
     },
   },
   transform: {

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,7 +1,6 @@
 import factory from 'rdf-ext';
-import {BlankNodeScoped} from '@comunica/data-factory';
 import {convertToXsdDate} from './literal.js';
-import {BlankNode, NamedNode, Quad, Quad_Object, Term} from '@rdfjs/types';
+import {NamedNode} from '@rdfjs/types';
 
 const dataset = 'dataset';
 const identifier = 'identifier';
@@ -23,14 +22,11 @@ const version = 'version';
 const includedInDataCatalog = 'includedInDataCatalog';
 
 const creatorName = 'creator_name';
-const creatorEmail = 'creator_email';
-const creatorUrl = 'creator_url';
-const creatorSameAs = 'creator_sameAs';
+const creatorType = 'creator_type';
 
+const publisherType = 'publisher_type';
 const publisherName = 'publisher_name';
 const publisherEmail = 'publisher_email';
-const publisherUrl = 'publisher_url';
-const publisherSameAs = 'publisher_sameAs';
 
 const distributionUrl = 'distribution_url';
 const distributionMediaType = 'distribution_mediaType';
@@ -49,69 +45,60 @@ export const dct = (property: string): NamedNode =>
   factory.namedNode(`http://purl.org/dc/terms/${property}`);
 export const foaf = (property: string): NamedNode =>
   factory.namedNode(`http://xmlns.com/foaf/0.1/${property}`);
-const owl = (property: string): NamedNode =>
-  factory.namedNode(`http://www.w3.org/2002/07/owl#${property}`);
 export const rdf = (property: string): NamedNode =>
   factory.namedNode(`http://www.w3.org/1999/02/22-rdf-syntax-ns#${property}`);
 
-// https://www.w3.org/TR/vocab-dcat-2/#Class:Dataset
-const datasetMapping = new Map([
-  [identifier, dct('identifier')],
-  [name, dct('title')],
-  [alternateName, dct('alternative')],
-  [description, dct('description')],
-  [license, dct('license')],
-  [dateCreated, dct('created')],
-  [datePublished, dct('issued')],
-  [dateModified, dct('modified')],
-  [language, dct('language')],
-  [source, dct('source')],
-  [keyword, dcat('keyword')],
-  // [spatial, dct('spatial')],
-  // [temporal, dct('temporal')],
-  [mainEntityOfPage, dcat('landingPage')],
-  [version, owl('versionInfo')],
-  [includedInDataCatalog, dct('isPartOf')],
-]);
-
-export const creatorMapping = new Map([
-  [creatorName, foaf('name')],
-  [creatorEmail, foaf('mbox')],
-  [creatorUrl, foaf('workplaceHomepage')],
-  [creatorSameAs, owl('sameAs')],
-]);
-
-export const publisherMapping = new Map([
-  [publisherName, foaf('name')],
-  [publisherEmail, foaf('mbox')],
-  [publisherUrl, foaf('workplaceHomepage')],
-  [publisherSameAs, owl('sameAs')],
-]);
-
-// https://www.w3.org/TR/vocab-dcat-2/#Class:Distribution
-const distributionMapping = new Map([
-  [distributionUrl, dcat('accessURL')],
-  [distributionMediaType, dcat('mediaType')],
-  [distributionFormat, dct('format')],
-  [distributionDatePublished, dct('issued')],
-  [distributionDateModified, dct('modified')],
-  [distributionDescription, dct('description')],
-  [distributionLanguage, dct('language')],
-  [distributionLicense, dct('license')],
-  [distributionName, dct('title')],
-  [distributionSize, dcat('byteSize')],
-]);
-
 export const datasetType = dcat('Dataset');
 export const sparqlLimit = 50000;
-export const selectQuery = `
+
+export const constructQuery = `
   PREFIX dcat: <http://www.w3.org/ns/dcat#>
   PREFIX dct: <http://purl.org/dc/terms/>
   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+  PREFIX owl: <http://www.w3.org/2002/07/owl#>
   PREFIX schema: <https://schema.org/>
   PREFIX httpSchema: <http://schema.org/>
   PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-  SELECT * WHERE {
+
+  CONSTRUCT {
+    ?${dataset} a dcat:Dataset ;
+      dct:title ?${name} ;
+      dct:alternative ?${alternateName} ;
+      dct:description ?${description} ;
+      dct:identifier ?${identifier} ;
+      dct:license ?${license} ;
+      dct:created ?${dateCreated} ;
+      dct:issued ?${datePublished} ;
+      dct:modified ?${dateModified} ;
+      dct:language ?${language} ;
+      dct:source ?${source} ;
+      dcat:keyword ?${keyword} ;
+      dcat:landingPage ?${mainEntityOfPage} ;
+      owl:versionInfo ?${version} ;
+      dct:isPartOf ?${includedInDataCatalog} ;
+      dct:publisher ?${publisher} ;
+      dct:creator ?${creator} ;
+      dcat:distribution ?${distribution} .
+      
+    ?${publisher} a ?${publisherType} ;
+      foaf:name ?${publisherName} ;
+      foaf:mbox ?${publisherEmail} .
+
+    ?${creator} a ?${creatorType} ;
+      foaf:name ?${creatorName} .
+      
+    ?${distribution} a dcat:Distribution ;
+      dcat:accessURL ?${distributionUrl} ;
+      dcat:mediaType ?${distributionMediaType} ;
+      dct:format ?${distributionFormat} ;
+      dct:issued ?${distributionDatePublished} ;
+      dct:modified ?${distributionDateModified} ;
+      dct:description ?${distributionDescription} ;
+      dct:language ?${distributionLanguage} ;
+      dct:license ?${distributionLicense} ;
+      dct:title ?${distributionName} ;
+      dcat:byteSize ?${distributionSize} .
+  } WHERE {
     {
       ${schemaOrgQuery('schema')}
     } UNION {
@@ -123,12 +110,12 @@ export const selectQuery = `
         dct:publisher ?${publisher} .
         
       ?${publisher} a ?foafOrganizationOrPerson ;
-        a ?publisherType ;
+        a ?${publisherType} ;
         foaf:name ?${publisherName} .
       
       OPTIONAL {
         ?${creator} a ?foafOrganizationOrPerson ;
-          a ?creatorType ;
+          a ?${creatorType} ;
           foaf:name ?${creatorName} .
       }
         
@@ -169,95 +156,6 @@ export const selectQuery = `
     }
   } LIMIT ${sparqlLimit}`;
 
-export function bindingsToQuads(binding: Map<string, Term>): Quad[] {
-  const datasetIri = binding.get('dataset') as NamedNode;
-  const quads = [
-    factory.quad(datasetIri, rdf('type'), datasetType, datasetIri),
-    ..._bindingsToQuads(datasetIri, binding, datasetMapping, datasetIri),
-  ];
-
-  if (binding.get(publisher)) {
-    const publisherNode = binding.get(publisher) as NamedNode;
-    quads.push(
-      factory.quad(datasetIri, dct('publisher'), publisherNode, datasetIri),
-      factory.quad(
-        publisherNode,
-        rdf('type'),
-        organizationOrPersonToFoaf(
-          (binding.get('publisherType') as NamedNode) || foaf('Organization')
-        ),
-        datasetIri
-      ),
-      ..._bindingsToQuads(publisherNode, binding, publisherMapping, datasetIri)
-    );
-  }
-
-  if (binding.get(creator)) {
-    const creatorNode = binding.get(creator) as NamedNode;
-    quads.push(
-      factory.quad(datasetIri, dct('creator'), creatorNode, datasetIri),
-      factory.quad(
-        creatorNode,
-        rdf('type'),
-        organizationOrPersonToFoaf(
-          (binding.get('creatorType') as NamedNode) || foaf('Organization')
-        ),
-        datasetIri
-      ),
-      ..._bindingsToQuads(creatorNode, binding, creatorMapping, datasetIri)
-    );
-  }
-
-  if (binding.get(distribution)) {
-    const distributionBlankNode = binding.get(distribution) as BlankNodeScoped;
-    quads.push(
-      factory.quad(
-        datasetIri,
-        dcat('distribution'),
-        distributionBlankNode,
-        datasetIri
-      ),
-      factory.quad(
-        distributionBlankNode,
-        rdf('type'),
-        dcat('Distribution'),
-        datasetIri
-      ),
-      ..._bindingsToQuads(
-        distributionBlankNode,
-        binding,
-        distributionMapping,
-        datasetIri
-      )
-    );
-  }
-
-  return quads;
-}
-
-function _bindingsToQuads(
-  subject: NamedNode | BlankNode,
-  binding: Map<string, Term>,
-  mapping: Map<string, NamedNode>,
-  graphIri: NamedNode
-): Quad[] {
-  const quads: Quad[] = [];
-  mapping.forEach((predicate, variable) => {
-    if (binding.get(variable)) {
-      quads.push(
-        factory.quad(
-          subject,
-          predicate,
-          binding.get(variable) as Quad_Object,
-          graphIri
-        )
-      );
-    }
-  });
-
-  return quads;
-}
-
 function schemaOrgQuery(prefix: string): string {
   return `
     ?${dataset} a ${prefix}:Dataset ;
@@ -266,19 +164,40 @@ function schemaOrgQuery(prefix: string): string {
       
     FILTER (!isBlank(?${license}))
 
-    VALUES ?organizationOrPerson { ${prefix}:Organization ${prefix}:Person }          
     OPTIONAL { 
       ?${dataset} ${prefix}:creator ?${creator} .        
-      ?${creator} a ?organizationOrPerson ;
-        a ?creatorType ; 
+      ?${creator} a ?creatorTypeRaw ;
         ${prefix}:name ?${creatorName} .
+      BIND(
+        IF(
+          ?creatorTypeRaw = ${prefix}:Organization,
+          foaf:Organization,
+          IF(
+            ?creatorTypeRaw = ${prefix}:Person,
+            foaf:Person,
+            ""
+          )
+        )
+      AS ?${creatorType})
+      FILTER(?${creatorType} != "")
     }
       
     OPTIONAL { 
-      ?${dataset} ${prefix}:publisher ?${publisher} .        
-      ?${publisher} a ?organizationOrPerson ;
-        a ?publisherType ;
+      ?${dataset} ${prefix}:publisher ?${publisher} .
+      ?${publisher} a ?publisherTypeRaw ;
         ${prefix}:name ?${publisherName} .
+      BIND(
+        IF(
+          ?publisherTypeRaw = ${prefix}:Organization,
+          foaf:Organization,
+          IF(
+            ?publisherTypeRaw = ${prefix}:Person,
+            foaf:Person,
+            ""
+          )
+        )
+      AS ?${publisherType})
+      FILTER(?${publisherType} != "")
       OPTIONAL {
         ?${publisher} ${prefix}:contactPoint/${prefix}:email ?${publisherEmail} .  
       }
@@ -324,18 +243,4 @@ function schemaOrgQuery(prefix: string): string {
     OPTIONAL { ?${dataset} ${prefix}:includedInDataCatalog ?${includedInDataCatalog} }
     OPTIONAL { ?${dataset} ${prefix}:mainEntityOfPage ?${mainEntityOfPage} }
 `;
-}
-
-function organizationOrPersonToFoaf(type: NamedNode) {
-  switch (type.value) {
-    case 'http://schema.org/Person':
-    case 'https://schema.org/Person':
-      return foaf('Person');
-    case 'http://schema.org/Organization':
-    case 'https://schema.org/Organization':
-      return foaf('Organization');
-  }
-
-  // Already in FOAF.
-  return type;
 }

--- a/test/datasets/dataset-dcat-valid.jsonld
+++ b/test/datasets/dataset-dcat-valid.jsonld
@@ -6,31 +6,72 @@
   },
   "@type": "dcat:Dataset",
   "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
-  "dct:title": "Alba amicorum van de Koninklijke Bibliotheek",
-  "dct:description": "Just some dataset",
+  "dct:title": [
+    {
+      "@value": "Alba amicorum van de Koninklijke Bibliotheek",
+      "@language": "nl"
+    },
+    {
+      "@value": "Alba amicorum of the Dutch Royal Library",
+      "@language": "en"
+    }
+  ],
+  "dct:description": {
+    "@value": "Description only in English",
+    "@language": "en"
+  },
   "dcat:keyword": [
     "alba amicorum"
   ],
-  "dct:license": "http://creativecommons.org/publicdomain/zero/1.0/",
-  "dct:created": "2021-05-27",
-  "dct:issued": "2021-06-27",
-  "dct:modified": "2021-07-27",
+  "dct:identifier": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "dct:license": {
+    "@id": "http://creativecommons.org/publicdomain/zero/1.0/"
+  },
+  "dct:created": {
+    "@type": "http://www.w3.org/2001/XMLSchema#date",
+    "@value": "2021-05-27"
+  },
+  "dct:issued": {
+    "@type": "http://www.w3.org/2001/XMLSchema#date",
+    "@value": "2021-05-28"
+  },
+  "dct:modified": {
+    "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+    "@value": "2021-05-27T09:56:21.370767"
+  },
   "dct:publisher": {
-    "@id": "https://example.com/dataset-provider",
-    "@type": "foaf:Person",
-    "foaf:name": "Dataset Provider"
-  },
-  "dct:creator": {
+    "@id": "https://example.com/publisher",
     "@type": "foaf:Organization",
-    "@id": "https://example.com/dataset-creator",
-    "foaf:name": "Dataset creator"
+    "foaf:name": "Koninklijke Bibliotheek",
+    "foaf:mbox": "datasets@example.com"
   },
-  "dct:language": "nl-NL",
+  "dct:creator": [
+    {
+      "@id": "https://example.com/creator1",
+      "@type": "foaf:Person",
+      "foaf:name": "Creator 1"
+    },
+    {
+      "@id": "https://example.com/creator2",
+      "@type": "foaf:Person",
+      "foaf:name": "Creator 2"
+    }
+  ],
+  "dct:language": ["nl-NL", "en-GB"],
   "dcat:distribution": [
     {
       "@type": "dcat:Distribution",
       "dct:format": ["application/rdf+xml", "text/turtle"],
-      "dcat:accessURL": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf"
+      "dcat:accessURL": {
+        "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf"
+      }
+    },
+    {
+      "@type": "dcat:Distribution",
+      "dct:format": ["application/ld+json"],
+      "dcat:accessURL": {
+        "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba.jsonld"
+      }
     }
   ]
 }

--- a/test/datasets/dataset-schema-org-valid.jsonld
+++ b/test/datasets/dataset-schema-org-valid.jsonld
@@ -13,12 +13,14 @@
     }
   ],
   "description": {
-    "@value": "en",
-    "@language": "Description only in English"
+    "@value": "Description only in English",
+    "@language": "en"
   },
+  "keywords": "alba amicorum",
   "url": "https://www.kb.nl/bronnen-zoekwijzers/kb-collecties/moderne-handschriften-vanaf-ca-1550/alba-amicorum",
   "identifier": "http://data.bibliotheken.nl/id/dataset/rise-alba",
   "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "inLanguage": ["nl-NL", "en-GB"],
   "publisher": {
     "@type": "Organization",
     "@id": "https://example.com/publisher",
@@ -51,7 +53,7 @@
   "distribution": [
     {
       "@type": "DataDownload",
-      "encodingFormat": "application/rdf+xml",
+      "encodingFormat": ["application/rdf+xml", "text/turtle"],
       "contentUrl": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf"
     },
     {

--- a/test/datasets/hydra-page1.jsonld
+++ b/test/datasets/hydra-page1.jsonld
@@ -36,6 +36,15 @@
           "publisher": {
             "@id": "/publisher"
           }
+        },
+        {
+          "@type": "Dataset",
+          "@id": "https://example.com/dataset/2",
+          "name": "Dataset 2",
+          "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+          "publisher": {
+            "@id": "/publisher"
+          }
         }
       ]
     }

--- a/test/datasets/hydra-page2.jsonld
+++ b/test/datasets/hydra-page2.jsonld
@@ -30,8 +30,8 @@
       "dataset": [
         {
           "@type": "Dataset",
-          "@id": "https://example.com/dataset/2",
-          "name": "Dataset 2",
+          "@id": "https://example.com/dataset/3",
+          "name": "Dataset 3",
           "license": "http://creativecommons.org/publicdomain/zero/1.0/",
           "publisher": {
             "@id": "/publisher"


### PR DESCRIPTION
* This seems to work now that we require a URI for publisher/creator.
* Replace transformation logic with a CONSTRUCT query.
* Simplify by replacing EventEmitter listeners with for await.
