### PR TITLE
fix: Distribution media type mapping

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,8 +11,8 @@ export default {
   coverageReporters: ['json-summary', 'text'],
   coverageThreshold: {
     global: {
-      lines: 69.31,
-      statements: 69.55,
+      lines: 69.23,
+      statements: 69.47,
       branches: 60.52,
       functions: 67.01,
     },

--- a/shacl/register.ttl
+++ b/shacl/register.ttl
@@ -189,7 +189,7 @@ reg:DistributionContentUrlIriProperty a sh:PropertyShape ;
 .
 
 reg:DistributionEncodingFormatProperty a sh:PropertyShape ;
-    rdfs:comment "Het MIME-formaat van de distributie, bijvoorbeeld application/sparql-query voor een SPARL-endpoint of application/ld+json voor een datadump die is geserialiseerd als JSON-LD."@nl, "The distribution's MIME format, for example application/sparql-query for a SPARL endpoint or application/ld+json for a data dump serialized as JSON-LD."@en ;
+    rdfs:comment "Het MIME-formaat van de distributie, bijvoorbeeld application/sparql-query voor een SPARQL-endpoint of application/ld+json voor een datadump die is geserialiseerd als JSON-LD."@nl, "The distribution's MIME format, for example application/sparql-query for a SPARQL endpoint or application/ld+json for a data dump serialized as JSON-LD."@en ;
     sh:minCount 1 ;
     sh:path schema:encodingFormat ;
     sh:message "Een dataset distributie dient minstens 1 encoding format te bevatten"@nl, "A dataset distribution must contain at least one encoding format"@en ;

--- a/src/query.ts
+++ b/src/query.ts
@@ -33,7 +33,6 @@ const publisherEmail = 'publisher_email';
 
 const distributionUrl = 'distribution_url';
 const distributionMediaType = 'distribution_mediaType';
-const distributionFormat = 'distribution_format';
 const distributionDatePublished = 'distribution_datePublished';
 const distributionDateModified = 'distribution_dateModified';
 const distributionDescription = 'distribution_description';
@@ -96,7 +95,6 @@ export const constructQuery = `
     ?${distribution} a dcat:Distribution ;
       dcat:accessURL ?${distributionUrl} ;
       dcat:mediaType ?${distributionMediaType} ;
-      dct:format ?${distributionFormat} ;
       dct:issued ?${distributionDatePublished} ;
       dct:modified ?${distributionDateModified} ;
       dct:description ?${distributionDescription} ;
@@ -133,7 +131,6 @@ export const constructQuery = `
           ?${distribution} a dcat:Distribution ;
             dcat:accessURL ?${convertToIri(distributionUrl)} .
             
-          OPTIONAL { ?${distribution} dct:format ?${distributionFormat} }
           OPTIONAL { ?${distribution} dcat:mediaType ?${distributionMediaType} }
           OPTIONAL { ?${distribution} dct:issued ${convertToXsdDate(
             distributionDatePublished,
@@ -218,10 +215,9 @@ function schemaOrgQuery(prefix: string): string {
     OPTIONAL {
       ?${dataset} ${prefix}:distribution ?${distribution} .
       ?${distribution} a ${prefix}:DataDownload ;
-        ${prefix}:encodingFormat ?${distributionFormat} ;
+        ${prefix}:encodingFormat ?${distributionMediaType} ;
         ${prefix}:contentUrl ?${convertToIri(distributionUrl)} .
         
-      OPTIONAL { ?${distribution} ${prefix}:fileFormat ?${distributionMediaType} }
       OPTIONAL { ?${distribution} ${prefix}:datePublished ${convertToXsdDate(
         distributionDatePublished,
       )} }

--- a/test/datasets/catalog-dcat-valid.jsonld
+++ b/test/datasets/catalog-dcat-valid.jsonld
@@ -24,7 +24,7 @@
       "dcat:distribution": [
         {
           "@type": "dcat:Distribution",
-          "dct:format": "application/rdf+xml",
+          "dcat:mediaType": "application/rdf+xml",
           "dcat:accessURL": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf"
         }
       ]

--- a/test/datasets/dataset-dcat-valid.jsonld
+++ b/test/datasets/dataset-dcat-valid.jsonld
@@ -66,14 +66,14 @@
   "dcat:distribution": [
     {
       "@type": "dcat:Distribution",
-      "dct:format": ["application/rdf+xml", "text/turtle"],
+      "dcat:mediaType": ["application/rdf+xml", "text/turtle"],
       "dcat:accessURL": {
         "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf"
       }
     },
     {
       "@type": "dcat:Distribution",
-      "dct:format": ["application/ld+json"],
+      "dcat:mediaType": ["application/ld+json"],
       "dcat:accessURL": {
         "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba.jsonld"
       }

--- a/test/datasets/datasets-dcat-valid.jsonld
+++ b/test/datasets/datasets-dcat-valid.jsonld
@@ -23,7 +23,7 @@
       "dcat:distribution": [
         {
           "@type": "dcat:Distribution",
-          "dct:format": "application/rdf+xml",
+          "dcat:mediaType": "application/rdf+xml",
           "dcat:accessURL": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf"
         }
       ]

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -36,12 +36,11 @@ describe('Fetch', () => {
     ];
     expect(distributions).toHaveLength(2);
 
-    // dcat:
     expect(
       dataset.has(
         factory.quad(
           distributions[0].object as BlankNode,
-          dct('format'),
+          dcat('mediaType'),
           factory.literal('application/rdf+xml'),
         ),
       ),


### PR DESCRIPTION
* Remove schema:fileFormat, which is superseded.
* Use dcat:mediaType, preferred for IANA types, instead of dct:format.

Ref netwerk-digitaal-erfgoed/dataset-register#1102