### PR TITLE
feat: add CIDOC-CRM creative work classes to facet group

### DIFF
--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -99,6 +99,8 @@ const classGroups = {
     'http://schema.org/MusicComposition',
     'https://schema.org/MusicComposition',
     'http://www.cidoc-crm.org/cidoc-crm/E65_Creation',
+    'http://www.cidoc-crm.org/cidoc-crm/E22_Human-Made_Object',
+    'http://www.cidoc-crm.org/cidoc-crm/E12_Production',
   ],
   [GROUP_PLACE]: [
     'http://schema.org/Place',


### PR DESCRIPTION
## Summary

Adds CIDOC-CRM E22_Human-Made_Object and E12_Production classes to the creative works facet group.

Fix #1338.

## Changes

* Added E22_Human-Made_Object to creative works classification
* Added E12_Production to creative works classification

This allows datasets using CIDOC-CRM ontology to be properly categorized under the creative works facet.