### PR TITLE
fix: use dct:title for terminology source labels

### DIFF
--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -273,7 +273,7 @@ export const facetConfigs: Record<string, FacetConfig> = {
         [] a void:Linkset ;
           void:subjectsTarget ?dataset ;
           void:objectsTarget ?value .
-        OPTIONAL { ?value dct:name ?label }
+        OPTIONAL { ?value dct:title ?label }
       }
     }`,
     filterClause: (values) => {


### PR DESCRIPTION
## Summary

This PR fixes the SPARQL query for the terminology source facet to use the correct property for retrieving labels.

* Changes `dct:name` to `dct:title` in the terminology source facet SPARQL query
* This aligns with Dublin Core Metadata Initiative standards where `dct:title` is the standard property for resource names

## Changes

* **apps/browser/src/lib/services/facets.ts**: Updated SPARQL query to use `dct:title` instead of `dct:name`