### PR TITLE
fix: translate filter drawer buttons

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -50,6 +50,8 @@
   "facets_search": "Search...",
   "facets_show_more": "Show more",
   "facets_show_less": "Show less",
+  "facets_apply_filters": "Apply Filters",
+  "facets_clear_all": "Clear All",
   "publisher_explanation": "The organization that publishes the dataset.",
   "keyword_explanation": "Keywords that describe the dataset.",
   "format_explanation": "Formats in which the dataset is made available for downloading or querying.",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -50,6 +50,8 @@
   "facets_search": "Zoek...",
   "facets_show_more": "Toon meer",
   "facets_show_less": "Toon minder",
+  "facets_apply_filters": "Filters toepassen",
+  "facets_clear_all": "Alle filters wissen",
   "publisher_explanation": "De organisatie die de dataset publiceert.",
   "keyword_explanation": "Trefwoorden die de dataset beschrijven.",
   "format_explanation": "Formaten waarin de dataset gedownload of bevraagd kan worden.",

--- a/apps/browser/src/routes/datasets/+page.svelte
+++ b/apps/browser/src/routes/datasets/+page.svelte
@@ -537,7 +537,7 @@
       onclick={toggleMobileFilters}
       class="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors cursor-pointer"
     >
-      Apply Filters
+      {m.facets_apply_filters()}
     </button>
     <button
       onclick={() => {
@@ -552,7 +552,7 @@
       }}
       class="w-full px-6 py-3 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 font-semibold rounded-lg transition-colors cursor-pointer"
     >
-      Clear All
+      {m.facets_clear_all()}
     </button>
   </div>
 </aside>


### PR DESCRIPTION
## Summary

Translates the "Apply Filters" and "Clear All" buttons in the mobile filter drawer to support both English and Dutch.

## Changes

* Added `facets_apply_filters` translation key (EN: "Apply Filters", NL: "Filters toepassen")
* Added `facets_clear_all` translation key (EN: "Clear All", NL: "Alle filters wissen")
* Updated +page.svelte to use Paraglide translation calls instead of hardcoded strings

## Testing

* ✅ Lint passed
* ✅ Type check passed
* ✅ Build successful