### PR TITLE
feat: add RSS feed for dataset search results

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "header_title": "Dataset Register",
   "header_tagline": "Discover cultural heritage datasets",
+  "organization": "Dutch Heritage Network",
   "nav_create": "Create",
   "nav_validate": "Validate",
   "nav_submit": "Submit",
@@ -80,5 +81,15 @@
   "lang_fr": "French",
   "lang_es": "Spanish",
   "lang_it": "Italian",
-  "dataset_status_archived": "Archived"
+  "dataset_status_archived": "Archived",
+  "rss_subscribe": "Subscribe to RSS feed for this search query",
+  "rss_feed_title": "RSS feed for search results",
+  "rss_filter_search": "Search",
+  "rss_filter_publishers": "Publishers",
+  "rss_filter_keywords": "Keywords",
+  "rss_filter_formats": "Formats",
+  "rss_filter_classes": "Classes",
+  "rss_filter_terminology_sources": "Terminology sources",
+  "rss_filter_size": "Size",
+  "rss_triples": "triples"
 }

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "header_title": "Datasetregister",
   "header_tagline": "Ontdek datasets over cultureel erfgoed",
+  "organization": "Netwerk Digitaal Erfgoed",
   "nav_create": "Maak",
   "nav_validate": "Valideer",
   "nav_submit": "Meld aan",
@@ -80,5 +81,15 @@
   "lang_fr": "Frans",
   "lang_es": "Spaans",
   "lang_it": "Italiaans",
-  "dataset_status_archived": "Gearchiveerd"
+  "dataset_status_archived": "Gearchiveerd",
+  "rss_subscribe": "Abonneer op RSS-feed voor deze zoekopdracht",
+  "rss_feed_title": "RSS-feed voor zoekresultaten",
+  "rss_filter_search": "Zoeken",
+  "rss_filter_publishers": "Uitgevers",
+  "rss_filter_keywords": "Trefwoorden",
+  "rss_filter_formats": "Formaten",
+  "rss_filter_classes": "Klassen",
+  "rss_filter_terminology_sources": "Terminologiebronnen",
+  "rss_filter_size": "Grootte",
+  "rss_triples": "triples"
 }

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@lde/dataset-registry-client": "^0.4.3",
+    "feed": "^5.1.0",
     "fetch-sparql-endpoint": "^6.2.0",
     "ldkit": "^2.5.1",
     "sparqljs": "^3.7.3",

--- a/apps/browser/src/lib/components/RssButton.svelte
+++ b/apps/browser/src/lib/components/RssButton.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import * as m from '$lib/paraglide/messages';
+  import { page } from '$app/state';
+
+  // Generate RSS feed URL with current search parameters
+  const rssUrl = $derived(`/datasets/rss${page.url.search}`);
+</script>
+
+<a
+  href={rssUrl}
+  target="_blank"
+  rel="noopener noreferrer"
+  class="group relative inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 border border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+>
+  <div
+    class="invisible absolute bottom-full left-1/2 mb-2 -translate-x-1/2 transform rounded bg-gray-800 px-2 py-1 text-xs whitespace-nowrap text-white opacity-0 transition-opacity duration-200 group-hover:visible group-hover:opacity-100"
+  >
+    {m.rss_subscribe()}
+    <div
+      class="absolute top-full left-1/2 h-0 w-0 -translate-x-1/2 border-t-4 border-r-4 border-l-4 border-t-gray-800 border-r-transparent border-l-transparent"
+    ></div>
+  </div>
+  RSS
+  <svg
+    class="w-3 h-3"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M6.503 20.752c0 1.794-1.456 3.248-3.251 3.248-1.796 0-3.252-1.454-3.252-3.248 0-1.794 1.456-3.248 3.252-3.248 1.795.001 3.251 1.454 3.251 3.248zm-6.503-12.572v4.811c6.05.062 10.96 4.966 11.022 11.009h4.817c-.062-8.71-7.118-15.758-15.839-15.82zm0-3.368c10.58.046 19.152 8.594 19.183 19.188h4.817c-.03-13.231-10.755-23.954-24-24v4.812z"
+    />
+  </svg>
+</a>

--- a/apps/browser/src/lib/url.ts
+++ b/apps/browser/src/lib/url.ts
@@ -1,7 +1,10 @@
 import { page } from '$app/state';
 
-export function decodeRangeParam(name: string): { min?: number; max?: number } {
-  const param = page.url.searchParams.get(name);
+export function decodeRangeParam(
+  name: string,
+  urlSearchParams: URLSearchParams = page.url.searchParams,
+): { min?: number; max?: number } {
+  const param = urlSearchParams.get(name);
   const [min, max] = param
     ?.split('-')
     .map((s) => (s ? parseInt(s) : undefined)) ?? [undefined, undefined];
@@ -9,6 +12,9 @@ export function decodeRangeParam(name: string): { min?: number; max?: number } {
   return { min, max };
 }
 
-export function decodeDiscreteParam(name: string) {
-  return page.url.searchParams.get(name)?.split(',').filter(Boolean) || [];
+export function decodeDiscreteParam(
+  name: string,
+  urlSearchParams: URLSearchParams = page.url.searchParams,
+) {
+  return urlSearchParams.get(name)?.split(',').filter(Boolean) || [];
 }

--- a/apps/browser/src/routes/datasets/+page.svelte
+++ b/apps/browser/src/routes/datasets/+page.svelte
@@ -3,6 +3,7 @@
   import FacetsPanel from '$lib/components/FacetsPanel.svelte';
   import ActiveFilters from '$lib/components/ActiveFilters.svelte';
   import RunSparqlButton from '$lib/components/RunSparqlButton.svelte';
+  import RssButton from '$lib/components/RssButton.svelte';
   import * as m from '$lib/paraglide/messages';
   import { page } from '$app/state';
   import { goto } from '$app/navigation';
@@ -287,6 +288,12 @@
 <svelte:head>
   <title>Datasets - Netwerk Digitaal Erfgoed</title>
   <meta content={m.header_tagline()} name="description" />
+  <link
+    rel="alternate"
+    type="application/rss+xml"
+    title={m.rss_feed_title()}
+    href={`/datasets/rss${page.url.search}`}
+  />
 </svelte:head>
 
 <div class="max-w-7xl mx-auto px-4 lg:px-8 py-8 font-sans">
@@ -381,7 +388,10 @@
               searchResults.time,
             )} ms)
           </p>
-          <RunSparqlButton {searchRequest} />
+          <div class="flex items-center gap-2">
+            <RssButton />
+            <RunSparqlButton {searchRequest} />
+          </div>
         </div>
 
         {#if searchResults.datasets.length === 0}

--- a/apps/browser/src/routes/datasets/rss/+server.ts
+++ b/apps/browser/src/routes/datasets/rss/+server.ts
@@ -1,0 +1,147 @@
+import { Feed } from 'feed';
+import type { RequestEvent } from '@sveltejs/kit';
+import { fetchDatasets, type SearchRequest } from '$lib/services/datasets';
+import { extractLocaleFromUrl, setLocale } from '$lib/paraglide/runtime';
+import * as m from '$lib/paraglide/messages';
+import { decodeDiscreteParam, decodeRangeParam } from '$lib/url';
+import { getLocalizedValue } from '$lib/utils/i18n';
+
+const cacheTtl = 3600;
+
+/**
+ * RSS feed endpoint for dataset search results.
+ * Supports all search parameters from the main search page.
+ */
+export async function GET({ url }: RequestEvent) {
+  // Extract and set locale from URL path
+  const locale = extractLocaleFromUrl(url.pathname) || 'en';
+  setLocale(locale);
+
+  const searchRequest: SearchRequest = {
+    query: url.searchParams.get('search') || undefined,
+    publisher: decodeDiscreteParam('publishers', url.searchParams),
+    keyword: decodeDiscreteParam('keywords', url.searchParams),
+    format: decodeDiscreteParam('format', url.searchParams),
+    class: decodeDiscreteParam('class', url.searchParams),
+    terminologySource: decodeDiscreteParam(
+      'terminologySource',
+      url.searchParams,
+    ),
+    size: decodeRangeParam('size', url.searchParams),
+  };
+
+  const results = await fetchDatasets(searchRequest, 20, 0, 'datePosted');
+
+  // Calculate most recent date from results for feed's updated timestamp
+  const mostRecentDate =
+    results.datasets.length > 0 && results.datasets[0].datePosted
+      ? new Date(results.datasets[0].datePosted)
+      : new Date();
+
+  // Build feed title and description based on active filters
+  const feedDescription = buildFeedDescription(searchRequest, results.total);
+
+  // Build link to the HTML datasets page (not the RSS feed)
+  const datasetsPageUrl = `${url.origin}/datasets${url.search}`;
+
+  // Create RSS feed
+  const feed = new Feed({
+    title: `${m.header_title()} — ${m.header_tagline()}`,
+    description: feedDescription,
+    id: url.toString(),
+    link: datasetsPageUrl,
+    language: locale,
+    copyright: m.organization(),
+    updated: mostRecentDate,
+    generator: 'Dataset Register',
+    ttl: cacheTtl,
+    feedLinks: {
+      rss: url.toString(),
+    },
+  });
+
+  // Add each dataset as a feed item
+  for (const dataset of results.datasets) {
+    const title = getLocalizedValue(dataset.title) || 'Untitled Dataset';
+    const description = getLocalizedValue(dataset.description) || '';
+    const publisherName = dataset.publisher
+      ? getLocalizedValue(dataset.publisher.name)
+      : undefined;
+
+    // Link to the dataset detail page
+    const datasetLink = `https://datasetregister.netwerkdigitaalerfgoed.nl/show.php?lang=${locale}&uri=${encodeURIComponent(dataset.$id)}`;
+
+    feed.addItem({
+      title,
+      id: dataset.$id,
+      link: datasetLink,
+      description,
+      author: publisherName
+        ? [
+            {
+              name: publisherName,
+            },
+          ]
+        : undefined,
+      date: dataset.datePosted ? new Date(dataset.datePosted) : new Date(),
+    });
+  }
+
+  return new Response(feed.rss2(), {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': `max-age=0, s-maxage=${cacheTtl}`,
+    },
+  });
+}
+
+/**
+ * Build feed description based on active filters and result count
+ */
+function buildFeedDescription(
+  searchRequest: SearchRequest,
+  total: number,
+): string {
+  const parts: string[] = [];
+
+  if (searchRequest.query) {
+    parts.push(`${m.rss_filter_search()}: "${searchRequest.query}"`);
+  }
+
+  if (searchRequest.publisher.length > 0) {
+    parts.push(
+      `${m.rss_filter_publishers()}: ${searchRequest.publisher.length}`,
+    );
+  }
+
+  if (searchRequest.keyword.length > 0) {
+    parts.push(`${m.rss_filter_keywords()}: ${searchRequest.keyword.length}`);
+  }
+
+  if (searchRequest.format.length > 0) {
+    parts.push(`${m.rss_filter_formats()}: ${searchRequest.format.length}`);
+  }
+
+  if (searchRequest.class.length > 0) {
+    parts.push(`${m.rss_filter_classes()}: ${searchRequest.class.length}`);
+  }
+
+  if (searchRequest.terminologySource.length > 0) {
+    parts.push(
+      `${m.rss_filter_terminology_sources()}: ${searchRequest.terminologySource.length}`,
+    );
+  }
+
+  if (
+    searchRequest.size.min !== undefined ||
+    searchRequest.size.max !== undefined
+  ) {
+    parts.push(
+      `${m.rss_filter_size()}: ${searchRequest.size.min ?? '∞'} - ${searchRequest.size.max ?? '∞'} ${m.rss_triples()}`,
+    );
+  }
+
+  const filterDescription = parts.length > 0 ? ` (${parts.join(', ')})` : '';
+
+  return `${m.search_datasets_found({ count: total })}${filterDescription}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@lde/dataset-registry-client": "^0.4.3",
+        "feed": "^5.1.0",
         "fetch-sparql-endpoint": "^6.2.0",
         "ldkit": "^2.5.1",
         "sparqljs": "^3.7.3",
@@ -162,7 +163,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -11383,7 +11383,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -13001,7 +13000,6 @@
       "integrity": "sha512-/rnwfSWS3qwUSzvHynUTORF9xSJi7PCR9yXkxUOnRrNqyKmCmh3FPHH+E9BbgqxXfTevGXBqgnlh9kMb+9T5XA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -13041,7 +13039,6 @@
       "integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "debug": "^4.4.1",
@@ -13612,7 +13609,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -14031,7 +14027,6 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -14697,7 +14692,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -14756,7 +14750,6 @@
       "integrity": "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -14800,7 +14793,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -15413,7 +15405,6 @@
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -15791,7 +15782,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -17463,7 +17453,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -17533,7 +17522,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -17594,7 +17582,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -18233,6 +18220,19 @@
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
       "license": "MIT"
+    },
+    "node_modules/feed": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-5.1.0.tgz",
+      "integrity": "sha512-qGNhgYygnefSkAHHrNHqC7p3R8J0/xQDS/cYUud8er/qD9EFGWyCdUDfULHTJQN1d3H3WprzVwMc9MfB4J50Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=20",
+        "pnpm": ">=10"
+      }
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -21187,7 +21187,6 @@
       "resolved": "https://registry.npmjs.org/ky/-/ky-0.33.3.tgz",
       "integrity": "sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -21226,7 +21225,6 @@
       "integrity": "sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -21471,6 +21469,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -21492,6 +21491,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -21513,6 +21513,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -21534,6 +21535,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -21555,6 +21557,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -21576,6 +21579,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -21597,6 +21601,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -21618,6 +21623,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -21639,6 +21645,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -21660,6 +21667,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -21681,6 +21689,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -22634,7 +22643,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -23246,7 +23254,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -23380,7 +23387,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -25766,7 +25772,6 @@
       "integrity": "sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -25880,6 +25885,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/secure-compare": {
       "version": "3.0.1",
@@ -26928,7 +26939,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.43.8.tgz",
       "integrity": "sha512-d53/xClCjHsuFXuHsn7+F/0NKkkwgRv8kLg2his5YBYqVtfIrBqkvWd+5ZjYN6ryk/jv/rJF00vexXHkK8ofXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -27113,8 +27123,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -27673,7 +27682,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -27742,7 +27750,6 @@
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -28232,7 +28239,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -28848,7 +28854,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -28948,7 +28953,6 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -29201,6 +29205,18 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xmlchars": {


### PR DESCRIPTION
## Summary

Adds RSS 2.0 feed functionality to enable users to subscribe to dataset search results and receive updates about new datasets matching their search criteria.

## New Components

### RSS Feed Endpoint (`/datasets/rss/+server.ts`)
- **RSS 2.0 feed** supporting all search parameters (query, publishers, keywords, formats, classes, terminology sources, size)
- **Chronological ordering**: Items ordered by `datePosted` (newest first)
- **Smart caching**: Feed `updated` timestamp derived from most recent dataset's `datePosted` for accurate cache control
- **Limit**: 20 most recent items per feed
- **Fully internationalized**: All labels translated via Paraglide (English/Dutch)

### RSS Button Component (`RssButton.svelte`)
- **Subscription button** on dataset search page with RSS icon
- **Auto-discovery**: Adds `<link rel="alternate">` in page head for RSS auto-discovery
- **Preserves search context**: RSS URL includes all active search filters

## Schema Changes

### DatasetCard Schema Extension
- Added `schema:datePosted` field to support chronological ordering in feeds
- Enables accurate "most recent dataset" determination for feed timestamp

## Code Improvements

### URL Parameter Utilities
- Refactored `decodeDiscreteParam` and `decodeRangeParam` to accept `URLSearchParams` parameter
- Enables reuse in both server-side (RSS endpoint) and client-side contexts

## Technical Details

- **Dependencies**: Added `feed@5.1.0` library for RSS generation
- **Caching strategy**: `max-age=0, s-maxage=3600` (1 hour CDN cache, but no CDN yet in use)
- **Feed format**: RSS 2.0 XML with UTF-8 encoding
- **Content**: Dataset title, description, publisher, link, and publication date per item

Fix #1344 