### PR TITLE
fix: apply RDF serialization hook per-route instead of globally

### DIFF
--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -35,13 +35,25 @@ describe('Server', () => {
     nock.restore();
   });
 
-  it('shows documentation', async () => {
-    const redirect = await httpServer.inject({
+  it('shows documentation as HTML', async () => {
+    const response = await httpServer.inject({
       method: 'GET',
       url: '/',
       headers: { Accept: '*/*' },
     });
-    expect(redirect.statusCode).toEqual(200);
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['content-type']).toEqual(
+      'text/html; charset=utf-8',
+    );
+  });
+
+  it('shows documentation as JSON', async () => {
+    const response = await httpServer.inject({
+      method: 'GET',
+      url: '/json',
+      headers: { Accept: '*/*' },
+    });
+    expect(response.statusCode).toEqual(200);
   });
 
   it('rejects validation requests without URL', async () => {

--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -16,10 +16,10 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
       thresholds: {
         autoUpdate: true,
-        lines: 78.61,
+        lines: 79.32,
         functions: 84.61,
         branches: 80.76,
-        statements: 78.61,
+        statements: 79.32,
       },
     },
   },


### PR DESCRIPTION
## Summary

Fixes API documentation (Swagger UI) not being accessible after #1388.

The issue was caused by the global `preSerialization` hook trying to serialize all responses as RDF, including Swagger UI's HTML, JSON, CSS, and JavaScript files.

## Changes

* Remove global `preSerialization` hook registration from server setup
* Apply `rdfPreSerializationHook` per-route to RDF endpoints only:
  - `POST /datasets`
  - `PUT /datasets/validate`
  - `POST /datasets/validate`
  - `GET /shacl`
* Add test coverage for Swagger UI HTML and JSON endpoints
* Update test coverage thresholds

This restores the opt-in behavior from before #1388, ensuring Swagger UI routes use standard serialization while RDF routes get custom serialization with Hydra error handling.
