### PR TITLE
fix: use favicon from legacy app

### DIFF
--- a/apps/browser/src/routes/+layout.svelte
+++ b/apps/browser/src/routes/+layout.svelte
@@ -32,10 +32,10 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <svelte:head>
-  <link href="/favicon-32x32.png" rel="icon" />
-  <link href="/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180" />
-  <link href="/favicon-32x32.png" rel="icon" type="image/png" sizes="32x32" />
-  <link href="/favicon-16x16.png" rel="icon" type="image/png" sizes="16x16" />
+  <link href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/favicon-32x32.png" rel="icon" />
+  <link href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180" />
+  <link href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png" />
+  <link href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link
     href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap"

--- a/apps/browser/static/favicon.ico
+++ b/apps/browser/static/favicon.ico
@@ -1,7 +1,0 @@
-<html>
-<head><title>404 Not Found</title></head>
-<body>
-<center><h1>404 Not Found</h1></center>
-<hr><center>nginx/1.28.0</center>
-</body>
-</html>


### PR DESCRIPTION
* The new app doesn’t yet live at the https://datasetregister.netwerkdigitaalerfgoed.nl/ root,
  so re-use favicons from the legacy app for now.

Fix #1400