### PR TITLE
fix: make datePosted optional to fix publisher filtering

### DIFF
--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -79,6 +79,7 @@ export const DatasetCardSchema = {
   datePosted: {
     '@id': schema.datePosted,
     '@type': xsd.dateTime,
+    '@optional': true,
   },
 } as const;
 
@@ -166,7 +167,7 @@ export function datasetCardsQuery(
       SELECT DISTINCT ?dataset WHERE {
         ${filterDatasets(filters)}
         
-        ?registrationUrl schema:datePosted ?datePosted .
+        ${orderBy === 'datePosted' ? 'OPTIONAL { ?registrationUrl schema:datePosted ?datePosted }' : ''}
         
         OPTIONAL { 
           ?registrationUrl schema:validUntil ?validUntil . 
@@ -182,7 +183,7 @@ export function datasetCardsQuery(
     ?dataset a dcat:Dataset ;
       schema:subjectOf ?registrationUrl .
 
-    ?registrationUrl schema:datePosted ?datePosted .
+    ${orderBy === 'datePosted' ? 'OPTIONAL { ?registrationUrl schema:datePosted ?datePosted }' : ''}
 
     OPTIONAL { 
       ?registrationUrl schema:validUntil ?validUntil . 


### PR DESCRIPTION
## Summary

Fixes publisher filtering for datasets that don't have `schema:datePosted` in the registry's default graph.

## Problem

When filtering by publisher (e.g., University of Amsterdam Library), the query would return a count of 10 datasets but display 0 results. This was because:

1. The inner SELECT query required `?registrationUrl schema:datePosted ?datePosted` to be present
2. Some datasets don't have `datePosted` in the registry metadata
3. The query would filter these datasets out, even though they matched the publisher filter

## Solution

* Made `schema:datePosted` optional in `DatasetCardSchema`
* Made `datePosted` OPTIONAL in the SPARQL query's inner SELECT clause
* Made `datePosted` OPTIONAL in the outer WHERE clause

This allows datasets without `datePosted` to still be returned when filtering by publisher.

Fix #1398