### PR TITLE
fix: show loading animation on all facet changes

### DIFF
--- a/apps/browser/src/routes/+layout.svelte
+++ b/apps/browser/src/routes/+layout.svelte
@@ -32,10 +32,27 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <svelte:head>
-  <link href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/favicon-32x32.png" rel="icon" />
-  <link href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180" />
-  <link href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png" />
-  <link href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png" />
+  <link
+    href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/favicon-32x32.png"
+    rel="icon"
+  />
+  <link
+    href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/apple-touch-icon.png"
+    rel="apple-touch-icon"
+    sizes="180x180"
+  />
+  <link
+    href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/favicon-32x32.png"
+    rel="icon"
+    sizes="32x32"
+    type="image/png"
+  />
+  <link
+    href="https://datasetregister.netwerkdigitaalerfgoed.nl/assets/favicon-16x16.png"
+    rel="icon"
+    sizes="16x16"
+    type="image/png"
+  />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link
     href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap"

--- a/apps/browser/src/routes/datasets/+page.svelte
+++ b/apps/browser/src/routes/datasets/+page.svelte
@@ -350,7 +350,7 @@
           terminologySource: searchRequest.terminologySource,
           size: searchRequest.size,
         }}
-        loading={isLoading}
+        loading={!searchResults?.facets}
         onChange={(facetKey, value) => {
           updateURL(searchRequest, { [facetKey]: value });
         }}
@@ -359,7 +359,7 @@
 
     <!-- Main content area -->
     <div class="flex-1 min-w-0">
-      {#if isLoading && !searchResults}
+      {#if isLoading}
         <!-- Loading state -->
         <div class="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-6">
           {#each createSkeletons(6) as skeletonId (skeletonId)}
@@ -527,7 +527,7 @@
         terminologySource: searchRequest.terminologySource,
         size: searchRequest.size,
       }}
-      loading={isLoading}
+      loading={!searchResults?.facets}
       onChange={(facetKey, value) => {
         updateURL(searchRequest, { [facetKey]: value });
       }}


### PR DESCRIPTION
## Summary

Fixes a bug where the loading animation for dataset cards was not shown on subsequent facet changes, only on initial page load.

## Changes

* **Dataset cards**: Show loading skeleton whenever search is in progress (removed `!searchResults` condition)
* **Facets panel**: Keep facets visible and interactive during search by changing loading condition from `isLoading` to `!searchResults?.facets`
* Applied same behavior to both desktop sidebar and mobile drawer

## Behavior

**Before:**
- First facet change: ✅ Loading skeleton shown
- Subsequent facet changes: ❌ No loading indication, old results remain visible

**After:**
- All facet changes: ✅ Loading skeleton shown for dataset cards
- Facets remain visible and interactive with previous counts until new results load