### PR TITLE
fix: sort multilingual titles

### DIFF
--- a/apps/browser/src/lib/components/RunSparqlButton.svelte
+++ b/apps/browser/src/lib/components/RunSparqlButton.svelte
@@ -3,6 +3,7 @@
   import { datasetCardsQuery } from '$lib/services/datasets';
   import { cleanSparqlQuery } from '$lib/utils/sparql';
   import * as m from '$lib/paraglide/messages';
+  import { getLocale } from '$lib/paraglide/runtime';
 
   interface Props {
     searchRequest: SearchRequest;
@@ -13,7 +14,9 @@
   const ITEMS_PER_PAGE = 24;
 
   // Generate SPARQL query from search request
-  const query = $derived(datasetCardsQuery(searchRequest, ITEMS_PER_PAGE, 0));
+  const query = $derived(
+    datasetCardsQuery(searchRequest, ITEMS_PER_PAGE, 0, 'title', getLocale()),
+  );
 
   // Clean and URL encode the query (preserving formatting)
   const sparqlUrl = $derived(() => {


### PR DESCRIPTION
## Summary

Fixes multilingual dataset sorting by using COALESCE with OPTIONAL patterns to select titles in the user's current locale before sorting.

## Changes

* Modified SPARQL query to use COALESCE for locale-aware title selection
* Bind `?titleForSort` variable using preferred title (current locale → fallback to any language)
* Include `?titleForSort` in SELECT clause to enable proper ORDER BY
* Pass locale parameter from `fetchDatasets` to `datasetCardsQuery`
* Sort datasets alphabetically by titles in user's current language (case-insensitive)

## Test Results

✅ Dutch interface: Datasets sorted alphabetically by Dutch titles
✅ English interface: Datasets sorted alphabetically by English titles
✅ Fallback: Datasets without preferred locale title use available title and sort correctly

Fix #1401