### PR TITLE
fix: update TTL test fixtures for xsd:anyURI contentUrl validation

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -9,7 +9,10 @@
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/src/test-setup.[jt]s"
     ],
-    "sharedGlobals": ["{workspaceRoot}/.github/workflows/qa.yml"]
+    "sharedGlobals": [
+      "{workspaceRoot}/.github/workflows/qa.yml",
+      "{workspaceRoot}/requirements/shacl.ttl"
+    ]
   },
   "plugins": [
     {

--- a/packages/core/test/datasets/dataset-http-schema-org-valid.ttl
+++ b/packages/core/test/datasets/dataset-http-schema-org-valid.ttl
@@ -18,5 +18,5 @@
 
 <https://www.goudatijdmachine.nl/data/api/items/144>
   a schema:DataDownload ;
-  schema:contentUrl "https://www.goudatijdmachine.nl/wp-content/uploads/sites/7/2021/09/Totaal_perceel_Plaand_EPSG_4326.geojson" ;
+  schema:contentUrl "https://www.goudatijdmachine.nl/wp-content/uploads/sites/7/2021/09/Totaal_perceel_Plaand_EPSG_4326.geojson"^^xsd:anyURI ;
   schema:encodingFormat "application/geo+json" .

--- a/packages/core/test/datasets/dataset-schema-org-valid.ttl
+++ b/packages/core/test/datasets/dataset-schema-org-valid.ttl
@@ -18,5 +18,5 @@
 
 <https://www.goudatijdmachine.nl/data/api/items/144>
   a schema:DataDownload ;
-  schema:contentUrl "https://www.goudatijdmachine.nl/wp-content/uploads/sites/7/2021/09/Totaal_perceel_Plaand_EPSG_4326.geojson" ;
+  schema:contentUrl "https://www.goudatijdmachine.nl/wp-content/uploads/sites/7/2021/09/Totaal_perceel_Plaand_EPSG_4326.geojson"^^xsd:anyURI ;
   schema:encodingFormat "application/geo+json" .

--- a/packages/core/test/datasets/hydra-page1.ttl
+++ b/packages/core/test/datasets/hydra-page1.ttl
@@ -35,5 +35,5 @@
 
 <https://www.goudatijdmachine.nl/data/api/items/144>
   a schema:DataDownload ;
-  schema:contentUrl "https://www.goudatijdmachine.nl/wp-content/uploads/sites/7/2021/09/Totaal_perceel_Plaand_EPSG_4326.geojson" ;
+  schema:contentUrl "https://www.goudatijdmachine.nl/wp-content/uploads/sites/7/2021/09/Totaal_perceel_Plaand_EPSG_4326.geojson"^^xsd:anyURI ;
   schema:encodingFormat "application/geo+json" .

--- a/packages/core/test/datasets/hydra-page2.ttl
+++ b/packages/core/test/datasets/hydra-page2.ttl
@@ -35,5 +35,5 @@
 
 <https://www.goudatijdmachine.nl/data/api/items/144>
   a schema:DataDownload ;
-  schema:contentUrl "https://www.goudatijdmachine.nl/wp-content/uploads/sites/7/2021/09/Totaal_perceel_Plaand_EPSG_4326.geojson" ;
+  schema:contentUrl "https://www.goudatijdmachine.nl/wp-content/uploads/sites/7/2021/09/Totaal_perceel_Plaand_EPSG_4326.geojson"^^xsd:anyURI ;
   schema:encodingFormat "application/geo+json" .


### PR DESCRIPTION
## Summary

* Add `xsd:anyURI` datatype to `schema:contentUrl` in TTL test files to comply with SHACL constraint from PR #1367
* Add `requirements/shacl.ttl` to Nx sharedGlobals to ensure SHACL changes invalidate test cache

## Context

PR #1367 updated the SHACL constraint for `schema:contentUrl` to require either `xsd:anyURI` typed literal or an IRI. JSON-LD automatically interprets URL strings as IRIs, but Turtle parses quoted strings as plain `xsd:string` literals. The TTL test files were not updated to match, and Nx affected didn't detect the needed re-run because the SHACL file wasn't tracked as a shared input.