### PR TITLE
fix: use 14-char timestamp in Docker image tags

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -64,7 +64,7 @@
       "skipVersionActions": true,
       "registryUrl": "ghcr.io/netwerk-digitaal-erfgoed/dataset-register",
       "versionSchemes": {
-        "production": "{currentDate|YYYYMMDDHHmm}-{shortCommitSha}"
+        "production": "{currentDate|YYYYMMDDHHmmss}-{shortCommitSha}"
       }
     }
   },


### PR DESCRIPTION
* Standardise according to https://github.com/netwerk-digitaal-erfgoed/infrastructure/blob/master/doc/software-requirements.md#5-the-container-must-be-tagged-with-an-incremental-version-number
* Add seconds to timestamp format (YYYYMMDDHHmmss instead of YYYYMMDDHHmm)