### PR TITLE
feat(browser): remove IANA prefix from mediaType

### DIFF
--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -6,6 +6,7 @@ import { facetConfigs, type Facets, fetchFacets } from '$lib/services/facets';
 import { PUBLIC_SPARQL_ENDPOINT } from '$env/static/public';
 import { voidNs } from '../rdf.js';
 import { getLocale } from '$lib/paraglide/runtime';
+import { normalizeMediaType } from '$lib/utils/sparql';
 
 export const SPARQL_ENDPOINT = PUBLIC_SPARQL_ENDPOINT;
 const fetcher = new SparqlEndpointFetcher();
@@ -222,7 +223,8 @@ export function datasetCardsQuery(
                  
       OPTIONAL {
         ?dataset dcat:distribution ?distribution .
-        ?distribution dcat:mediaType ?mediaType .
+        ?distribution dcat:mediaType ?rawMediaType .
+        ${normalizeMediaType('?rawMediaType', '?mediaType')}
         OPTIONAL { ?distribution dct:conformsTo ?conformsTo }
       }
     }

--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -10,7 +10,7 @@ import { getLocalizedValue } from '$lib/utils/i18n';
 import * as m from '$lib/paraglide/messages';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { voidNs } from '../rdf.js';
-import { inLiterals } from '$lib/utils/sparql';
+import { inLiterals, normalizeMediaType } from '$lib/utils/sparql';
 import { getLocale } from '$lib/paraglide/runtime';
 
 const fetcher = new SparqlEndpointFetcher();
@@ -174,7 +174,8 @@ export const facetConfigs: Record<string, FacetConfig> = {
       ?dataset dcat:distribution ?distribution .
       {
         ?dataset dcat:distribution ?distribution .
-        ?distribution dcat:mediaType ?value .
+        ?distribution dcat:mediaType ?rawMediaType .
+        ${normalizeMediaType('?rawMediaType', '?value')}
       } UNION {
         ?dataset dcat:distribution ?distribution .
         ?distribution dct:conformsTo ?conformsTo .
@@ -182,7 +183,8 @@ export const facetConfigs: Record<string, FacetConfig> = {
         BIND("${GROUP_SPARQL}" AS ?value)
        } UNION {
         ?dataset dcat:distribution ?distribution .
-        ?distribution dcat:mediaType ?rdf .
+        ?distribution dcat:mediaType ?rawRdf .
+        ${normalizeMediaType('?rawRdf', '?rdf')}
         FILTER(REGEX(?rdf, "^(${rdfMediaTypesPattern})$"))
         BIND("${GROUP_RDF}" AS ?value)
        }
@@ -210,7 +212,8 @@ export const facetConfigs: Record<string, FacetConfig> = {
       }
 
       if (selectedMediaTypes.length > 0) {
-        selectClauses.push('?distribution dcat:mediaType ?mediaType');
+        selectClauses.push(`?distribution dcat:mediaType ?rawMediaType .
+          ${normalizeMediaType('?rawMediaType', '?mediaType')}`);
 
         const selectedMediaTypesQuoted = selectedMediaTypes
           .map((type) => `"${type}"`)

--- a/apps/browser/src/lib/utils/sparql.ts
+++ b/apps/browser/src/lib/utils/sparql.ts
@@ -44,3 +44,14 @@ function isIriTerm(term: unknown): term is IriTerm {
 
 export const inLiterals = (values: string[]) =>
   values.map((v) => `"${v}"`).join(', ');
+
+const IANA_MEDIA_TYPES_PREFIX = 'https://www.iana.org/assignments/media-types/';
+
+/**
+ * SPARQL expression to normalize IANA media type URIs to bare media types.
+ * Strips the IANA prefix if present, otherwise returns the value as-is.
+ */
+export const normalizeMediaType = (inputVar: string, outputVar: string) =>
+  `BIND(IF(STRSTARTS(STR(${inputVar}), "${IANA_MEDIA_TYPES_PREFIX}"),
+          STRAFTER(STR(${inputVar}), "${IANA_MEDIA_TYPES_PREFIX}"),
+          STR(${inputVar})) AS ${outputVar})`;


### PR DESCRIPTION
## Summary

* Extract repeated SPARQL IANA media type normalization logic into a reusable `normalizeMediaType()` helper function
* Replace 4 duplicate BIND expressions across `datasets.ts` and `facets.ts`
* No functional changes to query logic