### PR TITLE
fix(browser): add mailto prefix to publisher email link

### DIFF
--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -310,7 +310,7 @@
                     >
                       {#if dataset.publisher.email}
                         <a
-                          href={dataset.publisher.email}
+                          href="mailto:{dataset.publisher.email}"
                           class="inline-flex items-center gap-1.5 hover:text-blue-600 dark:hover:text-blue-400"
                         >
                           <svg


### PR DESCRIPTION
## Summary

Adds missing `mailto:` prefix to the publisher email link on the dataset detail page, enabling users to click and open their email client.