### PR TITLE
fix(browser): fetch datePosted and dateRead from registration URL

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -131,6 +131,17 @@ export const DatasetDetailSchema = {
       '@type': schema.EntryPoint,
       validUntil: {
         '@id': schema.validUntil,
+        '@type': xsd.dateTime,
+        '@optional': true,
+      },
+      datePosted: {
+        '@id': schema.datePosted,
+        '@type': xsd.dateTime,
+        '@optional': true,
+      },
+      dateRead: {
+        '@id': schema.dateRead,
+        '@type': xsd.dateTime,
         '@optional': true,
       },
     },
@@ -145,21 +156,6 @@ export const DatasetDetailSchema = {
         '@multilang': true,
       },
     },
-  },
-  datePosted: {
-    '@id': schema.datePosted,
-    '@type': xsd.dateTime,
-    '@optional': true,
-  },
-  dateRead: {
-    '@id': schema.dateRead,
-    '@type': xsd.dateTime,
-    '@optional': true,
-  },
-  validUntil: {
-    '@id': schema.validUntil,
-    '@type': xsd.dateTime,
-    '@optional': true,
   },
   contentRating: {
     '@id': schema.contentRating,

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -1315,7 +1315,7 @@
             </div>
           {/if}
 
-          {#if dataset.datePosted}
+          {#if dataset.subjectOf?.datePosted}
             <div
               class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
             >
@@ -1353,7 +1353,7 @@
                 </div>
               </dt>
               <dd class="text-sm text-gray-700 dark:text-gray-300">
-                {new Date(dataset.datePosted).toLocaleDateString(getLocale(), {
+                {new Date(dataset.subjectOf.datePosted).toLocaleDateString(getLocale(), {
                   year: 'numeric',
                   month: 'long',
                   day: 'numeric',
@@ -1364,7 +1364,7 @@
             </div>
           {/if}
 
-          {#if dataset.dateRead}
+          {#if dataset.subjectOf?.dateRead}
             <div
               class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
             >
@@ -1402,7 +1402,7 @@
                 </div>
               </dt>
               <dd class="text-sm text-gray-700 dark:text-gray-300">
-                {new Date(dataset.dateRead).toLocaleDateString(getLocale(), {
+                {new Date(dataset.subjectOf.dateRead).toLocaleDateString(getLocale(), {
                   year: 'numeric',
                   month: 'long',
                   day: 'numeric',


### PR DESCRIPTION
## Summary

* Fix missing `datePosted` and `dateRead` fields on dataset detail page
* Move these properties into the `subjectOf` schema since they are stored on the `schema:EntryPoint` (registration URL), not directly on the dataset
* Update template to access fields via `dataset.subjectOf`
