### PR TITLE
feat(browser): add creator to dataset detail page

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -136,6 +136,7 @@
   "detail_query_dataset": "Query this dataset",
   "detail_uri": "URI",
   "detail_publisher": "Publisher",
+  "detail_creator": "Creator",
   "detail_publisher_email": "Email",
   "detail_publisher_website": "Website",
   "detail_license": "License",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -136,6 +136,7 @@
   "detail_query_dataset": "Bevraag deze dataset",
   "detail_uri": "URI",
   "detail_publisher": "Uitgever",
+  "detail_creator": "Maker",
   "detail_publisher_email": "E-mail",
   "detail_publisher_website": "Website",
   "detail_license": "Licentie",

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -367,6 +367,47 @@
               </div>
             {/if}
 
+            <!-- Creator -->
+            {#if dataset.creator && dataset.creator.length > 0}
+              <div
+                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+              >
+                <dt
+                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+                >
+                  <svg
+                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                    />
+                  </svg>
+                  {m.detail_creator()}
+                </dt>
+                <dd class="text-sm text-gray-700 dark:text-gray-300">
+                  {#each dataset.creator as creator, index (creator)}
+                    <span>
+                      <a
+                        href={creator.$id}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-blue-600 hover:underline dark:text-blue-400"
+                      >
+                        {getLocalizedValue(creator.name)}
+                      </a>
+                      <LanguageBadge values={creator.name} />
+                    </span>{#if index < dataset.creator.length - 1},&nbsp;{/if}
+                  {/each}
+                </dd>
+              </div>
+            {/if}
+
             <!-- Catalog -->
             {#if dataset.isPartOf?.title}
               <div


### PR DESCRIPTION
## Summary
Add creator field to the dataset detail page, similar to the existing publisher display.

## Changes
* Display dataset creators with a person icon in the metadata section
* Link each creator name to their URI (opens in new tab)
* Support multiple creators with comma separation
* Add translations for EN ("Creator") and NL ("Maker")

Fix #1466