### PR TITLE
feat(core): normalize human-readable byte sizes in SPARQL query

### DIFF
--- a/packages/core/src/literal.ts
+++ b/packages/core/src/literal.ts
@@ -55,3 +55,31 @@ export const normalizeMediaType = (variable: string) =>
           )
           AS ?${variable}
         )`;
+
+/**
+ * Normalize byte size to xsd:integer.
+ *
+ * Some datasets provide human-readable values like "87 MB" instead of raw bytes.
+ * This converts common formats (B, KB, MB, GB, TB) to integer bytes.
+ */
+export const normalizeByteSize = (variable: string) =>
+  `?${variable}Raw ;
+        BIND(
+          IF(
+            REGEX(STR(?${variable}Raw), "^[0-9.]+\\\\s*(B|KB|MB|GB|TB)$", "i"),
+            xsd:integer(FLOOR(
+              xsd:decimal(REPLACE(STR(?${variable}Raw), "^([0-9.]+).*", "$1")) *
+              IF(REGEX(STR(?${variable}Raw), "TB", "i"), 1099511627776,
+              IF(REGEX(STR(?${variable}Raw), "GB", "i"), 1073741824,
+              IF(REGEX(STR(?${variable}Raw), "MB", "i"), 1048576,
+              IF(REGEX(STR(?${variable}Raw), "KB", "i"), 1024,
+              1))))
+            )),
+            IF(
+              REGEX(STR(?${variable}Raw), "^[0-9]+$"),
+              xsd:integer(?${variable}Raw),
+              ?${variable}Raw
+            )
+          )
+          AS ?${variable}
+        )`;

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -2,6 +2,7 @@ import factory from 'rdf-ext';
 import {
   convertToIri,
   convertToXsdDate,
+  normalizeByteSize,
   normalizeLicense,
   normalizeMediaType,
 } from './literal.ts';
@@ -173,7 +174,7 @@ export const constructQuery = `
           OPTIONAL { ?${distribution} dct:language ?${distributionLanguage} }
           OPTIONAL { ?${distribution} dct:license ${normalizeLicense(distributionLicense)} }
           OPTIONAL { ?${distribution} dct:title ?${distributionName} }
-          OPTIONAL { ?${distribution} dcat:byteSize ?${distributionSize} }
+          OPTIONAL { ?${distribution} dcat:byteSize ${normalizeByteSize(distributionSize)} }
         }
           
         OPTIONAL { ?${dataset} dct:description ?${description} }
@@ -276,7 +277,7 @@ function schemaOrgQuery(prefix: string): string {
       OPTIONAL { ?${distribution} ${prefix}:inLanguage ?${distributionLanguage} }
       OPTIONAL { ?${distribution} ${prefix}:license ${normalizeLicense(distributionLicense)} }
       OPTIONAL { ?${distribution} ${prefix}:name ?${distributionName} }
-      OPTIONAL { ?${distribution} ${prefix}:contentSize ?${distributionSize} }
+      OPTIONAL { ?${distribution} ${prefix}:contentSize ${normalizeByteSize(distributionSize)} }
       OPTIONAL { 
         ?${distribution} ${prefix}:usageInfo ?${distributionConformsTo} .
         FILTER(isIRI(?${distributionConformsTo}))  

--- a/packages/core/test/datasets/dataset-dcat-valid.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-valid.jsonld
@@ -81,6 +81,7 @@
       "dcat:accessURL": {
         "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf"
       },
+      "dcat:byteSize": "12 MB",
       "dct:description": "Turtle dump"
     },
     {

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -43,6 +43,20 @@ describe('Fetch', () => {
         ),
       ),
     ).toBe(true);
+
+    // byteSize must be normalized in literal.ts.
+    expect(
+      dataset.has(
+        factory.quad(
+          distributions[0].object as BlankNode,
+          dcat('byteSize'),
+          factory.literal(
+            '12582912',
+            factory.namedNode('http://www.w3.org/2001/XMLSchema#integer'),
+          ),
+        ),
+      ),
+    ).toBe(true);
   });
 
   it('accepts minimal valid Schema.org dataset', async () => {

--- a/requirements/examples/dataset-schema-org-valid.jsonld
+++ b/requirements/examples/dataset-schema-org-valid.jsonld
@@ -63,6 +63,7 @@
             "text/turtle"
           ],
           "contentUrl": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf",
+          "contentSize": 12582912,
           "description": "Turtle dump"
         },
         {

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -186,7 +186,7 @@ reg:DistributionShape
             sh:path schema:contentSize ;
             sh:minCount 0 ;
             sh:maxCount 1 ;
-            sh:description "A measure indicating the size of the distribution."@en ;
+            sh:description "Distribution file size in bytes."@en ;
         ] ,
         [
             a sh:PropertyShape ;


### PR DESCRIPTION
## Summary

Normalize human-readable byte size values (like "87 MB") to integer bytes during SPARQL query, consistent with other normalizations like license.

## Changes

* Add `normalizeByteSize` function to `literal.ts` using SPARQL BIND expressions
* Parse formats: B, KB, MB, GB, TB (case-insensitive, with or without space)
* Apply to both `dcat:byteSize` and `schema:contentSize` in `query.ts`