### PR TITLE
fix(browser): prevent horizontal scroll on mobile viewports

### DIFF
--- a/apps/browser/src/app.css
+++ b/apps/browser/src/app.css
@@ -3,6 +3,12 @@
 @plugin '@tailwindcss/typography';
 @source "../node_modules/@flowbite-svelte-plugins/chart/dist";
 
+/* Prevent horizontal scrolling on mobile - fixes tooltip overflow issues */
+html,
+body {
+  overflow-x: hidden;
+}
+
 /* Enable dark mode based on OS preference */
 @media (prefers-color-scheme: dark) {
   :root {


### PR DESCRIPTION
## Summary
* Prevent horizontal scrolling/bouncing on mobile devices viewing `/datasets`
* Add `overflow-x: hidden` to html/body to block horizontal scroll caused by tooltip overflow

## Root Cause
Tooltips in DatasetCard extend beyond the viewport edge on narrow screens (e.g., 430px), causing 37px of horizontal overflow and enabling unwanted horizontal swipe/bounce.

Fixes #1475