### PR TITLE
fix(api): handle malformed JSON in content type parser

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -297,13 +297,18 @@ export async function server(
       }
 
       // Parse simple JSON-LD as JSON.
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
         let data = '';
         payload.on('data', (chunk) => {
           data += chunk;
         });
         payload.on('end', () => {
-          resolve(JSON.parse(data));
+          try {
+            resolve(JSON.parse(data));
+          } catch (e) {
+            (e as FastifyError).statusCode = 400;
+            reject(e);
+          }
         });
       });
     },

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -64,6 +64,16 @@ describe('Server', () => {
     expect(response.statusCode).toEqual(400);
   });
 
+  it('handles malformed JSON in request body', async () => {
+    const response = await httpServer.inject({
+      method: 'PUT',
+      url: '/datasets/validate',
+      headers: { 'Content-Type': 'application/ld+json' },
+      payload: 'not valid json {',
+    });
+    expect(response.statusCode).toEqual(400);
+  });
+
   it('rejects validation requests that point to 404 URL', async () => {
     nock('https://example.com/').get('/404').reply(404);
     const response = await httpServer.inject({


### PR DESCRIPTION
## Summary

Adds error handling for malformed JSON input in the API content type parser.

* Add try-catch around `JSON.parse()` in the content type parser
* Return HTTP 400 instead of crashing the server on invalid JSON input
* Add test case for malformed JSON in request body

Previously, malformed JSON input (e.g., embedded quotes, invalid syntax) would throw an uncaught `SyntaxError`, potentially crashing the server. Now it returns a proper 400 response.