### PR TITLE
feat(browser): add status facet to filter invalid/deleted datasets

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -176,5 +176,9 @@
   "detail_issued": "Issued",
   "detail_modified": "Modified",
   "detail_landing_page": "Landing Page",
-  "missing_properties": "Missing properties"
+  "missing_properties": "Missing properties",
+  "facets_status": "Status",
+  "facets_status_invalid": "Invalid datasets",
+  "facets_status_deleted": "Deleted datasets",
+  "facets_status_explanation": "By default only current datasets are shown. Here you can choose to view datasets that are no longer valid or no longer exist."
 }

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -176,5 +176,9 @@
   "detail_issued": "Uitgegeven",
   "detail_modified": "Gewijzigd",
   "detail_landing_page": "Landingspagina",
-  "missing_properties": "Ontbrekende eigenschappen"
+  "missing_properties": "Ontbrekende eigenschappen",
+  "facets_status": "Status",
+  "facets_status_invalid": "Ongeldige datasets",
+  "facets_status_deleted": "Verwijderde datasets",
+  "facets_status_explanation": "Standaard worden alleen actuele datasets getoond. Hier kun je kiezen datasets te bekijken die niet meer geldig of verdwenen zijn."
 }

--- a/apps/browser/src/lib/components/FacetHelper.svelte
+++ b/apps/browser/src/lib/components/FacetHelper.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import InfoCircleOutline from 'flowbite-svelte-icons/InfoCircleOutline.svelte';
+
   let { explanation }: { explanation: string } = $props();
 
   let showPopover = $state(false);
@@ -64,12 +66,11 @@
     onclick={isTouchDevice ? togglePopover : undefined}
     onmouseenter={!isTouchDevice ? showTooltip : undefined}
     onmouseleave={!isTouchDevice ? hideTooltip : undefined}
-    class="ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full border-2 border-gray-400 hover:border-gray-600 hover:bg-gray-50 dark:border-gray-500 dark:hover:border-gray-300 dark:hover:bg-gray-800 transition-all focus:outline-none focus:ring-2 focus:ring-gray-400"
+    class="ml-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors focus:outline-none"
     aria-label="Show explanation"
     type="button"
   >
-    <span class="text-[10px] font-bold text-gray-600 dark:text-gray-400">?</span
-    >
+    <InfoCircleOutline class="w-5 h-5" />
   </button>
 
   {#if showPopover}

--- a/apps/browser/src/lib/components/FacetsPanel.svelte
+++ b/apps/browser/src/lib/components/FacetsPanel.svelte
@@ -18,6 +18,7 @@
       class: string[];
       terminologySource: string[];
       size: { min?: number; max?: number };
+      status: string[];
     };
     loading?: boolean;
     onChange: (
@@ -85,4 +86,13 @@
       onChange={(min, max) => onChange('size', { min, max })}
     />
   {/if}
+
+  <!-- Status facet always visible so users can toggle archived/deleted -->
+  <SearchFacet
+    selectedValues={selectedValues.status}
+    values={facets?.status ?? []}
+    title={m.facets_status()}
+    explanation={m.facets_status_explanation()}
+    onChange={(values) => onChange('status', values)}
+  />
 {/if}

--- a/apps/browser/src/routes/datasets/+page.svelte
+++ b/apps/browser/src/routes/datasets/+page.svelte
@@ -46,6 +46,7 @@
     class: decodeDiscreteParam('class'),
     terminologySource: decodeDiscreteParam('terminologySource'),
     size: decodeRangeParam('size'),
+    status: decodeDiscreteParam('status'),
   });
 
   // Check cache synchronously to initialize state without flash
@@ -65,6 +66,7 @@
       class: decodeDiscreteParam('class'),
       terminologySource: decodeDiscreteParam('terminologySource'),
       size: decodeRangeParam('size'),
+      status: decodeDiscreteParam('status'),
     });
 
     if (searchCache && searchCache.searchKey === currentSearchKey) {
@@ -273,6 +275,12 @@
       url.searchParams.delete('terminologySource');
     }
 
+    if (params.status && params.status.length > 0) {
+      url.searchParams.set('status', params.status.join(','));
+    } else {
+      url.searchParams.delete('status');
+    }
+
     if (params.size?.min !== undefined || params.size?.max !== undefined) {
       url.searchParams.set(
         'size',
@@ -455,6 +463,7 @@
           class: searchRequest.class,
           terminologySource: searchRequest.terminologySource,
           size: searchRequest.size,
+          status: searchRequest.status,
         }}
         loading={!searchResults?.facets}
         onChange={(facetKey, value) => {
@@ -632,6 +641,7 @@
         class: searchRequest.class,
         terminologySource: searchRequest.terminologySource,
         size: searchRequest.size,
+        status: searchRequest.status,
       }}
       loading={!searchResults?.facets}
       onChange={(facetKey, value) => {
@@ -659,6 +669,7 @@
           class: [],
           terminologySource: [],
           size: { min: undefined, max: undefined },
+          status: [],
         });
       }}
       class="w-full px-6 py-3 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 font-semibold rounded-lg transition-colors cursor-pointer"

--- a/apps/browser/src/routes/datasets/rss/+server.ts
+++ b/apps/browser/src/routes/datasets/rss/+server.ts
@@ -28,6 +28,7 @@ export async function GET({ url }: RequestEvent) {
       url.searchParams,
     ),
     size: decodeRangeParam('size', url.searchParams),
+    status: decodeDiscreteParam('status', url.searchParams),
   };
 
   const results = await fetchDatasets(searchRequest, 20, 0, 'datePosted');


### PR DESCRIPTION
## Summary

Adds a status facet to the dataset search page that allows users to filter datasets by their validity status.

### Changes

- **Status facet configuration**: Add `defaultClause` support to `FacetConfig` interface for facets that need default filtering behavior
- **Default filtering**: Show only valid datasets by default (HTTP status 200, no `validUntil` date)
- **Status filter options**: Allow users to filter for invalid (expired) or deleted (HTTP > 200) datasets
- **Smart facet counts**: Status facet counts skip the default filter so users can see how many invalid/deleted datasets exist
- **URL persistence**: Status filter state is persisted in URL params
- **Translations**: Added English and Dutch labels for status facet

### Technical Details

The `defaultClause` pattern allows:
1. Dataset queries to apply default filtering when no status is selected
2. Facet count queries to skip the default when calculating status counts (so all available status values are shown)

Fixes #1485