### PR TITLE
fix(browser): improve types table responsiveness on narrow viewports

### DIFF
--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -1150,7 +1150,7 @@
               >
                 <div class="flex-1">{m.detail_class()}</div>
                 <div class="w-24 text-right">{m.detail_entities()}</div>
-                <div class="w-36">%</div>
+                <div class="w-12 sm:w-36">%</div>
               </div>
               <!-- Data rows -->
               {#each displayedClassRows ?? [] as row (row.className)}
@@ -1171,9 +1171,9 @@
                   >
                     {row.entities.toLocaleString(getLocale())}
                   </div>
-                  <div class="w-36 flex items-center gap-2">
+                  <div class="w-12 sm:w-36 flex items-center gap-2">
                     <div
-                      class="flex-1 h-2 bg-gray-200 rounded-full dark:bg-gray-600"
+                      class="hidden sm:block flex-1 h-2 bg-gray-200 rounded-full dark:bg-gray-600"
                     >
                       <div
                         class="h-2 bg-blue-600 rounded-full"
@@ -1181,7 +1181,7 @@
                       ></div>
                     </div>
                     <span
-                      class="text-xs w-12 text-right tabular-nums text-gray-600 dark:text-gray-400"
+                      class="text-xs w-full sm:w-12 text-right tabular-nums text-gray-600 dark:text-gray-400"
                       >{row.percent.toLocaleString(getLocale(), {
                         minimumFractionDigits: 1,
                         maximumFractionDigits: 1,


### PR DESCRIPTION
## Summary

Improves the responsiveness of the "Typen" (Types) table on the dataset detail page for narrow viewports.

**Problem:** On mobile devices, the fixed column widths left insufficient space for the type URIs, making them illegible.

**Solution:** 
* Hide the progress bar on mobile viewports (< 640px) using `hidden sm:block`
* Use responsive width classes (`w-12 sm:w-36`) for the percentage column
* The percentage number remains visible on all screen sizes

This recovers ~96px of horizontal space for the Type column on mobile devices.