### PR TITLE
feat(browser): add omekas prefix for Omeka-S vocabulary

### DIFF
--- a/apps/browser/src/lib/utils/prefix.ts
+++ b/apps/browser/src/lib/utils/prefix.ts
@@ -6,6 +6,7 @@ import { shrink } from '@zazuko/prefixes';
  */
 export function shortenUri(uri: string): string {
   const shortened = shrink(uri, {
+    omekas: 'http://omeka.org/s/vocabs/o#',
     pico: 'https://personsincontext.org/model#',
     pnv: 'https://w3id.org/pnv#',
     sdo: 'https://schema.org/',


### PR DESCRIPTION
## Summary

Adds a prefix mapping for the Omeka-S vocabulary namespace (`http://omeka.org/s/vocabs/o#`).

This enables shorter display of Omeka-S class URIs in the types table, e.g., `omekas:Item` instead of the full URI `http://omeka.org/s/vocabs/o#Item`.