### PR TITLE
feat(browser): add Matomo analytics tracking

### DIFF
--- a/apps/browser/src/app.d.ts
+++ b/apps/browser/src/app.d.ts
@@ -8,6 +8,10 @@ declare global {
     // interface PageState {}
     // interface Platform {}
   }
+
+  interface Window {
+    _paq?: Array<Array<string | number>>;
+  }
 }
 
 export {};

--- a/apps/browser/src/app.html
+++ b/apps/browser/src/app.html
@@ -4,6 +4,23 @@
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1" name="viewport" />
     %sveltekit.head%
+    <!-- Matomo -->
+    <script>
+      var _paq = (window._paq = window._paq || []);
+      _paq.push(['enableLinkTracking']);
+      (function () {
+        var u = '//matomo.netwerkdigitaalerfgoed.nl/';
+        _paq.push(['setTrackerUrl', u + 'matomo.php']);
+        _paq.push(['setSiteId', '1']);
+        var d = document,
+          g = d.createElement('script'),
+          s = d.getElementsByTagName('script')[0];
+        g.async = true;
+        g.src = u + 'matomo.js';
+        s.parentNode.insertBefore(g, s);
+      })();
+    </script>
+    <!-- End Matomo -->
   </head>
   <body data-sveltekit-preload-data="hover">
     <div style="display: contents">%sveltekit.body%</div>

--- a/apps/browser/src/routes/+layout.svelte
+++ b/apps/browser/src/routes/+layout.svelte
@@ -4,9 +4,18 @@
   import * as m from '$lib/paraglide/messages';
   import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { page } from '$app/state';
+  import { browser } from '$app/environment';
 
   let { children, data } = $props();
   const locale = $derived(data?.locale || getLocale());
+
+  // Track page views in Matomo on navigation
+  $effect(() => {
+    if (browser && window._paq) {
+      window._paq.push(['setCustomUrl', page.url.href]);
+      window._paq.push(['trackPageView']);
+    }
+  });
 
   // Mobile menu state
   let mobileMenuOpen = $state(false);


### PR DESCRIPTION
## Summary

* Add Matomo analytics tracking to the browser app with full SPA support
* Matomo loader script in `app.html` initializes the tracker
* Navigation tracking in root layout using `$effect` tracks all client-side page views
* TypeScript declaration for `window._paq`