### PR TITLE
feat(browser): add isPartOf field to dataset detail page

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -162,7 +162,7 @@
   "detail_distributions_tooltip": "Distributions provide access to the data.",
   "lang_badge_also_in": "Also in {lang}:",
   "lang_badge_unspecified": "Unspecified",
-  "detail_catalog": "Part of catalog",
+  "detail_is_part_of": "Part of",
   "license_cc0_1_0": "CC0 1.0 Universal",
   "license_cc_by_4_0": "CC BY 4.0 International",
   "license_cc_by_3_0": "CC BY 3.0 Unported",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -162,7 +162,7 @@
   "detail_distributions_tooltip": "Distributies geven toegang tot de data.",
   "lang_badge_also_in": "Ook in het {lang}:",
   "lang_badge_unspecified": "Niet gespecificeerd",
-  "detail_catalog": "Onderdeel van catalogus",
+  "detail_is_part_of": "Onderdeel van",
   "license_cc0_1_0": "CC0 1.0 Universeel",
   "license_cc_by_4_0": "CC BY 4.0 Internationaal",
   "license_cc_by_3_0": "CC BY 3.0 Unported",

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -148,13 +148,6 @@ export const DatasetDetailSchema = {
   isPartOf: {
     '@id': dcterms.isPartOf,
     '@optional': true,
-    '@schema': {
-      '@type': 'http://www.w3.org/ns/dcat#Catalog',
-      title: {
-        '@id': dcterms.title,
-        '@multilang': true,
-      },
-    },
   },
   contentRating: {
     '@id': schema.contentRating,

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -410,7 +410,7 @@
             {/if}
 
             <!-- Catalog -->
-            {#if dataset.isPartOf?.title}
+            {#if dataset.isPartOf}
               <div
                 class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
               >
@@ -430,18 +430,17 @@
                       d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
                     />
                   </svg>
-                  {m.detail_catalog()}
+                  {m.detail_is_part_of()}
                 </dt>
                 <dd class="text-sm text-gray-700 dark:text-gray-300">
                   <a
-                    href={dataset.isPartOf.$id}
+                    href={`https://datasetregister.netwerkdigitaalerfgoed.nl/catalog.php?lang=${getLocale()}&uri=${encodeURIComponent(dataset.isPartOf)}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     class="text-blue-600 hover:underline dark:text-blue-400"
                   >
-                    {getLocalizedValue(dataset.isPartOf.title)}
+                    {dataset.isPartOf}
                   </a>
-                  <LanguageBadge values={dataset.isPartOf.title} />
                 </dd>
               </div>
             {/if}


### PR DESCRIPTION
## Summary

* Display `dcterms:isPartOf` on dataset detail page with label "Onderdeel van" / "Part of"
* Link to catalog.php with dynamic language parameter based on UI locale
* Show catalog URI as link text

Fixes #1467