### PR TITLE
fix(core): prioritize 'gone' status over 'invalid' in registration

### DIFF
--- a/packages/core/src/registration.ts
+++ b/packages/core/src/registration.ts
@@ -67,11 +67,11 @@ export class Registration {
    * - 'valid': healthy registration
    */
   get registrationStatus(): 'valid' | 'invalid' | 'gone' {
-    if (this.validUntil !== undefined) {
-      return 'invalid';
-    }
     if (this._statusCode !== undefined && this._statusCode > 200) {
       return 'gone';
+    }
+    if (this.validUntil !== undefined) {
+      return 'invalid';
     }
     return 'valid';
   }

--- a/packages/core/test/registration.test.ts
+++ b/packages/core/test/registration.test.ts
@@ -50,14 +50,15 @@ describe('Registration', () => {
       expect(registration.registrationStatus).toBe('gone');
     });
 
-    it('returns invalid over gone when both conditions are met', () => {
-      // When a URL returns 404 AND has validUntil, invalid takes precedence
+    it('returns gone over invalid when both conditions are met', () => {
+      // When a URL returns 404 AND has validUntil, gone takes precedence
+      // because an unavailable URL is definitively gone regardless of validation state
       const registration = new Registration(
         new URL('https://example.com/registration'),
         new Date(),
       ).read([], 404, false);
 
-      expect(registration.registrationStatus).toBe('invalid');
+      expect(registration.registrationStatus).toBe('gone');
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the order of status checks in the `registrationStatus` getter to correctly identify registrations that have become unavailable.

* Check HTTP status code (> 200) before `validUntil` to correctly identify gone registrations
* Ensures registrations with both an error status and `validUntil` are marked as 'gone' rather than 'invalid'

## Why This Matters

When a registration URL returns an HTTP error (e.g., 404, 500), it should be marked as 'gone' regardless of whether it also has a `validUntil` timestamp. The previous order would mark such registrations as 'invalid', which incorrectly suggests they might become valid again.