### PR TITLE
fix(browser): hide status facet when there are no invalid/gone datasets

### DIFF
--- a/apps/browser/src/lib/components/FacetsPanel.svelte
+++ b/apps/browser/src/lib/components/FacetsPanel.svelte
@@ -87,12 +87,13 @@
     />
   {/if}
 
-  <!-- Status facet always visible so users can toggle invalid/gone -->
-  <SearchFacet
-    selectedValues={selectedValues.status}
-    values={facets?.status ?? []}
-    title={m.facets_status()}
-    explanation={m.facets_status_explanation()}
-    onChange={(values) => onChange('status', values)}
-  />
+  {#if (facets?.status ?? []).length > 0 || selectedValues.status.length > 0}
+    <SearchFacet
+      selectedValues={selectedValues.status}
+      values={facets?.status ?? []}
+      title={m.facets_status()}
+      explanation={m.facets_status_explanation()}
+      onChange={(values) => onChange('status', values)}
+    />
+  {/if}
 {/if}


### PR DESCRIPTION
## Summary
- Hide the status facet when there are no datasets with "gone" or "invalid" status
- Apply the same conditional rendering pattern used by other facets

This makes the status widget consistent with other search facets, which are only shown when they have values.