### PR TITLE
refactor(browser): consolidate REGISTRATION_STATUS_BASE_URI constant

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -168,6 +168,7 @@
   "detail_entities_count": "entities",
   "detail_valid": "Valid",
   "detail_invalid": "Invalid",
+  "detail_gone": "Gone",
   "detail_verified_tooltip": "This distribution has been validated by the Dataset Knowledge Graph.",
   "detail_distributions_tooltip": "Distributions provide access to the data.",
   "lang_badge_also_in": "Also in {lang}:",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -168,6 +168,7 @@
   "detail_entities_count": "entiteiten",
   "detail_valid": "Geldig",
   "detail_invalid": "Ongeldig",
+  "detail_gone": "Verdwenen",
   "detail_verified_tooltip": "Deze distributie is gevalideerd door de Dataset Knowledge Graph.",
   "detail_distributions_tooltip": "Distributies geven toegang tot de data.",
   "lang_badge_also_in": "Ook in het {lang}:",

--- a/apps/browser/src/app.css
+++ b/apps/browser/src/app.css
@@ -1,7 +1,13 @@
 @import 'tailwindcss';
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
-@source "../node_modules/@flowbite-svelte-plugins/chart/dist";
+@plugin 'flowbite/plugin';
+
+@custom-variant dark (&:where(.dark, .dark *));
+
+@source "../../../node_modules/flowbite-svelte/dist";
+@source "../../../node_modules/flowbite-svelte-icons/dist";
+@source "../../../node_modules/@flowbite-svelte-plugins/chart/dist";
 
 /* Prevent horizontal scrolling on mobile - fixes tooltip overflow issues */
 html,

--- a/apps/browser/src/lib/constants/registration.ts
+++ b/apps/browser/src/lib/constants/registration.ts
@@ -1,0 +1,6 @@
+/**
+ * Base URI for registration status values.
+ * Must match the value in @dataset-register/core.
+ */
+export const REGISTRATION_STATUS_BASE_URI =
+  'https://data.netwerkdigitaalerfgoed.nl/registry/';

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -5,6 +5,7 @@ import { error } from '@sveltejs/kit';
 import { ndeNs, owlNs, voidNs } from '../rdf.js';
 import { BaseDatasetSchema, BaseDistributionSchema } from './datasets.js';
 import { shortenUri } from '$lib/utils/prefix';
+import { REGISTRATION_STATUS_BASE_URI } from '$lib/constants/registration.js';
 
 export const DATASET_REGISTER_ENDPOINT =
   'https://datasetregister.netwerkdigitaalerfgoed.nl/sparql';
@@ -142,6 +143,9 @@ export const DatasetDetailSchema = {
         '@id': schema.validUntil,
         '@type': xsd.dateTime,
         '@optional': true,
+      },
+      additionalType: {
+        '@id': schema.additionalType,
       },
     },
   },
@@ -353,4 +357,25 @@ export function displayMissingProperties(ratingExplanation: string): string[] {
   return ratingExplanation
     .split(', ')
     .map((ratingExplanation) => shortenUri(ratingExplanation));
+}
+
+export type RegistrationStatus = 'gone' | 'invalid' | null;
+
+/**
+ * Extracts the registration status from the additionalType URI.
+ * Returns 'gone', 'invalid', or null for valid/undefined statuses.
+ */
+export function getRegistrationStatus(
+  additionalType: string | undefined,
+): RegistrationStatus {
+  if (!additionalType) return null;
+
+  if (additionalType === `${REGISTRATION_STATUS_BASE_URI}gone`) {
+    return 'gone';
+  }
+  if (additionalType === `${REGISTRATION_STATUS_BASE_URI}invalid`) {
+    return 'invalid';
+  }
+
+  return null;
 }

--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -6,6 +6,7 @@ import {
   PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
 } from '$env/static/public';
 import { RDF_MEDIA_TYPES } from '$lib/constants.js';
+import { REGISTRATION_STATUS_BASE_URI } from '$lib/constants/registration.js';
 import { getLocalizedValue } from '$lib/utils/i18n';
 import * as m from '$lib/paraglide/messages';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
@@ -65,9 +66,6 @@ const SPARQL_PROTOCOL_URI = '<https://www.w3.org/TR/sparql11-protocol/>';
 
 const VALUE_INVALID = 'invalid';
 const VALUE_GONE = 'gone';
-
-const REGISTRATION_STATUS_BASE_URI =
-  'https://data.netwerkdigitaalerfgoed.nl/registry/';
 
 const GROUP_RDF = 'group:rdf';
 const GROUP_SPARQL = 'group:sparql';


### PR DESCRIPTION
## Summary
Follow-up cleanup to #1509:
- Consolidate `REGISTRATION_STATUS_BASE_URI` into shared constants file
- Simplify `getRegistrationStatus` parameter type from `string | undefined | null` to `string | undefined`

## Test plan
- [ ] Type checking passes
- [ ] Dataset detail page still works correctly