### PR TITLE
fix(core): filter URI values from genre property in SPARQL queries

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -191,7 +191,10 @@ export const constructQuery = `
           FILTER(!isBlank(?${spatialCoverage}))
         }
         OPTIONAL { ?${dataset} dct:temporal ?${temporalCoverage} }
-        OPTIONAL { ?${dataset} dct:genre ?${genre} }
+        OPTIONAL { 
+          ?${dataset} dct:genre ?${genre}
+          FILTER(isLiteral(?${genre}))
+        }
         OPTIONAL { ?${dataset} owl:versionInfo ?${version} }
         OPTIONAL { ?${dataset} dct:isPartOf ?${includedInDataCatalog} }
         OPTIONAL { ?${dataset} dct:hasPart ?${hasPart} }
@@ -305,7 +308,10 @@ function schemaOrgQuery(prefix: string): string {
       FILTER(!isBlank(?${spatialCoverage}))
     }
     OPTIONAL { ?${dataset} ${prefix}:temporalCoverage ?${temporalCoverage} }
-    OPTIONAL { ?${dataset} ${prefix}:genre ?${genre} }
+    OPTIONAL { 
+      ?${dataset} ${prefix}:genre ?${genre}
+      FILTER(isLiteral(?${genre}))
+    }
     OPTIONAL { ?${dataset} ${prefix}:version ?${version} }
     OPTIONAL { ?${dataset} ${prefix}:includedInDataCatalog ?${includedInDataCatalog} }
     OPTIONAL { ?${dataset} ${prefix}:hasPart ?${hasPart} }


### PR DESCRIPTION
## Summary
* Add `FILTER(isLiteral(?genre))` to both DCAT and schema.org query branches
* Prevents URI values (e.g., Getty AAT terms) from being stored as `dct:type`
* Fixes 500 error in browser when LDKit encounters NamedNode instead of literal

## Test plan
- [ ] Re-crawl affected dataset (`https://n2t.net/ark:/67039/dataset`)
- [ ] Verify browser detail page loads without error

Fixes #1483