### PR TITLE
fix(browser): use correct Tailwind utility for checkbox checked color

### DIFF
--- a/apps/browser/src/lib/components/FacetItem.svelte
+++ b/apps/browser/src/lib/components/FacetItem.svelte
@@ -35,7 +35,7 @@
 >
   <input
     checked={isChecked}
-    class="w-4 h-4 accent-blue-600 border-gray-300 dark:border-gray-600 rounded focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-600 cursor-pointer"
+    class="w-4 h-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-600 cursor-pointer"
     onchange={handleChange}
     type="checkbox"
     value={value.value}


### PR DESCRIPTION
## Summary

Fixes black background on selected checkboxes in search facets.

* Replace `accent-blue-600` with `text-blue-600` on facet checkboxes
* The `@tailwindcss/forms` plugin uses `text-*` utilities to control checkbox checked state background color, not `accent-*`

## Background

The `@tailwindcss/forms` plugin creates custom-styled checkboxes that use `currentColor` for the checked state background. Without an explicit `text-*` utility, the checkbox was inheriting the parent's text color (gray), resulting in a dark/black background instead of blue.