### PR TITLE
feat(browser): add tooltips to status facet values

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -190,6 +190,8 @@
   "missing_properties": "Missing properties",
   "facets_status": "Status",
   "facets_status_invalid": "Invalid datasets",
+  "facets_status_invalid_tooltip": "Datasets whose description no longer conforms to the requirements.",
   "facets_status_gone": "Gone datasets",
+  "facets_status_gone_tooltip": "Datasets whose registration URL is no longer accessible.",
   "facets_status_explanation": "By default only current datasets are shown. Here you can choose to view datasets that are no longer valid or no longer exist."
 }

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -190,6 +190,8 @@
   "missing_properties": "Ontbrekende eigenschappen",
   "facets_status": "Status",
   "facets_status_invalid": "Ongeldige datasets",
+  "facets_status_invalid_tooltip": "Datasets waarvan de beschrijving niet meer voldoet aan de eisen.",
   "facets_status_gone": "Verdwenen datasets",
+  "facets_status_gone_tooltip": "Datasets waarvan de registratie-URL niet meer bereikbaar is.",
   "facets_status_explanation": "Standaard worden alleen actuele datasets getoond. Hier kun je kiezen datasets te bekijken die niet meer geldig of verdwenen zijn."
 }

--- a/apps/browser/src/lib/components/FacetItem.svelte
+++ b/apps/browser/src/lib/components/FacetItem.svelte
@@ -2,8 +2,11 @@
   import {
     type CountedFacetValue,
     facetDisplayValue,
+    facetValueTooltip,
   } from '$lib/services/facets';
   import { getLocale } from '$lib/paraglide/runtime';
+  import { Tooltip } from 'flowbite-svelte';
+  import InfoCircleOutline from 'flowbite-svelte-icons/InfoCircleOutline.svelte';
 
   let {
     value,
@@ -17,9 +20,11 @@
 
   const locale = $derived(getLocale());
   const displayValue = $derived(facetDisplayValue(value));
+  const tooltip = $derived(facetValueTooltip(value));
   const breakClass = $derived(
     displayValue.includes(' ') ? 'break-words' : 'break-all',
   );
+  const tooltipId = $derived(`tooltip-${value.value}`);
 
   function formatCount(count: number): string {
     return count.toLocaleString(locale);
@@ -41,10 +46,18 @@
     value={value.value}
   />
   <span
-    class="flex-1 text-sm text-gray-700 dark:text-gray-300 leading-tight {breakClass}"
+    class="flex-1 text-sm text-gray-700 dark:text-gray-300 leading-tight {breakClass} inline-flex items-center gap-1"
     title={displayValue}
   >
     {displayValue}
+    {#if tooltip}
+      <span id={tooltipId}>
+        <InfoCircleOutline
+          class="h-4 w-4 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+        />
+      </span>
+      <Tooltip triggeredBy="#{tooltipId}">{tooltip}</Tooltip>
+    {/if}
   </span>
   <span
     class="inline-flex items-center justify-center px-2 py-0.5 text-xs font-medium tabular-nums rounded-full bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300"

--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -545,6 +545,17 @@ const valueTranslations = {
   [GROUP_EVENT]: m['group:event'],
 };
 
+const valueTooltips = {
+  [VALUE_GONE]: m['facets_status_gone_tooltip'],
+  [VALUE_INVALID]: m['facets_status_invalid_tooltip'],
+};
+
+export function facetValueTooltip(
+  facetValue: SelectedFacetValue,
+): string | undefined {
+  return valueTooltips[facetValue.value as keyof typeof valueTooltips]?.();
+}
+
 export function facetDisplayValue(facetValue: SelectedFacetValue) {
   return (
     valueTranslations[facetValue.value as keyof typeof valueTranslations]?.() ??


### PR DESCRIPTION
## Summary

Adds informational tooltips to the "Invalid datasets" and "Gone datasets" options in the Status search facet.

* Add info icon with hover tooltip next to status facet values
* "Invalid datasets": Explains these are datasets whose description no longer conforms to the requirements
* "Gone datasets": Explains these are datasets whose registration URL is no longer accessible
* Fully internationalized (English/Dutch)