### PR TITLE
fix(browser): restore dark mode by removing custom variant override

### DIFF
--- a/apps/browser/src/app.css
+++ b/apps/browser/src/app.css
@@ -3,8 +3,6 @@
 @plugin '@tailwindcss/typography';
 @plugin 'flowbite/plugin';
 
-@custom-variant dark (&:where(.dark, .dark *));
-
 @source "../../../node_modules/flowbite-svelte/dist";
 @source "../../../node_modules/flowbite-svelte-icons/dist";
 @source "../../../node_modules/@flowbite-svelte-plugins/chart/dist";


### PR DESCRIPTION
## Summary

Fixes dark mode which was broken after adding Flowbite's Tailwind v4 configuration.

The `@custom-variant dark` directive was added for Flowbite, but it overrode Tailwind v4's default media query-based dark mode. Since Flowbite components use standard `dark:` utilities that work with either strategy, we can simply remove the custom variant to restore the default behavior.

## Changes

* Remove `@custom-variant dark` from app.css
* Tailwind v4 now uses its default `@media (prefers-color-scheme: dark)` for dark mode