### PR TITLE
perf(browser): use native fetch instead of SvelteKit's for LDkit

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -10,7 +10,6 @@ import {
   PUBLIC_SPARQL_ENDPOINT,
   PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
 } from '$env/static/public';
-
 // Extended distribution schema with additional fields for detail view
 const DetailDistributionSchema = {
   ...BaseDistributionSchema,
@@ -306,16 +305,17 @@ export interface DatasetDetailResult {
 // Main function to fetch all dataset detail data
 export async function fetchDatasetDetail(
   datasetUri: string,
-  fetch?: typeof globalThis.fetch,
 ): Promise<DatasetDetailResult> {
-  // Create lenses with custom fetch if provided
+  // We intentionally don't pass SvelteKit's fetch to LDkit.
+  // SvelteKit's fetch buffers entire response bodies for hydration serialization,
+  // which breaks the streaming RDF parser and causes 10x slower performance
+  // (~22s vs ~2.3s) on large SPARQL responses. Node's native fetch streams properly.
+  // SSR still works: content is rendered server-side with native fetch.
+
+  // Uncomment to enable query logging:
   // const options: Options = { logQuery: console.log };
   const options: Options = {};
-  if (fetch) {
-    options.fetch = fetch;
-  }
 
-  // We need to create the lenses dynamically to be able to pass Svelte's fetch.
   const detailLens = createLens(DatasetDetailSchema, {
     sources: [PUBLIC_SPARQL_ENDPOINT],
     ...options,

--- a/apps/browser/src/routes/datasets/[...uri]/+page.ts
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.ts
@@ -2,7 +2,7 @@ import { fetchDatasetDetail } from '$lib/services/dataset-detail';
 import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ params, fetch }) => {
+export const load: PageLoad = async ({ params }) => {
   // params.uri from [...uri] rest parameter contains the full path after /datasets/
   const datasetUri = params.uri;
 
@@ -10,5 +10,5 @@ export const load: PageLoad = async ({ params, fetch }) => {
     error(404, 'Dataset URI is required');
   }
 
-  return fetchDatasetDetail(datasetUri, fetch);
+  return fetchDatasetDetail(datasetUri);
 };


### PR DESCRIPTION
## Summary

Removes SvelteKit's custom fetch from the dataset detail page to fix a 10x performance regression.

## Problem

SvelteKit's SSR fetch buffers entire response bodies for hydration serialization, which breaks the streaming RDF parser used by LDkit/Comunica. This caused page load times of ~22 seconds instead of ~2.3 seconds on large SPARQL responses.

## Solution

Use Node's native fetch instead, which streams properly. SSR still works correctly - content is rendered server-side with native fetch.

## Performance Results

| Configuration | Server Time |
|--------------|-------------|
| With SvelteKit fetch | ~22s |
| With native fetch | ~2.3s |

**10x faster** with native fetch.