### PR TITLE
fix(browser): prevent tooltip from triggering facet selection

### DIFF
--- a/apps/browser/src/lib/components/FacetItem.svelte
+++ b/apps/browser/src/lib/components/FacetItem.svelte
@@ -51,11 +51,16 @@
   >
     {displayValue}
     {#if tooltip}
-      <span id={tooltipId}>
+      <button
+        type="button"
+        id={tooltipId}
+        class="inline-flex items-center"
+        onclick={(e) => e.stopPropagation()}
+      >
         <InfoCircleOutline
           class="h-4 w-4 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
         />
-      </span>
+      </button>
       <Tooltip triggeredBy="#{tooltipId}">{tooltip}</Tooltip>
     {/if}
   </span>


### PR DESCRIPTION
## Summary
* Change tooltip trigger from `<span>` to `<button>` with `stopPropagation()`
* Allows mobile users to tap the info icon to view tooltip without accidentally selecting/deselecting the facet

## Test plan
- [ ] On desktop: hover over info icon on Status facet values, verify tooltip appears without selecting the checkbox
- [ ] On mobile: tap info icon, verify tooltip appears without toggling the checkbox