### PR TITLE
feat: add middle truncation for class/property names on mobile

### DIFF
--- a/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
+++ b/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
@@ -2,7 +2,7 @@
   import { SvelteMap } from 'svelte/reactivity';
   import * as m from '$lib/paraglide/messages';
   import { getLocale } from '$lib/paraglide/runtime';
-  import { shortenUri } from '$lib/utils/prefix.js';
+  import { shortenUri, truncateMiddle } from '$lib/utils/prefix.js';
   import { Tooltip } from 'flowbite-svelte';
   import QuestionCircleSolid from 'flowbite-svelte-icons/QuestionCircleSolid.svelte';
   import CloseOutline from 'flowbite-svelte-icons/CloseOutline.svelte';
@@ -291,14 +291,18 @@
               ? (e) => handleClassKeydown(e, row)
               : undefined}
           >
-            <div class="flex-1 min-w-0 truncate">
+            <div class="flex-1 min-w-0">
               <span
                 class="text-blue-600 dark:text-blue-400 {hasAnyPropertyPartitions
                   ? 'group-hover:underline'
                   : ''}"
                 title={row.className}
               >
-                {shortenUri(row.className)}
+                <span class="hidden sm:inline">{shortenUri(row.className)}</span
+                >
+                <span class="sm:hidden"
+                  >{truncateMiddle(shortenUri(row.className), 18)}</span
+                >
               </span>
             </div>
             <div
@@ -419,12 +423,15 @@
                   ? 'text-blue-500'
                   : 'text-gray-300 group-hover:text-blue-400 dark:text-gray-600'}"
               />
-              <div class="flex-1 min-w-0 truncate">
+              <div class="flex-1 min-w-0">
                 <span
                   class="text-blue-600 dark:text-blue-400 group-hover:underline"
                   title={prop.property}
                 >
-                  {prop.shortProperty}
+                  <span class="hidden sm:inline">{prop.shortProperty}</span>
+                  <span class="sm:hidden"
+                    >{truncateMiddle(prop.shortProperty, 18)}</span
+                  >
                 </span>
               </div>
               <div

--- a/apps/browser/src/lib/utils/prefix.ts
+++ b/apps/browser/src/lib/utils/prefix.ts
@@ -6,12 +6,26 @@ import { shrink } from '@zazuko/prefixes';
  */
 export function shortenUri(uri: string): string {
   const shortened = shrink(uri, {
+    edm: 'http://www.europeana.eu/schemas/edm/',
     omekas: 'http://omeka.org/s/vocabs/o#',
     pico: 'https://personsincontext.org/model#',
     pnv: 'https://w3id.org/pnv#',
     sdo: 'https://schema.org/',
   });
   return shortened || uri;
+}
+
+/**
+ * Truncates a string in the middle if it exceeds maxLength.
+ * Shows beginning and end with ellipsis in the middle.
+ * @example truncateMiddle('sdo:hasExactMatch', 12) => 'sdo:h…Match'
+ */
+export function truncateMiddle(str: string, maxLength: number): string {
+  if (str.length <= maxLength) return str;
+  const charsToShow = maxLength - 1; // -1 for ellipsis
+  const frontChars = Math.ceil(charsToShow / 2);
+  const backChars = Math.floor(charsToShow / 2);
+  return str.slice(0, frontChars) + '…' + str.slice(-backChars);
 }
 
 const IANA_MEDIA_TYPES_PREFIX = 'https://www.iana.org/assignments/media-types/';


### PR DESCRIPTION
## Summary

Improves readability of class and property names on mobile by showing both the beginning and end of truncated names.

## Changes

* Add `truncateMiddle()` utility function that truncates in the middle with ellipsis
* On mobile: names longer than 18 chars show as `sdo:hasE…Match` instead of `sdo:hasEx...`
* On desktop (sm+): full shortened URI is displayed
* Full URI remains available on hover via title attribute
* Add `edm` prefix for Europeana namespace