### PR TITLE
fix: prevent class/properties panels from overflowing container

### DIFF
--- a/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
+++ b/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
@@ -223,7 +223,7 @@
 <div class="mt-6">
   <div class="flex flex-col lg:flex-row gap-4">
     <!-- Classes Panel (Left) -->
-    <div class="w-full lg:flex-1">
+    <div class="w-full lg:flex-1 min-w-0">
       <h3
         class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
       >
@@ -354,7 +354,7 @@
 
     <!-- Properties Panel (Right) -->
     {#if aggregatedProperties.length > 0}
-      <div class="w-full lg:flex-1">
+      <div class="w-full lg:flex-1 min-w-0">
         <h3
           class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
         >


### PR DESCRIPTION
## Summary

* Fixes the Classes and Properties widget panels not properly sharing container width
* The percentage column in the Properties panel was being cut off

## Changes

* Added `min-w-0` to both flex panel containers to allow proper shrinking below content size (a common flexbox gotcha)