### PR TITLE
fix(browser): disable Matomo analytics in development mode

### DIFF
--- a/apps/browser/src/app.html
+++ b/apps/browser/src/app.html
@@ -4,23 +4,6 @@
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1" name="viewport" />
     %sveltekit.head%
-    <!-- Matomo -->
-    <script>
-      var _paq = (window._paq = window._paq || []);
-      _paq.push(['enableLinkTracking']);
-      (function () {
-        var u = '//matomo.netwerkdigitaalerfgoed.nl/';
-        _paq.push(['setTrackerUrl', u + 'matomo.php']);
-        _paq.push(['setSiteId', '1']);
-        var d = document,
-          g = d.createElement('script'),
-          s = d.getElementsByTagName('script')[0];
-        g.async = true;
-        g.src = u + 'matomo.js';
-        s.parentNode.insertBefore(g, s);
-      })();
-    </script>
-    <!-- End Matomo -->
   </head>
   <body data-sveltekit-preload-data="hover">
     <div style="display: contents">%sveltekit.body%</div>

--- a/apps/browser/src/routes/+layout.svelte
+++ b/apps/browser/src/routes/+layout.svelte
@@ -4,14 +4,31 @@
   import * as m from '$lib/paraglide/messages';
   import { getLocale, localizeHref } from '$lib/paraglide/runtime';
   import { page } from '$app/state';
-  import { browser } from '$app/environment';
+  import { browser, dev } from '$app/environment';
 
   let { children, data } = $props();
   const locale = $derived(data?.locale || getLocale());
 
+  // Initialize Matomo (production only)
+  let matomoInitialized = false;
+  $effect(() => {
+    if (browser && !dev && !matomoInitialized) {
+      matomoInitialized = true;
+      window._paq = window._paq || [];
+      window._paq.push(['enableLinkTracking']);
+      const u = '//matomo.netwerkdigitaalerfgoed.nl/';
+      window._paq.push(['setTrackerUrl', u + 'matomo.php']);
+      window._paq.push(['setSiteId', '1']);
+      const g = document.createElement('script');
+      g.async = true;
+      g.src = u + 'matomo.js';
+      document.head.appendChild(g);
+    }
+  });
+
   // Track page views in Matomo on navigation
   $effect(() => {
-    if (browser && window._paq) {
+    if (browser && !dev && window._paq) {
       window._paq.push(['setCustomUrl', page.url.href]);
       window._paq.push(['trackPageView']);
     }


### PR DESCRIPTION
## Summary

Disables Matomo analytics tracking during local development to prevent polluting analytics data with development traffic.

## Changes

* Move Matomo initialization from `app.html` to `+layout.svelte`
* Use SvelteKit's `dev` environment variable to conditionally load analytics
* Analytics only loads in production builds