### PR TITLE
feat(browser): add Value Types panel to dataset detail page

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -193,5 +193,12 @@
   "facets_status_invalid_tooltip": "Datasets whose description no longer conforms to the requirements.",
   "facets_status_gone": "Gone datasets",
   "facets_status_gone_tooltip": "Datasets whose registration URL is no longer accessible.",
-  "facets_status_explanation": "By default only current datasets are shown. Here you can choose to view datasets that are no longer valid or no longer exist."
+  "facets_status_explanation": "By default only current datasets are shown. Here you can choose to view datasets that are no longer valid or no longer exist.",
+  "detail_value_types": "Value Types",
+  "detail_value_type": "Value Type",
+  "detail_value_types_description": "The distribution of data types for literal values and classes for URI objects in this dataset.",
+  "detail_value_types_for_class": "Value types for {className}",
+  "detail_value_types_for_property": "Value types for {propertyName}",
+  "detail_datatype": "Datatype (literal)",
+  "detail_object_class": "Object class (URI)"
 }

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -193,5 +193,12 @@
   "facets_status_invalid_tooltip": "Datasets waarvan de beschrijving niet meer voldoet aan de eisen.",
   "facets_status_gone": "Verdwenen datasets",
   "facets_status_gone_tooltip": "Datasets waarvan de registratie-URL niet meer bereikbaar is.",
-  "facets_status_explanation": "Standaard worden alleen actuele datasets getoond. Hier kun je kiezen datasets te bekijken die niet meer geldig of verdwenen zijn."
+  "facets_status_explanation": "Standaard worden alleen actuele datasets getoond. Hier kun je kiezen datasets te bekijken die niet meer geldig of verdwenen zijn.",
+  "detail_value_types": "Waardetypes",
+  "detail_value_type": "Waardetype",
+  "detail_value_types_description": "De verdeling van datatypes voor literale waarden en klassen voor URI-objecten in deze dataset.",
+  "detail_value_types_for_class": "Waardetypes voor {className}",
+  "detail_value_types_for_property": "Waardetypes voor {propertyName}",
+  "detail_datatype": "Datatype (literal)",
+  "detail_object_class": "Objectklasse (URI)"
 }

--- a/apps/browser/src/lib/rdf.ts
+++ b/apps/browser/src/lib/rdf.ts
@@ -40,3 +40,9 @@ export const owlNs = createNamespace({
   prefix: 'owl:',
   terms: ['sameAs'],
 } as const);
+
+export const voidExtNs = createNamespace({
+  iri: 'http://ldf.fi/void-ext#',
+  prefix: 'void-ext:',
+  terms: ['datatypePartition', 'datatype', 'objectClassPartition'],
+} as const);

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -2,7 +2,7 @@ import { dcat } from '@lde/dataset-registry-client';
 import { dcterms, foaf, ldkit, schema, xsd } from 'ldkit/namespaces';
 import { createLens, type Options, type SchemaInterface } from 'ldkit';
 import { error } from '@sveltejs/kit';
-import { ndeNs, owlNs, voidNs } from '../rdf.js';
+import { ndeNs, owlNs, voidExtNs, voidNs } from '../rdf.js';
 import { BaseDatasetSchema, BaseDistributionSchema } from './datasets.js';
 import { shortenUri } from '$lib/utils/prefix';
 import { REGISTRATION_STATUS_BASE_URI } from '@dataset-register/core/constants';
@@ -263,6 +263,34 @@ const DatasetSummarySchema = {
             '@id': voidNs.distinctObjects,
             '@type': xsd.integer,
             '@optional': true,
+          },
+          datatypePartition: {
+            '@id': voidExtNs.datatypePartition,
+            '@optional': true,
+            '@array': true,
+            '@schema': {
+              datatype: {
+                '@id': voidExtNs.datatype,
+              },
+              triples: {
+                '@id': voidNs.triples,
+                '@type': xsd.integer,
+              },
+            },
+          },
+          objectClassPartition: {
+            '@id': voidExtNs.objectClassPartition,
+            '@optional': true,
+            '@array': true,
+            '@schema': {
+              class: {
+                '@id': voidNs.class,
+              },
+              triples: {
+                '@id': voidNs.triples,
+                '@type': xsd.integer,
+              },
+            },
           },
         },
       },

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -125,6 +125,16 @@
           shortProperty: shortenUri(pp.property || 'Unknown'),
           entities: pp.entities || 0,
           distinctObjects: pp.distinctObjects || 0,
+          datatypePartition: pp.datatypePartition?.map((dt) => ({
+            datatype: dt.datatype || 'Unknown',
+            shortDatatype: shortenUri(dt.datatype || 'Unknown'),
+            triples: dt.triples || 0,
+          })),
+          objectClassPartition: pp.objectClassPartition?.map((oc) => ({
+            class: oc.class || 'Unknown',
+            shortClass: shortenUri(oc.class || 'Unknown'),
+            triples: oc.triples || 0,
+          })),
         }));
 
         return { className, shortName, entities, percent, propertyPartition };


### PR DESCRIPTION
## Summary

Adds a third "Value Types" panel to the dataset detail page's ClassPropertiesWidget, displaying:
- **Datatypes** (for literals like `xsd:string`, `xsd:dateTime`) - shown with quote icon in blue
- **Object Classes** (for URI references like `schema:Person`, `schema:Place`) - shown with share-nodes icon in cyan

The panel leverages new data from the Dataset Knowledge Graph using `void-ext:datatypePartition` and `void-ext:objectClassPartition`.

## Features

- **Context-aware filtering**: Panel updates based on selected class or property
- **Three-column layout**: Desktop shows Classes → Properties → Value Types side-by-side
- **Mobile responsive**: Panels stack vertically on smaller screens
- **Bidirectional navigation**: Properties panel has chevrons pointing to both Classes and Value Types
- **Middle truncation**: Long URIs are truncated in the middle (keeping prefix and end visible)

## Changes

- `apps/browser/src/lib/rdf.ts` - Added void-ext namespace for new vocabulary
- `apps/browser/src/lib/services/dataset-detail.ts` - Extended DatasetSummarySchema with new partitions
- `apps/browser/src/routes/datasets/[...uri]/+page.svelte` - Pass partition data to widget
- `apps/browser/src/lib/components/ClassPropertiesWidget.svelte` - Added Value Types panel
- `apps/browser/messages/en.json` & `nl.json` - Added translations

## Test plan

- [ ] Verify Value Types panel appears on dataset detail pages with Knowledge Graph data
- [ ] Test class selection filters the Value Types panel correctly
- [ ] Test property selection filters the Value Types panel correctly
- [ ] Verify mobile layout stacks panels properly
- [ ] Confirm long URIs are middle-truncated correctly