### PR TITLE
fix(browser): calculate property percentages relative to selected class

### DIFF
--- a/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
+++ b/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
@@ -197,6 +197,12 @@
   );
 
   function getPropertyPercent(entities: number): number {
+    // When a class is selected, calculate percentage relative to class entity count
+    if (selectionMode === 'class-selected' && selectedClass) {
+      if (selectedClass.entities === 0) return 0;
+      return (entities / selectedClass.entities) * 100;
+    }
+    // Otherwise, use the sum of displayed properties (relative comparison)
     if (totalPropertyEntities === 0) return 0;
     return (entities / totalPropertyEntities) * 100;
   }


### PR DESCRIPTION
## Summary

* When a class is selected in ClassPropertiesWidget, property percentages are now calculated relative to the selected class's entity count
* Previously, percentages were calculated relative to the sum of all displayed property entities, which was misleading

## Example

When `omekas:Item` is selected (500 entities) and `omekas:created_at` appears on all 500 items:
- **Before**: 62.5% (500 / sum of all property entities)
- **After**: 100% (500 / 500 class entities)

This makes percentages answer the question "what percentage of entities of this class have this property?"