### PR TITLE
feat(browser): make Value Types panel interactive with bidirectional filtering

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -200,5 +200,7 @@
   "detail_value_types_for_class": "Value types for {className}",
   "detail_value_types_for_property": "Value types for {propertyName}",
   "detail_datatype": "Datatype (literal)",
-  "detail_object_class": "Object class (URI)"
+  "detail_object_class": "Object class (URI)",
+  "detail_classes_for_value_type": "Classes for {valueTypeName}",
+  "detail_properties_for_value_type": "Properties for {valueTypeName}"
 }

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -200,5 +200,7 @@
   "detail_value_types_for_class": "Waardetypes voor {className}",
   "detail_value_types_for_property": "Waardetypes voor {propertyName}",
   "detail_datatype": "Datatype (literal)",
-  "detail_object_class": "Objectklasse (URI)"
+  "detail_object_class": "Objectklasse (URI)",
+  "detail_classes_for_value_type": "Typen voor {valueTypeName}",
+  "detail_properties_for_value_type": "Eigenschappen voor {valueTypeName}"
 }


### PR DESCRIPTION
## Summary

Makes the Value Types panel on the dataset detail page interactive. Clicking a value type now filters both the Classes and Properties panels to show only those that use the selected value type.

## Changes

* Add `value-type-selected` mode to enable clicking value types
* Filter Classes panel to show only classes with selected value type
* Filter Properties panel to show only properties with selected value type
* Add left chevron to value type items for visual interactivity cue
* Add border highlighting to Classes and Properties panels when filtering
* Add translation keys for filtered state labels in EN and NL
* Support keyboard navigation (Enter/Space to select, Escape to clear)

## Test plan

- [ ] Click a value type (e.g., `xsd:string`) and verify Classes and Properties panels filter correctly
- [ ] Verify both panels get blue borders when a value type is selected
- [ ] Click the same value type again to deselect and verify all panels return to full view
- [ ] Click the X button in the panel headers to clear the filter
- [ ] Test keyboard navigation: Tab to value type, press Enter to select, press Escape to clear
- [ ] Verify translations appear correctly in both English and Dutch