### PR TITLE
fix(browser): split classPartition into separate query to avoid timeout

### DIFF
--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -1100,7 +1100,10 @@
 
         <!-- Classes Section with Property Partitions -->
         {#if classPartitionTable}
-          <ClassPropertiesWidget {classPartitionTable} />
+          <ClassPropertiesWidget
+            {classPartitionTable}
+            globalPropertyPartitions={summary.propertyPartition}
+          />
         {/if}
 
         <!-- Vocabularies Section -->


### PR DESCRIPTION
## Summary

Fixes dataset detail page timeout caused by Cartesian product explosion in SPARQL query.

## Root Cause

The combined summary query with nested OPTIONALs caused exponential row growth:
- 253 global propertyPartitions × classPartitions × nested propertyPartitions × datatypePartitions × objectClassPartitions = millions of rows

While the SPARQL query itself returned in 0.2s, LDkit's streaming parser hung processing the massive CONSTRUCT result.

## Changes

* Move `classPartition` (4 levels of nesting) to separate LDkit schema/query
* Keep global `propertyPartition` in main summary query (flat structure, no explosion)
* Add dev-mode timing logs for all 4 parallel queries to aid debugging
* Merge `classPartition` results back into summary before returning
* Use global `propertyPartition` for accurate entity counts in properties panel (fixes double-counting from multi-typed entities)