### PR TITLE
fix(browser): handle hash fragments in dataset URIs

### DIFF
--- a/apps/browser/src/lib/components/DatasetCard.svelte
+++ b/apps/browser/src/lib/components/DatasetCard.svelte
@@ -17,7 +17,9 @@
     }),
   );
 
-  const detailUrl = $derived(localizeHref(`/datasets/${dataset.$id}`));
+  const detailUrl = $derived(
+    localizeHref(`/datasets/${dataset.$id.replace(/#/g, '%23')}`),
+  );
 
   const hasSparqlDistribution = $derived(
     dataset.distribution.some((distribution) =>

--- a/apps/browser/src/routes/datasets/[...uri]/+page.ts
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.ts
@@ -4,7 +4,8 @@ import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ params }) => {
   // params.uri from [...uri] rest parameter contains the full path after /datasets/
-  const datasetUri = params.uri;
+  // Decode URI components (e.g., %23 -> #) since SvelteKit doesn't auto-decode rest params
+  const datasetUri = decodeURIComponent(params.uri);
 
   if (!datasetUri) {
     error(404, 'Dataset URI is required');

--- a/apps/browser/src/routes/datasets/rss/+server.ts
+++ b/apps/browser/src/routes/datasets/rss/+server.ts
@@ -74,7 +74,7 @@ export async function GET({ url }: RequestEvent) {
       : undefined;
 
     // Link to the dataset detail page
-    const datasetLink = `${url.origin}${localizeHref('/datasets/' + dataset.$id)}`;
+    const datasetLink = `${url.origin}${localizeHref('/datasets/' + dataset.$id.replace(/#/g, '%23'))}`;
 
     feed.addItem({
       title,


### PR DESCRIPTION
## Summary

Fixes 404 errors when viewing datasets with hash fragments in their URIs (e.g., `https://example.org/data#MyDataset`).

* Encode `#` as `%23` in dataset detail URLs to prevent browsers from stripping the fragment
* Decode URI parameter in page loader since SvelteKit doesn't auto-decode rest params
* Apply same fix to RSS feed dataset links

## Test plan

- [x] Navigate to a dataset with a hash URI and verify it loads correctly
- [x] Lint passes