### PR TITLE
fix(browser): encode percent signs in dataset URIs

### DIFF
--- a/apps/browser/src/lib/components/DatasetCard.svelte
+++ b/apps/browser/src/lib/components/DatasetCard.svelte
@@ -4,6 +4,7 @@
   import { type DatasetCard } from '$lib/services/datasets';
   import { getLocalizedValue, localizeHref } from '$lib/utils/i18n';
   import { RDF_MEDIA_TYPES } from '$lib/constants.js';
+  import { encodeDatasetUri } from '$lib/url';
   import { formatNumber } from '$lib/services/facets';
 
   let { dataset }: { dataset: DatasetCard } = $props();
@@ -18,7 +19,7 @@
   );
 
   const detailUrl = $derived(
-    localizeHref(`/datasets/${dataset.$id.replace(/#/g, '%23')}`),
+    localizeHref(`/datasets/${encodeDatasetUri(dataset.$id)}`),
   );
 
   const hasSparqlDistribution = $derived(

--- a/apps/browser/src/lib/url.ts
+++ b/apps/browser/src/lib/url.ts
@@ -18,3 +18,15 @@ export function decodeDiscreteParam(
 ) {
   return urlSearchParams.get(name)?.split(',').filter(Boolean) || [];
 }
+
+/**
+ * Encode a dataset URI for use in URLs.
+ * Only encodes characters that would cause issues:
+ * - % (preserves existing percent-encoded sequences)
+ * - # (prevents browser fragment interpretation)
+ *
+ * Uses minimal encoding instead of encodeURIComponent to keep URLs human-readable.
+ */
+export function encodeDatasetUri(uri: string): string {
+  return uri.replace(/%/g, '%25').replace(/#/g, '%23');
+}

--- a/apps/browser/src/routes/datasets/rss/+server.ts
+++ b/apps/browser/src/routes/datasets/rss/+server.ts
@@ -3,7 +3,11 @@ import type { RequestEvent } from '@sveltejs/kit';
 import { fetchDatasets, type SearchRequest } from '$lib/services/datasets';
 import { extractLocaleFromUrl, setLocale } from '$lib/paraglide/runtime';
 import * as m from '$lib/paraglide/messages';
-import { decodeDiscreteParam, decodeRangeParam } from '$lib/url';
+import {
+  decodeDiscreteParam,
+  decodeRangeParam,
+  encodeDatasetUri,
+} from '$lib/url';
 import { getLocalizedValue, localizeHref } from '$lib/utils/i18n';
 
 const cacheTtl = 3600;
@@ -74,7 +78,7 @@ export async function GET({ url }: RequestEvent) {
       : undefined;
 
     // Link to the dataset detail page
-    const datasetLink = `${url.origin}${localizeHref('/datasets/' + dataset.$id.replace(/#/g, '%23'))}`;
+    const datasetLink = `${url.origin}${localizeHref('/datasets/' + encodeDatasetUri(dataset.$id))}`;
 
     feed.addItem({
       title,


### PR DESCRIPTION
## Summary

Fixes 404 errors on dataset detail pages for datasets whose URIs contain percent-encoded characters (e.g., Ihlia datasets with `%2b` in the URI).

**Root cause**: Dataset URIs stored in the database may contain literal percent-encoded sequences like `%2b`. When placed in a URL without re-encoding the `%`, `decodeURIComponent()` decodes them, changing the URI and causing a mismatch.

**Solution**: Add `encodeDatasetUri()` function that encodes only `%` and `#` characters, keeping URLs human-readable while preserving the original URI.

Fixes #1553