### PR TITLE
docs: replace schema:url with mainEntityOfPage in example

### DIFF
--- a/requirements/index.bs.liquid
+++ b/requirements/index.bs.liquid
@@ -282,7 +282,7 @@ If more information is available, publishers *SHOULD* add it.
             "@value": "Alba amicorum van de Koninklijke Bibliotheek, een dataset gedefinieerd voor het Europeana Rise of Literacy project.",
             "@language": "nl"
           },
-          "url": "https://www.kb.nl/bronnen-zoekwijzers/kb-collecties/moderne-handschriften-vanaf-ca-1550/alba-amicorum",
+          "mainEntityOfPage": "https://www.kb.nl/bronnen-zoekwijzers/kb-collecties/moderne-handschriften-vanaf-ca-1550/alba-amicorum",
           "keywords": [
             "alba amicorum"
           ]


### PR DESCRIPTION
## Summary

Replace `schema:url` with `schema:mainEntityOfPage` in Example 5 to align the documentation with the SHACL shape and dataset attributes.

Fixes #1573