### PR TITLE
feat(browser): add class→property→value-type drill-down interaction

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -198,9 +198,11 @@
   "detail_value_type": "Value Type",
   "detail_value_types_description": "The distribution of data types for literal values and classes for URI objects in this dataset.",
   "detail_value_types_for_class": "Value types for {className}",
+  "detail_value_types_for_class_property": "Value types for {className} → {propertyName}",
   "detail_value_types_for_property": "Value types for {propertyName}",
   "detail_datatype": "Datatype (literal)",
   "detail_object_class": "Object class (URI)",
+  "detail_language": "Language",
   "detail_classes_for_value_type": "Classes for {valueTypeName}",
   "detail_properties_for_value_type": "Properties for {valueTypeName}"
 }

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -198,9 +198,11 @@
   "detail_value_type": "Waardetype",
   "detail_value_types_description": "De verdeling van datatypes voor literale waarden en klassen voor URI-objecten in deze dataset.",
   "detail_value_types_for_class": "Waardetypes voor {className}",
+  "detail_value_types_for_class_property": "Waardetypes voor {className} → {propertyName}",
   "detail_value_types_for_property": "Waardetypes voor {propertyName}",
   "detail_datatype": "Datatype (literal)",
   "detail_object_class": "Objectklasse (URI)",
+  "detail_language": "Taal",
   "detail_classes_for_value_type": "Typen voor {valueTypeName}",
   "detail_properties_for_value_type": "Eigenschappen voor {valueTypeName}"
 }

--- a/apps/browser/src/lib/rdf.ts
+++ b/apps/browser/src/lib/rdf.ts
@@ -44,5 +44,11 @@ export const owlNs = createNamespace({
 export const voidExtNs = createNamespace({
   iri: 'http://ldf.fi/void-ext#',
   prefix: 'void-ext:',
-  terms: ['datatypePartition', 'datatype', 'objectClassPartition'],
+  terms: [
+    'datatypePartition',
+    'datatype',
+    'objectClassPartition',
+    'languagePartition',
+    'language',
+  ],
 } as const);

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -333,6 +333,20 @@ const ClassPartitionSchema = {
               },
             },
           },
+          languagePartition: {
+            '@id': voidExtNs.languagePartition,
+            '@optional': true,
+            '@array': true,
+            '@schema': {
+              language: {
+                '@id': voidExtNs.language,
+              },
+              triples: {
+                '@id': voidNs.triples,
+                '@type': xsd.integer,
+              },
+            },
+          },
         },
       },
     },

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -98,6 +98,18 @@
     dataset.subjectOf?.additionalType,
   );
 
+  // Helper function to convert language codes to display labels
+  function getLanguageLabel(langCode: string): string {
+    const code = langCode.toLowerCase();
+    if (code === 'nl' || code === 'nl-nl') return m.lang_nl();
+    if (code === 'en' || code.startsWith('en-')) return m.lang_en();
+    if (code === 'de') return m.lang_de();
+    if (code === 'fr') return m.lang_fr();
+    if (code === 'es') return m.lang_es();
+    if (code === 'it') return m.lang_it();
+    return langCode.toUpperCase();
+  }
+
   // Table data for all class partitions with nested property partitions
   const classPartitionTable = $derived.by(() => {
     if (!summary?.classPartition?.length) return undefined;
@@ -133,6 +145,11 @@
             class: oc.class || 'Unknown',
             shortClass: shortenUri(oc.class || 'Unknown'),
             triples: oc.triples || 0,
+          })),
+          languagePartition: pp.languagePartition?.map((lp) => ({
+            language: lp.language || '',
+            displayLabel: getLanguageLabel(lp.language || ''),
+            triples: lp.triples || 0,
           })),
         }));
 


### PR DESCRIPTION
## Summary

- Add three-level drill-down in the Linked Data Summary widget: class → property → value type selection
- Implement click-through pattern for progressive scope expansion:
  - First click narrows scope (e.g., clicking property while class is selected shows value types for that specific combination)
  - Second click expands scope (shows all classes/properties for the selected item)
  - Third click deselects
- Add language breakdown under `rdf:langString` with expandable list showing per-language statistics
- Add `scrollIntoViewWhenSelected` action for better UX when selecting items
- Add `languagePartition` support in `ClassPartitionSchema`

## Test plan

- [ ] Navigate to a dataset detail page (e.g., http://localhost:5173/datasets/https://n2t.net/ark:/60537/bD64Hu)
- [ ] Click a class → verify property panel shows "Properties for {className}"
- [ ] Click a property → verify value types panel shows "Value types for {className} → {propertyName}"
- [ ] Click a value type (e.g., langString) → verify class and property remain highlighted, languages expand
- [ ] Click same value type again → verify it expands to show all classes/properties
- [ ] Click same value type third time → verify all selections are cleared
- [ ] Verify scrolling works when selecting items in long lists