### PR TITLE
fix(browser): add void:Dataset type constraint to SPARQL federated queries

### DIFF
--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -242,7 +242,8 @@ export function datasetCardsQuery(
     # Fetch dataset size from Dataset Knowledge Graph via SPARQL Federation
     OPTIONAL {
       SERVICE <https://triplestore.netwerkdigitaalerfgoed.nl/repositories/dataset-knowledge-graph> {
-        ?dataset void:triples ?size .
+        ?dataset a void:Dataset ;
+          void:triples ?size .
       }
     }
   }
@@ -356,7 +357,8 @@ function filterClauses(searchFilters: SearchRequest, skipDefaults = false) {
     // This ensures only datasets with known sizes are returned in filtered results.
     filterClausesArray.push(`
       SERVICE <https://triplestore.netwerkdigitaalerfgoed.nl/repositories/dataset-knowledge-graph> {
-        ?dataset void:triples ?datasetSize .
+        ?dataset a void:Dataset ;
+          void:triples ?datasetSize .
       }
     `);
 

--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -436,7 +436,8 @@ export async function fetchSizeRange(): Promise<FacetValueRange> {
 
     SELECT (MIN(?size) as ?minSize) (MAX(?size) as ?maxSize)
     WHERE {
-      ?dataset void:triples ?size .
+      ?dataset a void:Dataset ;
+        void:triples ?size .
       FILTER(?size > 0)
     }
   `;
@@ -492,7 +493,8 @@ export async function fetchSizeHistogram(
       ${filterDatasets(filtersWithoutSize)}
 
       SERVICE <${PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT}> {
-        ?dataset void:triples ?size .
+        ?dataset a void:Dataset ;
+          void:triples ?size .
       }
 
       # Bin sizes into logarithmic buckets using nested IF conditions


### PR DESCRIPTION
## Summary

* Add explicit `a void:Dataset` type constraint to federated SERVICE queries against the Dataset Knowledge Graph.
* Ensures correct matching when querying `void:triples` property across dataset cards, filter clauses, size range, and histogram queries.
* Prevent nested `void:triples` from being selected, which causes QLever to complain about too many blank nodes.

## Test plan

- [ ] Verify dataset cards display correct sizes
- [ ] Verify size filter facet works correctly
- [ ] Verify size histogram renders properly