### PR TITLE
fix(core): add User-Agent header to rdf-dereference requests

### DIFF
--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -48,7 +48,9 @@ export async function* fetch(url: URL): AsyncGenerator<DatasetExt> {
  */
 export async function dereference(url: URL): Promise<DatasetExt> {
   try {
-    const { data } = await rdfDereferencer.dereference(url.toString());
+    const { data } = await rdfDereferencer.dereference(url.toString(), {
+      headers: { 'User-Agent': 'dataset-register (netwerk-digitaal-erfgoed)' },
+    });
     const stream = pipeline(
       data,
       new StandardizeSchemaOrgPrefixToHttps(),


### PR DESCRIPTION
## Summary

* Add custom User-Agent header to rdf-dereference requests.
* Some servers block requests without a User-Agent or with Comunica's default `Comunica/actor-http-fetch` header.

## Test plan

- [x] Verified fetching from `https://www.goudatijdmachine.nl/.well-known/datacatalog` now works (was returning 403)