### PR TITLE
fix(browser): fix dark mode background for language breakdown items

### DIFF
--- a/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
+++ b/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
@@ -1326,7 +1326,7 @@
                   selectedValueType?.uri === lang.language &&
                   selectedValueType?.type === 'language'}
                 <div
-                  class="group flex items-center gap-1 sm:gap-2 px-1 sm:px-4 py-2 pl-6 sm:pl-10 text-sm transition-all cursor-pointer hover:bg-amber-50 dark:hover:bg-amber-900/20 bg-gray-50 dark:bg-gray-750 {isLangSelected
+                  class="group flex items-center gap-1 sm:gap-2 px-1 sm:px-4 py-2 pl-6 sm:pl-10 text-sm transition-all cursor-pointer hover:bg-amber-50 dark:hover:bg-amber-900/20 bg-gray-50 dark:bg-gray-800 {isLangSelected
                     ? 'bg-amber-100 dark:bg-amber-900/30'
                     : ''}"
                   role="option"


### PR DESCRIPTION
## Summary

* Fix dark mode styling for language breakdown items under `rdf:langString` in the value types column.
* Replace invalid Tailwind CSS class `dark:bg-gray-750` with `dark:bg-gray-800` (Tailwind only provides gray-700 and gray-800, not gray-750).

## Test plan

- [ ] Open the browser app in dark mode
- [ ] Navigate to a dataset with `rdf:langString` values
- [ ] Expand the language breakdown
- [ ] Verify language items have proper background contrast