### PR TITLE
fix(core): convert URI keywords to literals in CONSTRUCT query

### DIFF
--- a/packages/core/src/literal.ts
+++ b/packages/core/src/literal.ts
@@ -83,3 +83,14 @@ export const normalizeByteSize = (variable: string) =>
           )
           AS ?${variable}
         )`;
+
+/**
+ * Convert URI keywords to string literals while preserving language-tagged literals.
+ *
+ * Some datasets use URIs as keywords (e.g., SKOS Concepts) while others use
+ * language-tagged literals. This normalizes URIs to string literals so they
+ * can be processed uniformly, while preserving language tags on literals.
+ */
+export const convertUriToLiteral = (variable: string) =>
+  `?${variable}Raw ;
+        BIND(IF(isIRI(?${variable}Raw), STR(?${variable}Raw), ?${variable}Raw) AS ?${variable})`;

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -2,6 +2,7 @@ import factory from 'rdf-ext';
 import {
   convertToIri,
   convertToXsdDate,
+  convertUriToLiteral,
   normalizeByteSize,
   normalizeLicense,
   normalizeMediaType,
@@ -185,7 +186,7 @@ export const constructQuery = `
         OPTIONAL { ?${dataset} dct:modified ${convertToXsdDate(dateModified)} }
         OPTIONAL { ?${dataset} dct:language ?${language} }
         OPTIONAL { ?${dataset} dct:source ?${source} }
-        OPTIONAL { ?${dataset} dcat:keyword ?${keyword} }
+        OPTIONAL { ?${dataset} dcat:keyword ${convertUriToLiteral(keyword)} }
         OPTIONAL {
           ?${dataset} dct:spatial ?${spatialCoverage} .
           FILTER(!isBlank(?${spatialCoverage}))
@@ -302,7 +303,7 @@ function schemaOrgQuery(prefix: string): string {
     OPTIONAL { ?${dataset} ${prefix}:inLanguage ?${language} }
     OPTIONAL { ?${dataset} ${prefix}:isBasedOn ?${source} }
     OPTIONAL { ?${dataset} ${prefix}:isBasedOnUrl ?${source} } 
-    OPTIONAL { ?${dataset} ${prefix}:keywords ?${keyword} }
+    OPTIONAL { ?${dataset} ${prefix}:keywords ${convertUriToLiteral(keyword)} }
     OPTIONAL {
       ?${dataset} ${prefix}:spatialCoverage ?${spatialCoverage} .
       FILTER(!isBlank(?${spatialCoverage}))


### PR DESCRIPTION
## Summary

- Add `convertUriToLiteral` function that converts URIs to string literals while preserving language-tagged literals unchanged
- Apply conversion to `dcat:keyword` in both DCAT and Schema.org queries
- Fixes dataset detail page failing when keywords are URIs instead of literals

## Background

Some datasets use URIs as keywords (e.g., SKOS Concepts) while others use language-tagged literals. The browser app's ldkit schema uses `@multilang: true` for keywords, which fails when the value is a URI.

The fix normalizes URI keywords to string literals at query time using `IF(isIRI(?keywordRaw), STR(?keywordRaw), ?keywordRaw)`, which:
- Converts URIs to plain string literals
- Passes through language-tagged literals unchanged (preserving language tags)

## Test plan

- [ ] Re-crawl a dataset that has URI keywords (e.g., `https://n2t.net/ark:/60537/b01v5m1`)
- [ ] Verify the dataset detail page loads without error
- [ ] Verify keywords display correctly as strings