### PR TITLE
fix(browser): improve SEO and TypeScript strictness

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --fail-on-warnings",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "dev": "vite dev",
     "format": "prettier --write .",

--- a/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
+++ b/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
@@ -439,7 +439,7 @@
       selectedProperty
     ) {
       const prop = selectedClass.propertyPartition?.find(
-        (p) => p.property === selectedProperty.property,
+        (p) => p.property === selectedProperty!.property,
       );
       if (!prop) return [];
 

--- a/apps/browser/src/routes/datasets/+page.svelte
+++ b/apps/browser/src/routes/datasets/+page.svelte
@@ -402,7 +402,7 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <svelte:head>
-  <title>Datasets - Netwerk Digitaal Erfgoed</title>
+  <title>Datasets | Netwerk Digitaal Erfgoed</title>
   <meta content={m.header_tagline()} name="description" />
   <link
     rel="alternate"

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -34,7 +34,9 @@
 
   // Data is loaded server-side via +page.ts for SEO
   const { data }: { data: DatasetDetailResult } = $props();
-  const { dataset, summary, linksets } = data;
+  const dataset = $derived(data.dataset);
+  const summary = $derived(data.summary);
+  const linksets = $derived(data.linksets);
 
   function isSparqlDistribution(distribution: DistributionDetail) {
     return distribution.conformsTo?.includes(
@@ -94,12 +96,12 @@
   );
 
   // Extract keywords and genres for current locale
-  const localizedKeywords = getLocalizedArray(dataset.keyword);
-  const localizedGenres = getLocalizedArray(dataset.type);
+  const localizedKeywords = $derived(getLocalizedArray(dataset.keyword));
+  const localizedGenres = $derived(getLocalizedArray(dataset.type));
 
   // Get registration status (gone, invalid, or null)
-  const registrationStatus = getRegistrationStatus(
-    dataset.subjectOf?.additionalType,
+  const registrationStatus = $derived(
+    getRegistrationStatus(dataset.subjectOf?.additionalType),
   );
 
   // Helper function to convert language codes to display labels
@@ -167,6 +169,13 @@
     initFlowbite();
   });
 </script>
+
+<svelte:head>
+  <title>{getLocalizedValue(dataset.title)} | Netwerk Digitaal Erfgoed</title>
+  {#if dataset.description}
+    <meta content={getLocalizedValue(dataset.description)} name="description" />
+  {/if}
+</svelte:head>
 
 <div class="mx-auto max-w-7xl px-1 py-8 sm:px-6 lg:px-8">
   {#if dataset}

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 92.94,
-        functions: 90.09,
+        lines: 92.98,
+        functions: 90.19,
         branches: 79.04,
-        statements: 92.98,
+        statements: 93.03,
       },
     },
   },


### PR DESCRIPTION
## Summary

- Add `<title>` and `<meta name="description">` to the dataset detail page for better SEO
- Use consistent title separator ("|" instead of "-") across pages
- Fix TypeScript non-null assertion in `ClassPropertiesWidget.svelte`
- Add `--fail-on-warnings` flag to `svelte-check` command to catch issues early
- Update test coverage thresholds in the core package