### PR TITLE
feat(browser): add sitemap and SEO improvements

### DIFF
--- a/apps/browser/src/routes/datasets/+page.svelte
+++ b/apps/browser/src/routes/datasets/+page.svelte
@@ -37,6 +37,7 @@
   import { fetchDatasets } from '$lib/services/datasets';
   import type { SelectedFacetValue } from '$lib/services/facets';
   import { decodeDiscreteParam, decodeRangeParam } from '$lib/url';
+  import { localizeHref } from '$lib/utils/i18n';
 
   // Derive searchRequest from URL, which is the single source of truth.
   let searchRequest: SearchRequest = $derived({
@@ -397,6 +398,14 @@
   function createSkeletons(count: number) {
     return Array.from({ length: count }, (_, i) => i);
   }
+
+  // SEO: canonical and hreflang URLs
+  const canonicalUrl = $derived(
+    `${page.url.origin}${localizeHref('/datasets', { locale: 'nl' })}${page.url.search}`,
+  );
+  const enUrl = $derived(
+    `${page.url.origin}${localizeHref('/datasets', { locale: 'en' })}${page.url.search}`,
+  );
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -404,6 +413,10 @@
 <svelte:head>
   <title>Datasets | Netwerk Digitaal Erfgoed</title>
   <meta content={m.header_tagline()} name="description" />
+  <link rel="canonical" href={canonicalUrl} />
+  <link rel="alternate" hreflang="nl" href={canonicalUrl} />
+  <link rel="alternate" hreflang="en" href={enUrl} />
+  <link rel="alternate" hreflang="x-default" href={canonicalUrl} />
   <link
     rel="alternate"
     type="application/rss+xml"

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -5,6 +5,7 @@
   } from '$lib/services/dataset-detail';
   import * as m from '$lib/paraglide/messages';
   import { getLocale } from '$lib/paraglide/runtime';
+  import { page } from '$app/state';
   import { RDF_MEDIA_TYPES } from '$lib/constants.js';
   import { onMount } from 'svelte';
   import { initFlowbite } from 'flowbite';
@@ -37,6 +38,15 @@
   const dataset = $derived(data.dataset);
   const summary = $derived(data.summary);
   const linksets = $derived(data.linksets);
+
+  // SEO: canonical and hreflang URLs
+  const datasetPath = $derived(`/datasets/${dataset.$id}`);
+  const canonicalUrl = $derived(
+    `${page.url.origin}${localizeHref(datasetPath, { locale: 'nl' })}`,
+  );
+  const enUrl = $derived(
+    `${page.url.origin}${localizeHref(datasetPath, { locale: 'en' })}`,
+  );
 
   function isSparqlDistribution(distribution: DistributionDetail) {
     return distribution.conformsTo?.includes(
@@ -175,6 +185,10 @@
   {#if dataset.description}
     <meta content={getLocalizedValue(dataset.description)} name="description" />
   {/if}
+  <link rel="canonical" href={canonicalUrl} />
+  <link rel="alternate" hreflang="nl" href={canonicalUrl} />
+  <link rel="alternate" hreflang="en" href={enUrl} />
+  <link rel="alternate" hreflang="x-default" href={canonicalUrl} />
 </svelte:head>
 
 <div class="mx-auto max-w-7xl px-1 py-8 sm:px-6 lg:px-8">

--- a/apps/browser/src/routes/sitemap.xml/+server.ts
+++ b/apps/browser/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,101 @@
+import type { RequestEvent } from '@sveltejs/kit';
+import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
+import { PUBLIC_SPARQL_ENDPOINT } from '$env/static/public';
+import { encodeDatasetUri } from '$lib/url';
+
+const fetcher = new SparqlEndpointFetcher();
+const CACHE_TTL = 86400; // 24 hours in seconds
+
+interface DatasetInfo {
+  uri: string;
+  dateRead?: string;
+}
+
+/**
+ * Fetch all dataset URIs with their last read dates from the SPARQL endpoint.
+ */
+async function fetchDatasetUris(): Promise<DatasetInfo[]> {
+  const query = `
+    PREFIX dcat: <http://www.w3.org/ns/dcat#>
+    PREFIX schema: <http://schema.org/>
+
+    SELECT DISTINCT ?dataset ?dateRead WHERE {
+      ?dataset a dcat:Dataset ;
+        schema:subjectOf ?registrationUrl .
+      FILTER NOT EXISTS { ?registrationUrl schema:validUntil ?validUntil }
+      OPTIONAL { ?dataset schema:dateRead ?dateRead }
+    }
+  `;
+
+  const datasets: DatasetInfo[] = [];
+
+  try {
+    const bindings = await fetcher.fetchBindings(PUBLIC_SPARQL_ENDPOINT, query);
+
+    for await (const binding of bindings) {
+      const typedBinding = binding as unknown as {
+        dataset: { value: string };
+        dateRead?: { value: string };
+      };
+
+      datasets.push({
+        uri: typedBinding.dataset.value,
+        dateRead: typedBinding.dateRead?.value,
+      });
+    }
+  } catch (error) {
+    console.error('Sitemap query failed:', error);
+  }
+
+  return datasets;
+}
+
+/**
+ * Generate sitemap XML from dataset information.
+ */
+function generateSitemapXml(datasets: DatasetInfo[], origin: string): string {
+  const urls = datasets
+    .map((dataset) => {
+      const loc = `${origin}/datasets/${encodeDatasetUri(dataset.uri)}`;
+      const lastmod = dataset.dateRead
+        ? `\n    <lastmod>${dataset.dateRead.split('T')[0]}</lastmod>`
+        : '';
+
+      return `  <url>
+    <loc>${escapeXml(loc)}</loc>${lastmod}
+  </url>`;
+    })
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>`;
+}
+
+/**
+ * Escape special XML characters.
+ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Sitemap endpoint for search engine discovery.
+ */
+export async function GET({ url }: RequestEvent) {
+  const datasets = await fetchDatasetUris();
+  const xml = generateSitemapXml(datasets, url.origin);
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+      'Cache-Control': `public, max-age=${CACHE_TTL}`,
+    },
+  });
+}

--- a/apps/browser/static/robots.txt
+++ b/apps/browser/static/robots.txt
@@ -1,3 +1,5 @@
-# allow crawling everything by default
+# Allow crawling everything
 User-agent: *
 Disallow:
+
+Sitemap: https://datasetregister.netwerkdigitaalerfgoed.nl/sitemap.xml


### PR DESCRIPTION
## Summary

- Add dynamic `/sitemap.xml` endpoint that queries SPARQL for all dataset URIs
- Include `lastmod` dates from `schema:dateRead` for each dataset
- Set 24-hour cache headers on sitemap response
- Add canonical URLs to dataset search and detail pages
- Add hreflang tags for nl, en, and x-default language variants
- Update robots.txt to reference sitemap

## Details

The sitemap helps search engines discover all dataset detail pages, which was previously not possible since the search page loads data client-side.

**Note:** For correct origin detection behind a reverse proxy (e.g., Kubernetes ingress), set these environment variables:
```
PROTOCOL_HEADER=x-forwarded-proto
HOST_HEADER=x-forwarded-host
```

## Test plan

- [ ] Visit `/sitemap.xml` and verify it lists all datasets with valid URLs
- [ ] Verify `lastmod` dates are present for datasets
- [ ] Check `/robots.txt` references the sitemap
- [ ] Inspect page source on `/datasets` and `/datasets/{uri}` for canonical and hreflang tags