### PR TITLE
fix(browser): fix 500 error on dataset detail page for datasets with unresolvable dataDumps

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -254,18 +254,6 @@ const DatasetSummarySchema = {
     '@id': voidNs.dataDump,
     '@optional': true,
     '@array': true,
-    '@schema': {
-      contentSize: {
-        '@id': 'https://schema.org/contentSize',
-        '@type': xsd.integer,
-        '@optional': true,
-      },
-      dateModified: {
-        '@id': 'https://schema.org/dateModified',
-        '@type': xsd.dateTime,
-        '@optional': true,
-      },
-    },
   },
   sparqlEndpoint: {
     '@id': voidNs.sparqlEndpoint,
@@ -394,7 +382,10 @@ export async function fetchDatasetDetail(
 
   const [dataset, summary, linksets, classPartitionResult] = await Promise.all([
     detailLens.findByIri(datasetUri),
-    summaryLens.findByIri(datasetUri),
+    summaryLens.findByIri(datasetUri).catch((e: unknown) => {
+      console.error('Summary query failed:', e instanceof Error ? e.message : e);
+      return null;
+    }),
     linksLens.find({ where: { subjectsTarget: datasetUri } }),
     classPartitionLens.findByIri(datasetUri),
   ]);

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -76,7 +76,7 @@
     const urls = new SvelteSet<string>();
     if (summary?.dataDump) {
       for (const dump of summary.dataDump) {
-        if (dump.$id) urls.add(dump.$id);
+        urls.add(dump);
       }
     }
     if (summary?.sparqlEndpoint) {


### PR DESCRIPTION
## Problem

Visiting the detail page of certain datasets (e.g. the Maastricht University Library dataset) resulted in a 500 Internal Server Error:

```
Error: Error decoding graph, <https://…/api/items?item_set_id=14> node not found.
```

## Root cause

`DatasetSummarySchema.dataDump` used `@array + @schema` with all nested properties (`contentSize`, `dateModified`) marked `@optional`. When LDKit generates the CONSTRUCT query, a dataDump IRI whose optional sub-properties all fail to match appears only as an *object* in the graph (via `?dataset void:dataDump ?dump`) — never as a *subject*. LDKit's `decodeNode` then calls `graph.get(dumpIri)` which returns `undefined` → throws "node not found", propagating through `Promise.all` as a 500.

## Fix

- Remove the nested `@schema` from `dataDump` in `DatasetSummarySchema`: dataDump IRIs are now decoded as plain strings, so *all* dataDumps are included regardless of which sub-properties they carry in the knowledge graph
- Update the `verifiedUrls` derived in the template to use the string IRI directly instead of `dump.$id`
- Add `.catch()` on `summaryLens.findByIri()` as a defensive safety net for unexpected errors

The `contentSize` and `dateModified` sub-properties were fetched but never rendered in the template, so removing them has no UI impact.

Fix #1642