### PR TITLE
feat(browser): use void-ext properties for object counts

### DIFF
--- a/apps/browser/src/lib/rdf.ts
+++ b/apps/browser/src/lib/rdf.ts
@@ -24,17 +24,6 @@ export const voidNs = createNamespace({
   ],
 } as const);
 
-export const ndeNs = createNamespace({
-  iri: 'https://www.netwerkdigitaalerfgoed.nl/def#',
-  prefix: 'nde:',
-  terms: [
-    'objectsLiteral',
-    'distinctObjectsLiteral',
-    'objectsURI',
-    'distinctObjectsURI',
-  ],
-} as const);
-
 export const owlNs = createNamespace({
   iri: 'http://www.w3.org/2002/07/owl#',
   prefix: 'owl:',
@@ -47,6 +36,8 @@ export const voidExtNs = createNamespace({
   terms: [
     'datatypePartition',
     'datatype',
+    'distinctIRIReferenceObjects',
+    'distinctLiterals',
     'objectClassPartition',
     'languagePartition',
     'language',

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -2,7 +2,7 @@ import { dcat } from '@lde/dataset-registry-client';
 import { dcterms, foaf, ldkit, schema, xsd } from 'ldkit/namespaces';
 import { createLens, type SchemaInterface } from 'ldkit';
 import { error } from '@sveltejs/kit';
-import { ndeNs, owlNs, voidExtNs, voidNs } from '../rdf.js';
+import { owlNs, voidExtNs, voidNs } from '../rdf.js';
 import { BaseDatasetSchema, BaseDistributionSchema } from './datasets.js';
 import { shortenUri } from '$lib/utils/prefix';
 import { REGISTRATION_STATUS_BASE_URI } from '@dataset-register/core/constants';
@@ -220,12 +220,12 @@ const DatasetSummarySchema = {
     '@optional': true,
   },
   distinctObjectsLiteral: {
-    '@id': ndeNs.distinctObjectsLiteral,
+    '@id': voidExtNs.distinctLiterals,
     '@type': xsd.integer,
     '@optional': true,
   },
   distinctObjectsURI: {
-    '@id': ndeNs.distinctObjectsURI,
+    '@id': voidExtNs.distinctIRIReferenceObjects,
     '@type': xsd.integer,
     '@optional': true,
   },
@@ -383,7 +383,10 @@ export async function fetchDatasetDetail(
   const [dataset, summary, linksets, classPartitionResult] = await Promise.all([
     detailLens.findByIri(datasetUri),
     summaryLens.findByIri(datasetUri).catch((e: unknown) => {
-      console.error('Summary query failed:', e instanceof Error ? e.message : e);
+      console.error(
+        'Summary query failed:',
+        e instanceof Error ? e.message : e,
+      );
       return null;
     }),
     linksLens.find({ where: { subjectsTarget: datasetUri } }),


### PR DESCRIPTION
## Summary

The DKG pipeline (`@lde/pipeline-void` v0.10.0) now outputs object-count properties using standard `void-ext` terms instead of the custom NDE namespace. This PR updates the browser app to match:

- Map `distinctObjectsLiteral` to `void-ext:distinctLiterals` (was `nde:distinctObjectsLiteral`)
- Map `distinctObjectsURI` to `void-ext:distinctIRIReferenceObjects` (was `nde:distinctObjectsURI`)
- Remove the `ndeNs` namespace from `rdf.ts` (no longer used)

No template changes needed — the TypeScript property names stay the same; only the underlying RDF IRI mappings change.

## Test plan

- [x] `npx nx build @dataset-register/browser` passes
- [x] `npx nx test @dataset-register/browser` passes
- [x] `npx nx lint @dataset-register/browser` passes
- [ ] Verify dataset detail page still shows 'Unique subjects' counts correctly with new DKG data