### PR TITLE
feat(browser): improve DatasetCard UI

### DIFF
--- a/apps/browser/src/lib/components/DatasetCard.svelte
+++ b/apps/browser/src/lib/components/DatasetCard.svelte
@@ -42,7 +42,7 @@
 </script>
 
 <a
-  class="group/card relative block border border-gray-300 dark:border-gray-700 rounded-lg p-6 bg-white dark:bg-gray-800 transition-all hover:shadow-lg hover:border-gray-400 dark:hover:border-gray-600 cursor-pointer no-underline overflow-visible"
+  class="group/card relative block border border-gray-300 dark:border-gray-700 rounded-lg p-6 bg-white dark:bg-gray-800 transition-all hover:shadow-xl hover:border-gray-500 dark:hover:border-gray-500 cursor-pointer no-underline overflow-visible"
   href={detailUrl}
 >
   {#if dataset.status}


### PR DESCRIPTION
## Summary

- **Title truncation**: add `line-clamp-2` to truncate long titles at 2 lines, with a `title` attribute so users can hover to see the full text
- **Hover feedback**: underline the title on card hover using a named Tailwind group (`group/card`), increase shadow from `shadow-lg` to `shadow-xl`, and strengthen hover border to `gray-500` in both light and dark modes
- **Publisher placement**: move the publisher block directly under the title and before the description for better visual hierarchy