### PR TITLE
fix(browser): improve dataset detail page accessibility

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -205,5 +205,6 @@
   "detail_object_class": "Object class (URI)",
   "detail_language": "Language",
   "detail_classes_for_value_type": "Classes for {valueTypeName}",
-  "detail_properties_for_value_type": "Properties for {valueTypeName}"
+  "detail_properties_for_value_type": "Properties for {valueTypeName}",
+  "opens_in_new_tab": "opens in new tab"
 }

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -205,5 +205,6 @@
   "detail_object_class": "Objectklasse (URI)",
   "detail_language": "Taal",
   "detail_classes_for_value_type": "Typen voor {valueTypeName}",
-  "detail_properties_for_value_type": "Eigenschappen voor {valueTypeName}"
+  "detail_properties_for_value_type": "Eigenschappen voor {valueTypeName}",
+  "opens_in_new_tab": "opent in nieuw tabblad"
 }

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -7,8 +7,6 @@
   import { getLocale } from '$lib/paraglide/runtime';
   import { page } from '$app/state';
   import { RDF_MEDIA_TYPES } from '$lib/constants.js';
-  import { onMount } from 'svelte';
-  import { initFlowbite } from 'flowbite';
   import {
     getLocalizedValue,
     getLocalizedArray,
@@ -109,6 +107,17 @@
   const localizedKeywords = $derived(getLocalizedArray(dataset.keyword));
   const localizedGenres = $derived(getLocalizedArray(dataset.type));
 
+  const hasVoidStats = $derived(
+    summary &&
+      (summary.triples != null ||
+        summary.distinctSubjects != null ||
+        summary.properties != null ||
+        summary.distinctObjectsURI != null ||
+        summary.distinctObjectsLiteral != null ||
+        (summary.classPartition && summary.classPartition.length > 0) ||
+        (summary.vocabulary && summary.vocabulary.length > 0)),
+  );
+
   // Get registration status (gone, invalid, or null)
   const registrationStatus = $derived(
     getRegistrationStatus(dataset.subjectOf?.additionalType),
@@ -174,10 +183,6 @@
       total,
     };
   });
-
-  onMount(() => {
-    initFlowbite();
-  });
 </script>
 
 <svelte:head>
@@ -191,78 +196,126 @@
   <link rel="alternate" hreflang="x-default" href={canonicalUrl} />
 </svelte:head>
 
-<div class="mx-auto max-w-7xl px-1 py-8 sm:px-6 lg:px-8">
-  {#if dataset}
-    <!-- Gone/Invalid Dataset Warning -->
-    {#if registrationStatus === 'invalid' || registrationStatus === 'gone'}
-      <Alert border color="red" class="mb-6">
-        {#snippet icon()}
-          <ExclamationCircleOutline class="h-5 w-5" />
-        {/snippet}
-        <p class="font-semibold">{m.detail_archived_warning()}</p>
-        <p>{m.detail_archived_message()}</p>
-      </Alert>
+<main class="mx-auto max-w-7xl px-1 py-8 sm:px-6 lg:px-8">
+  <!-- Gone/Invalid Dataset Warning -->
+  {#if registrationStatus === 'invalid' || registrationStatus === 'gone'}
+    <Alert border color="red" class="mb-6">
+      {#snippet icon()}
+        <ExclamationCircleOutline class="h-5 w-5" />
+      {/snippet}
+      <p class="font-semibold">{m.detail_archived_warning()}</p>
+      <p>{m.detail_archived_message()}</p>
+    </Alert>
+  {/if}
+
+  <!-- Dataset Header -->
+  <div class="mb-8">
+    <h1
+      class="mb-4 text-3xl font-bold leading-[1.2] tracking-[-0.02em] text-gray-900 dark:text-white lg:text-4xl"
+    >
+      {getLocalizedValue(dataset.title)}
+      <LanguageBadge values={dataset.title} />
+    </h1>
+
+    {#if dataset.description}
+      <p
+        class="mb-6 text-lg leading-relaxed text-gray-700 dark:text-gray-300 lg:text-xl"
+      >
+        {getLocalizedValue(dataset.description)}
+        <LanguageBadge values={dataset.description} />
+      </p>
     {/if}
 
-    <!-- Dataset Header -->
-    <div class="mb-8">
-      <h1
-        class="mb-4 text-3xl font-bold leading-[1.2] tracking-[-0.02em] text-gray-900 dark:text-white lg:text-4xl"
-      >
-        {getLocalizedValue(dataset.title)}
-        <LanguageBadge values={dataset.title} />
-      </h1>
-
-      {#if dataset.description}
-        <p
-          class="mb-6 text-lg leading-relaxed text-gray-700 dark:text-gray-300 lg:text-xl"
+    <!-- SPARQL Query Button -->
+    {#if dataset.distribution}
+      {@const sparqlDist = dataset.distribution.find((d) =>
+        d.conformsTo?.includes('https://www.w3.org/TR/sparql11-protocol/'),
+      )}
+      {#if sparqlDist?.accessURL}
+        <a
+          href="https://yasgui.org/#query=SELECT+*+WHERE+%7B%0A++%3Fsub+%3Fpred+%3Fobj+.%0A%7D+%0ALIMIT+10&endpoint={encodeURIComponent(
+            sparqlDist.accessURL,
+          )}"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="mb-6 inline-flex items-center gap-2 rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition-colors"
         >
-          {getLocalizedValue(dataset.description)}
-          <LanguageBadge values={dataset.description} />
-        </p>
-      {/if}
-
-      <!-- SPARQL Query Button -->
-      {#if dataset.distribution}
-        {@const sparqlDist = dataset.distribution.find((d) =>
-          d.conformsTo?.includes('https://www.w3.org/TR/sparql11-protocol/'),
-        )}
-        {#if sparqlDist?.accessURL}
-          <a
-            href="https://yasgui.org/#query=SELECT+*+WHERE+%7B%0A++%3Fsub+%3Fpred+%3Fobj+.%0A%7D+%0ALIMIT+10&endpoint={encodeURIComponent(
-              sparqlDist.accessURL,
-            )}"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="mb-6 inline-flex items-center gap-2 rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition-colors"
+          <svg
+            class="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            <svg
-              class="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-              />
-            </svg>
-            {m.detail_query_dataset()}
-          </a>
-        {/if}
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          {m.detail_query_dataset()}
+          <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+        </a>
       {/if}
-    </div>
+    {/if}
+  </div>
 
-    <!-- Dataset Details Section (compact) -->
-    {#if localizedKeywords.length > 0 || dataset.publisher?.name || dataset.license || (dataset.spatial && dataset.spatial.length > 0) || dataset.temporal || localizedGenres.length > 0 || (dataset.language && dataset.language.length > 0)}
-      <div class="mb-8">
-        <div
-          class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
-        >
-          <dl class="divide-y divide-gray-200 dark:divide-gray-700">
-            <!-- URI -->
+  <!-- Dataset Details Section (compact) -->
+  {#if localizedKeywords.length > 0 || dataset.publisher?.name || dataset.license || (dataset.spatial && dataset.spatial.length > 0) || dataset.temporal || localizedGenres.length > 0 || (dataset.language && dataset.language.length > 0)}
+    <div class="mb-8">
+      <div
+        class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+      >
+        <dl class="divide-y divide-gray-200 dark:divide-gray-700">
+          <!-- URI -->
+          <div
+            class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+          >
+            <dt
+              class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+            >
+              <svg
+                class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                />
+              </svg>
+              {m.detail_uri()}
+            </dt>
+            <dd class="text-sm flex items-center gap-2">
+              <a
+                href={dataset.$id}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="break-all text-blue-600 hover:underline dark:text-blue-400"
+              >
+                {dataset.$id}
+                <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+              </a>
+              <Clipboard value={dataset.$id} class="p-0">
+                {#snippet children(success)}
+                  <Tooltip
+                    >{success ? m.detail_copied() : m.detail_copy()}</Tooltip
+                  >
+                  {#if success}<CheckOutline
+                      class="h-4 w-4 text-gray-500 dark:text-gray-400"
+                    />{:else}<ClipboardCleanSolid
+                      class="h-4 w-4 text-gray-500 dark:text-gray-400"
+                    />{/if}
+                {/snippet}
+              </Clipboard>
+            </dd>
+          </div>
+
+          <!-- Publisher -->
+          {#if dataset.publisher?.name}
             <div
               class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
             >
@@ -279,891 +332,924 @@
                     stroke-linecap="round"
                     stroke-linejoin="round"
                     stroke-width="2"
-                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                    d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
                   />
                 </svg>
-                {m.detail_uri()}
+                {m.detail_publisher()}
               </dt>
-              <dd class="text-sm flex items-center gap-2">
+              <dd class="text-sm text-gray-700 dark:text-gray-300">
                 <a
-                  href={dataset.$id}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="truncate text-blue-600 hover:underline dark:text-blue-400"
+                  href={localizeHref(
+                    `/datasets?publishers=${encodeURIComponent(dataset.publisher.$id || '')}`,
+                  )}
+                  class="text-blue-600 hover:underline dark:text-blue-400"
                 >
-                  {dataset.$id}
+                  {getLocalizedValue(dataset.publisher.name)}
                 </a>
-                <Clipboard value={dataset.$id} class="p-0">
-                  {#snippet children(success)}
-                    <Tooltip
-                      >{success ? m.detail_copied() : m.detail_copy()}</Tooltip
-                    >
-                    {#if success}<CheckOutline
-                        class="h-4 w-4 text-gray-500 dark:text-gray-400"
-                      />{:else}<ClipboardCleanSolid
-                        class="h-4 w-4 text-gray-500 dark:text-gray-400"
-                      />{/if}
-                  {/snippet}
-                </Clipboard>
-              </dd>
-            </div>
-
-            <!-- Publisher -->
-            {#if dataset.publisher?.name}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <svg
-                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
+                {#if dataset.publisher.nick}
+                  <span class="text-gray-500 dark:text-gray-400"
+                    >({getLocalizedValue(dataset.publisher.nick)})</span
                   >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                    />
-                  </svg>
-                  {m.detail_publisher()}
-                </dt>
-                <dd class="text-sm text-gray-700 dark:text-gray-300">
-                  <a
-                    href={localizeHref(
-                      `/datasets?publishers=${encodeURIComponent(dataset.publisher.$id || '')}`,
-                    )}
-                    class="text-blue-600 hover:underline dark:text-blue-400"
+                {/if}
+                <LanguageBadge values={dataset.publisher.name} />
+                {#if dataset.publisher.email || dataset.publisher.sameAs}
+                  <div
+                    class="mt-1.5 flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-400"
                   >
-                    {getLocalizedValue(dataset.publisher.name)}
-                  </a>
-                  {#if dataset.publisher.nick}
-                    <span class="text-gray-500 dark:text-gray-400"
-                      >({getLocalizedValue(dataset.publisher.nick)})</span
-                    >
-                  {/if}
-                  <LanguageBadge values={dataset.publisher.name} />
-                  {#if dataset.publisher.email || dataset.publisher.sameAs}
-                    <div
-                      class="mt-1.5 flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-400"
-                    >
-                      {#if dataset.publisher.email}
-                        <a
-                          href="mailto:{dataset.publisher.email}"
-                          class="inline-flex items-center gap-1.5 hover:text-blue-600 dark:hover:text-blue-400"
-                        >
-                          <svg
-                            class="h-3.5 w-3.5 flex-shrink-0"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                            />
-                          </svg>
-                          <span class="break-all"
-                            >{dataset.publisher.email.replace(
-                              'mailto:',
-                              '',
-                            )}</span
-                          >
-                        </a>
-                      {/if}
-                      {#if dataset.publisher.sameAs}
-                        <a
-                          href={dataset.publisher.sameAs}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          class="inline-flex items-center gap-1.5 hover:text-blue-600 dark:hover:text-blue-400"
-                        >
-                          <svg
-                            class="h-3.5 w-3.5 flex-shrink-0"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                            />
-                          </svg>
-                          <span class="break-all"
-                            >{dataset.publisher.sameAs}</span
-                          >
-                        </a>
-                      {/if}
-                    </div>
-                  {/if}
-                </dd>
-              </div>
-            {/if}
-
-            <!-- Creator -->
-            {#if dataset.creator && dataset.creator.length > 0}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <svg
-                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                    />
-                  </svg>
-                  {m.detail_creator()}
-                </dt>
-                <dd class="text-sm text-gray-700 dark:text-gray-300">
-                  {#each dataset.creator as creator, index (creator)}
-                    <span>
+                    {#if dataset.publisher.email}
                       <a
-                        href={creator.$id}
+                        href="mailto:{dataset.publisher.email}"
+                        class="inline-flex items-center gap-1.5 hover:text-blue-600 dark:hover:text-blue-400"
+                      >
+                        <svg
+                          class="h-3.5 w-3.5 flex-shrink-0"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                          />
+                        </svg>
+                        <span class="break-all"
+                          >{dataset.publisher.email.replace(
+                            'mailto:',
+                            '',
+                          )}</span
+                        >
+                      </a>
+                    {/if}
+                    {#if dataset.publisher.sameAs}
+                      <a
+                        href={dataset.publisher.sameAs}
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="text-blue-600 hover:underline dark:text-blue-400"
+                        class="inline-flex items-center gap-1.5 hover:text-blue-600 dark:hover:text-blue-400"
                       >
-                        {getLocalizedValue(creator.name)}
+                        <svg
+                          class="h-3.5 w-3.5 flex-shrink-0"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                          />
+                        </svg>
+                        <span class="break-all">{dataset.publisher.sameAs}</span
+                        >
+                        <span class="sr-only"> ({m.opens_in_new_tab()})</span>
                       </a>
-                      <LanguageBadge values={creator.name} />
-                    </span>{#if index < dataset.creator.length - 1},&nbsp;{/if}
-                  {/each}
-                </dd>
-              </div>
-            {/if}
-
-            <!-- Catalog -->
-            {#if dataset.isPartOf}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <svg
-                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-                    />
-                  </svg>
-                  {m.detail_is_part_of()}
-                </dt>
-                <dd class="text-sm text-gray-700 dark:text-gray-300">
-                  <a
-                    href={`https://datasetregister.netwerkdigitaalerfgoed.nl/catalog.php?lang=${getLocale()}&uri=${encodeURIComponent(dataset.isPartOf)}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-blue-600 hover:underline dark:text-blue-400"
-                  >
-                    {dataset.isPartOf}
-                  </a>
-                </dd>
-              </div>
-            {/if}
-
-            <!-- Landing Page -->
-            {#if dataset.landingPage}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <ArrowUpRightFromSquareOutline
-                    class="h-5 w-5 flex-shrink-0 text-gray-500 dark:text-gray-400"
-                  />
-                  {m.detail_landing_page()}
-                </dt>
-                <dd class="text-sm truncate">
-                  <a
-                    href={dataset.landingPage}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex items-center gap-1 text-blue-600 hover:underline dark:text-blue-400"
-                    title={dataset.landingPage}
-                  >
-                    {dataset.landingPage}
-                    <ArrowUpRightFromSquareOutline class="h-3 w-3 shrink-0" />
-                  </a>
-                </dd>
-              </div>
-            {/if}
-
-            <!-- License -->
-            {#if dataset.license}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <svg
-                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
-                    />
-                  </svg>
-                  {m.detail_license()}
-                </dt>
-                <dd class="text-sm truncate">
-                  <a
-                    href={dataset.license}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-blue-600 hover:underline dark:text-blue-400"
-                    title={dataset.license}
-                  >
-                    {getLicenseName(dataset.license)}
-                  </a>
-                </dd>
-              </div>
-            {/if}
-
-            <!-- Spatial Coverage -->
-            {#if dataset.spatial && dataset.spatial.length > 0}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <svg
-                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                    />
-                  </svg>
-                  {m.detail_spatial_coverage()}
-                </dt>
-                <dd class="text-sm text-gray-700 dark:text-gray-300 break-all">
-                  {dataset.spatial.join(', ')}
-                </dd>
-              </div>
-            {/if}
-
-            <!-- Temporal Coverage -->
-            {#if dataset.temporal}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <svg
-                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                    />
-                  </svg>
-                  {m.detail_temporal_coverage()}
-                </dt>
-                <dd class="text-sm text-gray-700 dark:text-gray-300">
-                  {dataset.temporal}
-                </dd>
-              </div>
-            {/if}
-
-            <!-- Language -->
-            {#if dataset.language && dataset.language.length > 0}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <svg
-                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"
-                    />
-                  </svg>
-                  {m.dataset_languages()}
-                </dt>
-                <dd class="text-sm text-gray-700 dark:text-gray-300">
-                  {dataset.language.join(', ')}
-                </dd>
-              </div>
-            {/if}
-
-            <!-- Genre -->
-            {#if localizedGenres.length > 0}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <svg
-                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"
-                    />
-                  </svg>
-                  {m.detail_genres()}
-                </dt>
-                <dd class="text-sm text-gray-700 dark:text-gray-300">
-                  {localizedGenres.join(', ')}
-                </dd>
-              </div>
-            {/if}
-
-            <!-- Keywords -->
-            {#if localizedKeywords.length > 0}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <svg
-                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
-                    />
-                  </svg>
-                  {m.detail_keywords()}
-                </dt>
-                <dd class="flex flex-wrap gap-1.5">
-                  {#each localizedKeywords as keyword (keyword)}
-                    <a
-                      href={localizeHref(
-                        `/datasets?keywords=${encodeURIComponent(keyword)}`,
-                      )}
-                      class="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800 transition-colors hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-200 dark:hover:bg-blue-900/50 no-underline"
-                    >
-                      {keyword}
-                    </a>
-                  {/each}
-                </dd>
-              </div>
-            {/if}
-
-            <!-- Issued -->
-            {#if dataset.issued}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <svg
-                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                    />
-                  </svg>
-                  {m.detail_issued()}
-                </dt>
-                <dd class="text-sm text-gray-700 dark:text-gray-300">
-                  {new Date(dataset.issued).toLocaleDateString(getLocale(), {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
-                </dd>
-              </div>
-            {/if}
-
-            <!-- Modified -->
-            {#if dataset.modified}
-              <div
-                class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-              >
-                <dt
-                  class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
-                >
-                  <svg
-                    class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-                    />
-                  </svg>
-                  {m.detail_modified()}
-                </dt>
-                <dd class="text-sm text-gray-700 dark:text-gray-300">
-                  {new Date(dataset.modified).toLocaleDateString(getLocale(), {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
-                </dd>
-              </div>
-            {/if}
-          </dl>
-        </div>
-      </div>
-    {/if}
-
-    <!-- Distributions Section -->
-    {#if sortedDistributions.length > 0}
-      <div class="mb-8">
-        <h2
-          class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
-        >
-          <svg
-            class="w-5 h-5 text-gray-600 dark:text-gray-400"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-            />
-          </svg>
-          {m.detail_distributions()}
-          <button
-            data-tooltip-target="tooltip-distributions"
-            data-tooltip-placement="bottom"
-            type="button"
-            class="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-          >
-            <QuestionCircleSolid class="h-5 w-5" />
-            <span class="sr-only">{m.detail_show_info()}</span>
-          </button>
-          <div
-            id="tooltip-distributions"
-            role="tooltip"
-            class="tooltip invisible absolute z-10 inline-block max-w-xs rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300 dark:bg-gray-700"
-          >
-            {m.detail_distributions_tooltip()}
-            <div class="tooltip-arrow" data-popper-arrow></div>
-          </div>
-        </h2>
-        <div
-          class="divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800"
-        >
-          {#each sortedDistributions as distribution, distIndex (distribution.$id)}
-            {@const isVerified = verifiedUrls.has(distribution.accessURL)}
-            {@const isSparql = isSparqlDistribution(distribution)}
-            <div class="flex flex-wrap items-center gap-3 px-4 py-3">
-              <!-- Type badge -->
-              <div class="w-20 flex-shrink-0">
-                {#if isSparql}
-                  <span
-                    class="inline-flex w-full items-center justify-center rounded bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-800 dark:bg-purple-900/30 dark:text-purple-300"
-                  >
-                    SPARQL
-                  </span>
-                {:else if distribution.mediaType}
-                  <span
-                    class="inline-flex w-full items-center justify-center truncate rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300"
-                    title={distribution.mediaType}
-                  >
-                    {getMediaTypeLabel(distribution.mediaType)}
-                  </span>
-                {/if}
-              </div>
-
-              <!-- Title, URL, and Description -->
-              <div class="min-w-0 flex-1">
-                {#if distribution.title}
-                  <div
-                    class="text-sm font-medium text-gray-900 dark:text-white"
-                  >
-                    {getLocalizedValue(distribution.title)}
-                  </div>
-                {/if}
-                <a
-                  href={isSparql
-                    ? `https://yasgui.org/#query=SELECT+*+WHERE+%7B%0A++%3Fsub+%3Fpred+%3Fobj+.%0A%7D+%0ALIMIT+10&endpoint=${encodeURIComponent(distribution.accessURL)}`
-                    : distribution.accessURL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="block truncate text-sm text-blue-600 hover:underline dark:text-blue-400"
-                  title={isSparql
-                    ? `Query in YASGUI: ${distribution.accessURL}`
-                    : distribution.accessURL}
-                >
-                  {distribution.accessURL}
-                </a>
-                {#if distribution.description}
-                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    {getLocalizedValue(distribution.description)}
-                  </p>
-                {/if}
-                {#if distribution.issued || distribution.modified || distribution.byteSize}
-                  <div
-                    class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400"
-                  >
-                    {#if distribution.issued}
-                      <span
-                        >{m.detail_issued()}: {new Date(
-                          distribution.issued,
-                        ).toLocaleDateString(getLocale())}</span
-                      >
-                    {/if}
-                    {#if distribution.modified}
-                      <span
-                        >{m.detail_modified()}: {new Date(
-                          distribution.modified,
-                        ).toLocaleDateString(getLocale())}</span
-                      >
-                    {/if}
-                    {#if distribution.byteSize}
-                      <span
-                        >{m.detail_file_size()}: {formatByteSize(
-                          distribution.byteSize,
-                        )}</span
-                      >
                     {/if}
                   </div>
                 {/if}
-              </div>
-
-              <!-- Action buttons -->
-              <div class="flex flex-shrink-0 items-center gap-1">
-                {#if isVerified}
-                  <button
-                    type="button"
-                    data-tooltip-target="tooltip-verified-{distIndex}"
-                    data-tooltip-placement="bottom"
-                    class="group relative inline-flex cursor-help items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                  >
-                    <svg
-                      class="h-3 w-3"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M5 13l4 4L19 7"
-                      />
-                    </svg>
-                    {m.detail_verified()}
-                  </button>
-                  <div
-                    id="tooltip-verified-{distIndex}"
-                    role="tooltip"
-                    class="tooltip invisible absolute z-10 inline-block max-w-xs rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300 dark:bg-gray-700"
-                  >
-                    {m.detail_verified_tooltip()}
-                    <div class="tooltip-arrow" data-popper-arrow></div>
-                  </div>
-                {/if}
-
-                <Clipboard value={distribution.accessURL} class="p-0">
-                  {#snippet children(success)}
-                    <Tooltip
-                      >{success ? m.detail_copied() : m.detail_copy()}</Tooltip
-                    >
-                    {#if success}<CheckOutline
-                        class="h-4 w-4 text-gray-500 dark:text-gray-400"
-                      />{:else}<ClipboardCleanSolid
-                        class="h-4 w-4 text-gray-500 dark:text-gray-400"
-                      />{/if}
-                  {/snippet}
-                </Clipboard>
-              </div>
-            </div>
-          {/each}
-        </div>
-      </div>
-    {/if}
-
-    <!-- VoID Summary Section -->
-    {@const hasVoidStats =
-      summary &&
-      (summary.triples != null ||
-        summary.distinctSubjects != null ||
-        summary.properties != null ||
-        summary.distinctObjectsURI != null ||
-        summary.distinctObjectsLiteral != null ||
-        (summary.classPartition && summary.classPartition.length > 0) ||
-        (summary.vocabulary && summary.vocabulary.length > 0))}
-    {#if hasVoidStats}
-      <div class="mb-8">
-        <h2
-          class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
-        >
-          {m.detail_linked_data_summary()}
-          <button
-            data-tooltip-target="tooltip-linked-data-summary"
-            data-tooltip-placement="bottom"
-            type="button"
-            class="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-          >
-            <QuestionCircleSolid class="h-5 w-5" />
-            <span class="sr-only">{m.detail_show_info()}</span>
-          </button>
-          <div
-            id="tooltip-linked-data-summary"
-            role="tooltip"
-            class="tooltip invisible absolute z-10 inline-block max-w-xs rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300 dark:bg-gray-700"
-          >
-            {m.detail_linked_data_summary_description()}
-            <div class="tooltip-arrow" data-popper-arrow></div>
-          </div>
-        </h2>
-        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <!-- Merged: Triples + Subjects + Avg Triples Per Subject -->
-          {#if (summary.triples !== undefined && summary.triples !== null) || (summary.distinctSubjects !== undefined && summary.distinctSubjects !== null)}
-            <div
-              class="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
-            >
-              <div class="space-y-3">
-                {#if summary.distinctSubjects !== undefined && summary.distinctSubjects !== null}
-                  <div>
-                    <div
-                      class="text-3xl font-bold text-gray-900 dark:text-white"
-                    >
-                      {summary.distinctSubjects.toLocaleString(getLocale())}
-                    </div>
-                    <div class="text-sm text-gray-600 dark:text-gray-400">
-                      {m.detail_subjects()}
-                    </div>
-                  </div>
-                {/if}
-                {#if summary.triples !== undefined && summary.triples !== null}
-                  <div
-                    class="border-t border-gray-200 dark:border-gray-700 pt-3"
-                  >
-                    <div
-                      class="text-3xl font-bold text-gray-900 dark:text-white"
-                    >
-                      {summary.triples.toLocaleString(getLocale())}
-                    </div>
-                    <div class="text-sm text-gray-600 dark:text-gray-400">
-                      {m.detail_triples()}
-                    </div>
-                  </div>
-                {/if}
-                {#if summary.triples !== undefined && summary.triples !== null && summary.distinctSubjects !== undefined && summary.distinctSubjects !== null && summary.distinctSubjects > 0}
-                  <div
-                    class="border-t border-gray-200 dark:border-gray-700 pt-3"
-                  >
-                    <div
-                      class="text-2xl font-semibold text-blue-700 dark:text-blue-300"
-                    >
-                      {(
-                        summary.triples / summary.distinctSubjects
-                      ).toLocaleString(getLocale(), {
-                        minimumFractionDigits: 1,
-                        maximumFractionDigits: 1,
-                      })}
-                    </div>
-                    <div class="text-xs text-gray-600 dark:text-gray-400">
-                      {m.detail_avg_triples_per_subject()}
-                    </div>
-                  </div>
-                {/if}
-              </div>
+              </dd>
             </div>
           {/if}
 
-          {#if summary.properties !== undefined && summary.properties !== null}
+          <!-- Creator -->
+          {#if dataset.creator && dataset.creator.length > 0}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+                {m.detail_creator()}
+              </dt>
+              <dd class="text-sm text-gray-700 dark:text-gray-300">
+                {#each dataset.creator as creator, index (creator)}
+                  <span>
+                    <a
+                      href={creator.$id}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      {getLocalizedValue(creator.name)}
+                      <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                    </a>
+                    <LanguageBadge values={creator.name} />
+                  </span>{#if index < dataset.creator.length - 1},&nbsp;{/if}
+                {/each}
+              </dd>
+            </div>
+          {/if}
+
+          <!-- Catalog -->
+          {#if dataset.isPartOf}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                  />
+                </svg>
+                {m.detail_is_part_of()}
+              </dt>
+              <dd class="text-sm text-gray-700 dark:text-gray-300">
+                <a
+                  href={`https://datasetregister.netwerkdigitaalerfgoed.nl/catalog.php?lang=${getLocale()}&uri=${encodeURIComponent(dataset.isPartOf)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {dataset.isPartOf}
+                  <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                </a>
+              </dd>
+            </div>
+          {/if}
+
+          <!-- Landing Page -->
+          {#if dataset.landingPage}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <ArrowUpRightFromSquareOutline
+                  class="h-5 w-5 flex-shrink-0 text-gray-500 dark:text-gray-400"
+                />
+                {m.detail_landing_page()}
+              </dt>
+              <dd class="text-sm break-all">
+                <a
+                  href={dataset.landingPage}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center gap-1 text-blue-600 hover:underline dark:text-blue-400"
+                  title={dataset.landingPage}
+                >
+                  {dataset.landingPage}
+                  <ArrowUpRightFromSquareOutline class="h-3 w-3 shrink-0" />
+                  <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                </a>
+              </dd>
+            </div>
+          {/if}
+
+          <!-- License -->
+          {#if dataset.license}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+                  />
+                </svg>
+                {m.detail_license()}
+              </dt>
+              <dd class="text-sm break-all">
+                <a
+                  href={dataset.license}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-blue-600 hover:underline dark:text-blue-400"
+                  title={dataset.license}
+                >
+                  {getLicenseName(dataset.license)}
+                  <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                </a>
+              </dd>
+            </div>
+          {/if}
+
+          <!-- Spatial Coverage -->
+          {#if dataset.spatial && dataset.spatial.length > 0}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                  />
+                </svg>
+                {m.detail_spatial_coverage()}
+              </dt>
+              <dd class="text-sm text-gray-700 dark:text-gray-300 break-all">
+                {dataset.spatial.join(', ')}
+              </dd>
+            </div>
+          {/if}
+
+          <!-- Temporal Coverage -->
+          {#if dataset.temporal}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+                {m.detail_temporal_coverage()}
+              </dt>
+              <dd class="text-sm text-gray-700 dark:text-gray-300">
+                {dataset.temporal}
+              </dd>
+            </div>
+          {/if}
+
+          <!-- Language -->
+          {#if dataset.language && dataset.language.length > 0}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"
+                  />
+                </svg>
+                {m.dataset_languages()}
+              </dt>
+              <dd class="text-sm text-gray-700 dark:text-gray-300">
+                {dataset.language.join(', ')}
+              </dd>
+            </div>
+          {/if}
+
+          <!-- Genre -->
+          {#if localizedGenres.length > 0}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"
+                  />
+                </svg>
+                {m.detail_genres()}
+              </dt>
+              <dd class="text-sm text-gray-700 dark:text-gray-300">
+                {localizedGenres.join(', ')}
+              </dd>
+            </div>
+          {/if}
+
+          <!-- Keywords -->
+          {#if localizedKeywords.length > 0}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
+                  />
+                </svg>
+                {m.detail_keywords()}
+              </dt>
+              <dd class="flex flex-wrap gap-1.5">
+                {#each localizedKeywords as keyword (keyword)}
+                  <a
+                    href={localizeHref(
+                      `/datasets?keywords=${encodeURIComponent(keyword)}`,
+                    )}
+                    class="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800 transition-colors hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-200 dark:hover:bg-blue-900/50 no-underline"
+                  >
+                    {keyword}
+                  </a>
+                {/each}
+              </dd>
+            </div>
+          {/if}
+
+          <!-- Issued -->
+          {#if dataset.issued}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+                {m.detail_issued()}
+              </dt>
+              <dd class="text-sm text-gray-700 dark:text-gray-300">
+                {new Date(dataset.issued).toLocaleDateString(getLocale(), {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </dd>
+            </div>
+          {/if}
+
+          <!-- Modified -->
+          {#if dataset.modified}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                  />
+                </svg>
+                {m.detail_modified()}
+              </dt>
+              <dd class="text-sm text-gray-700 dark:text-gray-300">
+                {new Date(dataset.modified).toLocaleDateString(getLocale(), {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </dd>
+            </div>
+          {/if}
+        </dl>
+      </div>
+    </div>
+  {/if}
+
+  <!-- Distributions Section -->
+  {#if sortedDistributions.length > 0}
+    <div class="mb-8">
+      <h2
+        class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
+      >
+        <svg
+          class="w-5 h-5 text-gray-600 dark:text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+        {m.detail_distributions()}
+        <span id="tooltip-distributions">
+          <QuestionCircleSolid
+            class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+          />
+        </span>
+        <Tooltip triggeredBy="#tooltip-distributions"
+          >{m.detail_distributions_tooltip()}</Tooltip
+        >
+      </h2>
+      <div
+        class="divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800"
+      >
+        {#each sortedDistributions as distribution, distIndex (distribution.$id)}
+          {@const isVerified = verifiedUrls.has(distribution.accessURL)}
+          {@const isSparql = isSparqlDistribution(distribution)}
+          <div class="flex flex-wrap items-center gap-3 px-4 py-3">
+            <!-- Type badge -->
+            <div class="w-20 flex-shrink-0">
+              {#if isSparql}
+                <span
+                  class="inline-flex w-full items-center justify-center rounded bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-800 dark:bg-purple-900/30 dark:text-purple-300"
+                >
+                  SPARQL
+                </span>
+              {:else if distribution.mediaType}
+                <span
+                  class="inline-flex w-full items-center justify-center truncate rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300"
+                  title={distribution.mediaType}
+                >
+                  {getMediaTypeLabel(distribution.mediaType)}
+                </span>
+              {/if}
+            </div>
+
+            <!-- Title, URL, and Description -->
+            <div class="min-w-0 flex-1">
+              {#if distribution.title}
+                <div class="text-sm font-medium text-gray-900 dark:text-white">
+                  {getLocalizedValue(distribution.title)}
+                </div>
+              {/if}
+              <a
+                href={isSparql
+                  ? `https://yasgui.org/#query=SELECT+*+WHERE+%7B%0A++%3Fsub+%3Fpred+%3Fobj+.%0A%7D+%0ALIMIT+10&endpoint=${encodeURIComponent(distribution.accessURL)}`
+                  : distribution.accessURL}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="block truncate text-sm text-blue-600 hover:underline dark:text-blue-400"
+                title={isSparql
+                  ? `Query in YASGUI: ${distribution.accessURL}`
+                  : distribution.accessURL}
+              >
+                {distribution.accessURL}
+                <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+              </a>
+              {#if distribution.description}
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {getLocalizedValue(distribution.description)}
+                </p>
+              {/if}
+              {#if distribution.issued || distribution.modified || distribution.byteSize}
+                <div
+                  class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400"
+                >
+                  {#if distribution.issued}
+                    <span
+                      >{m.detail_issued()}: {new Date(
+                        distribution.issued,
+                      ).toLocaleDateString(getLocale())}</span
+                    >
+                  {/if}
+                  {#if distribution.modified}
+                    <span
+                      >{m.detail_modified()}: {new Date(
+                        distribution.modified,
+                      ).toLocaleDateString(getLocale())}</span
+                    >
+                  {/if}
+                  {#if distribution.byteSize}
+                    <span
+                      >{m.detail_file_size()}: {formatByteSize(
+                        distribution.byteSize,
+                      )}</span
+                    >
+                  {/if}
+                </div>
+              {/if}
+            </div>
+
+            <!-- Action buttons -->
+            <div class="flex flex-shrink-0 items-center gap-1">
+              {#if isVerified}
+                <span
+                  id="tooltip-verified-{distIndex}"
+                  class="inline-flex cursor-help items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                >
+                  <svg
+                    class="h-3 w-3"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                  {m.detail_verified()}
+                </span>
+                <Tooltip triggeredBy="#tooltip-verified-{distIndex}"
+                  >{m.detail_verified_tooltip()}</Tooltip
+                >
+              {/if}
+
+              <Clipboard value={distribution.accessURL} class="p-0">
+                {#snippet children(success)}
+                  <Tooltip
+                    >{success ? m.detail_copied() : m.detail_copy()}</Tooltip
+                  >
+                  {#if success}<CheckOutline
+                      class="h-4 w-4 text-gray-500 dark:text-gray-400"
+                    />{:else}<ClipboardCleanSolid
+                      class="h-4 w-4 text-gray-500 dark:text-gray-400"
+                    />{/if}
+                {/snippet}
+              </Clipboard>
+            </div>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  <!-- VoID Summary Section -->
+  {#if hasVoidStats}
+    <div class="mb-8">
+      <h2
+        class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
+      >
+        {m.detail_linked_data_summary()}
+        <span id="tooltip-linked-data-summary">
+          <QuestionCircleSolid
+            class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+          />
+        </span>
+        <Tooltip triggeredBy="#tooltip-linked-data-summary"
+          >{m.detail_linked_data_summary_description()}</Tooltip
+        >
+      </h2>
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <!-- Merged: Triples + Subjects + Avg Triples Per Subject -->
+        {#if (summary.triples !== undefined && summary.triples !== null) || (summary.distinctSubjects !== undefined && summary.distinctSubjects !== null)}
+          <div
+            class="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
+          >
+            <div class="space-y-3">
+              {#if summary.distinctSubjects !== undefined && summary.distinctSubjects !== null}
+                <div>
+                  <div class="text-3xl font-bold text-gray-900 dark:text-white">
+                    {summary.distinctSubjects.toLocaleString(getLocale())}
+                  </div>
+                  <div class="text-sm text-gray-600 dark:text-gray-400">
+                    {m.detail_subjects()}
+                  </div>
+                </div>
+              {/if}
+              {#if summary.triples !== undefined && summary.triples !== null}
+                <div class="border-t border-gray-200 dark:border-gray-700 pt-3">
+                  <div class="text-3xl font-bold text-gray-900 dark:text-white">
+                    {summary.triples.toLocaleString(getLocale())}
+                  </div>
+                  <div class="text-sm text-gray-600 dark:text-gray-400">
+                    {m.detail_triples()}
+                  </div>
+                </div>
+              {/if}
+              {#if summary.triples !== undefined && summary.triples !== null && summary.distinctSubjects !== undefined && summary.distinctSubjects !== null && summary.distinctSubjects > 0}
+                <div class="border-t border-gray-200 dark:border-gray-700 pt-3">
+                  <div
+                    class="text-2xl font-semibold text-blue-700 dark:text-blue-300"
+                  >
+                    {(
+                      summary.triples / summary.distinctSubjects
+                    ).toLocaleString(getLocale(), {
+                      minimumFractionDigits: 1,
+                      maximumFractionDigits: 1,
+                    })}
+                  </div>
+                  <div class="text-xs text-gray-600 dark:text-gray-400">
+                    {m.detail_avg_triples_per_subject()}
+                  </div>
+                </div>
+              {/if}
+            </div>
+          </div>
+        {/if}
+
+        {#if summary.properties !== undefined && summary.properties !== null}
+          <div
+            class="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
+          >
+            <div class="text-3xl font-bold text-gray-900 dark:text-white">
+              {summary.properties.toLocaleString(getLocale())}
+            </div>
+            <div class="text-sm text-gray-600 dark:text-gray-400">
+              {m.detail_properties()}
+            </div>
+          </div>
+        {/if}
+
+        {#if summary.distinctObjectsURI !== undefined || summary.distinctObjectsLiteral !== undefined}
+          {@const totalObjects =
+            (summary.distinctObjectsURI || 0) +
+            (summary.distinctObjectsLiteral || 0)}
+          {@const literalsCount = summary.distinctObjectsLiteral || 0}
+          {@const urisCount = summary.distinctObjectsURI || 0}
+          {@const literalsPercent =
+            totalObjects > 0 ? (literalsCount / totalObjects) * 100 : 0}
+          {@const urisPercent =
+            totalObjects > 0 ? (urisCount / totalObjects) * 100 : 0}
+          {#if totalObjects > 0}
             <div
               class="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
             >
               <div class="text-3xl font-bold text-gray-900 dark:text-white">
-                {summary.properties.toLocaleString(getLocale())}
+                {totalObjects.toLocaleString(getLocale())}
               </div>
-              <div class="text-sm text-gray-600 dark:text-gray-400">
-                {m.detail_properties()}
+              <div class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                {m.detail_objects()}
+              </div>
+
+              <!-- Horizontal bar chart -->
+              <div class="mt-4 space-y-3">
+                <div class="flex h-8 overflow-hidden rounded-lg">
+                  {#if literalsCount > 0}
+                    <div
+                      class="flex items-center justify-center bg-blue-500 text-white text-xs font-semibold tabular-nums transition-all"
+                      style="width: {literalsPercent}%"
+                      title="{m.detail_literals()}: {literalsCount.toLocaleString(
+                        getLocale(),
+                      )} ({literalsPercent.toLocaleString(getLocale(), {
+                        minimumFractionDigits: 1,
+                        maximumFractionDigits: 1,
+                      })}%)"
+                    >
+                      {#if literalsPercent > 10}
+                        {literalsPercent.toLocaleString(getLocale(), {
+                          maximumFractionDigits: 0,
+                        })}%
+                      {/if}
+                    </div>
+                  {/if}
+                  {#if urisCount > 0}
+                    <div
+                      class="flex items-center justify-center bg-cyan-500 text-white text-xs font-semibold tabular-nums transition-all"
+                      style="width: {urisPercent}%"
+                      title="{m.detail_uris()}: {urisCount.toLocaleString(
+                        getLocale(),
+                      )} ({urisPercent.toLocaleString(getLocale(), {
+                        minimumFractionDigits: 1,
+                        maximumFractionDigits: 1,
+                      })}%)"
+                    >
+                      {#if urisPercent > 10}
+                        {urisPercent.toLocaleString(getLocale(), {
+                          maximumFractionDigits: 0,
+                        })}%
+                      {/if}
+                    </div>
+                  {/if}
+                </div>
+
+                <!-- Legend -->
+                <div class="flex flex-wrap gap-4 text-xs">
+                  <div class="flex items-center gap-2">
+                    <div class="h-3 w-3 rounded bg-blue-500"></div>
+                    <span class="text-gray-700 dark:text-gray-300">
+                      {m.detail_literals()}: {literalsCount.toLocaleString(
+                        getLocale(),
+                      )}
+                    </span>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <div class="h-3 w-3 rounded bg-cyan-500"></div>
+                    <span class="text-gray-700 dark:text-gray-300">
+                      {m.detail_uris()}: {urisCount.toLocaleString(getLocale())}
+                    </span>
+                  </div>
+                </div>
               </div>
             </div>
           {/if}
-
-          {#if summary.distinctObjectsURI !== undefined || summary.distinctObjectsLiteral !== undefined}
-            {@const totalObjects =
-              (summary.distinctObjectsURI || 0) +
-              (summary.distinctObjectsLiteral || 0)}
-            {@const literalsCount = summary.distinctObjectsLiteral || 0}
-            {@const urisCount = summary.distinctObjectsURI || 0}
-            {@const literalsPercent =
-              totalObjects > 0 ? (literalsCount / totalObjects) * 100 : 0}
-            {@const urisPercent =
-              totalObjects > 0 ? (urisCount / totalObjects) * 100 : 0}
-            {#if totalObjects > 0}
-              <div
-                class="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
-              >
-                <div class="text-3xl font-bold text-gray-900 dark:text-white">
-                  {totalObjects.toLocaleString(getLocale())}
-                </div>
-                <div class="text-sm text-gray-600 dark:text-gray-400 mb-3">
-                  {m.detail_objects()}
-                </div>
-
-                <!-- Horizontal bar chart -->
-                <div class="mt-4 space-y-3">
-                  <div class="flex h-8 overflow-hidden rounded-lg">
-                    {#if literalsCount > 0}
-                      <div
-                        class="flex items-center justify-center bg-blue-500 text-white text-xs font-semibold tabular-nums transition-all"
-                        style="width: {literalsPercent}%"
-                        title="{m.detail_literals()}: {literalsCount.toLocaleString(
-                          getLocale(),
-                        )} ({literalsPercent.toLocaleString(getLocale(), {
-                          minimumFractionDigits: 1,
-                          maximumFractionDigits: 1,
-                        })}%)"
-                      >
-                        {#if literalsPercent > 10}
-                          {literalsPercent.toLocaleString(getLocale(), {
-                            maximumFractionDigits: 0,
-                          })}%
-                        {/if}
-                      </div>
-                    {/if}
-                    {#if urisCount > 0}
-                      <div
-                        class="flex items-center justify-center bg-cyan-500 text-white text-xs font-semibold tabular-nums transition-all"
-                        style="width: {urisPercent}%"
-                        title="{m.detail_uris()}: {urisCount.toLocaleString(
-                          getLocale(),
-                        )} ({urisPercent.toLocaleString(getLocale(), {
-                          minimumFractionDigits: 1,
-                          maximumFractionDigits: 1,
-                        })}%)"
-                      >
-                        {#if urisPercent > 10}
-                          {urisPercent.toLocaleString(getLocale(), {
-                            maximumFractionDigits: 0,
-                          })}%
-                        {/if}
-                      </div>
-                    {/if}
-                  </div>
-
-                  <!-- Legend -->
-                  <div class="flex flex-wrap gap-4 text-xs">
-                    <div class="flex items-center gap-2">
-                      <div class="h-3 w-3 rounded bg-blue-500"></div>
-                      <span class="text-gray-700 dark:text-gray-300">
-                        {m.detail_literals()}: {literalsCount.toLocaleString(
-                          getLocale(),
-                        )}
-                      </span>
-                    </div>
-                    <div class="flex items-center gap-2">
-                      <div class="h-3 w-3 rounded bg-cyan-500"></div>
-                      <span class="text-gray-700 dark:text-gray-300">
-                        {m.detail_uris()}: {urisCount.toLocaleString(
-                          getLocale(),
-                        )}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            {/if}
-          {/if}
-        </div>
-
-        <!-- Classes Section with Property Partitions -->
-        {#if classPartitionTable}
-          <ClassPropertiesWidget
-            {classPartitionTable}
-            globalPropertyPartitions={summary.propertyPartition}
-          />
         {/if}
+      </div>
 
-        <!-- Vocabularies Section -->
-        {#if summary.vocabulary && summary.vocabulary.length > 0}
-          <div class="mt-6">
-            <h3
-              class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
+      <!-- Classes Section with Property Partitions -->
+      {#if classPartitionTable}
+        <ClassPropertiesWidget
+          {classPartitionTable}
+          globalPropertyPartitions={summary.propertyPartition}
+        />
+      {/if}
+
+      <!-- Vocabularies Section -->
+      {#if summary.vocabulary && summary.vocabulary.length > 0}
+        <div class="mt-6">
+          <h3
+            class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
+          >
+            {m.detail_vocabularies()}
+            <span id="tooltip-vocabularies">
+              <QuestionCircleSolid
+                class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+              />
+            </span>
+            <Tooltip triggeredBy="#tooltip-vocabularies"
+              >{m.detail_vocabularies_description()}</Tooltip
             >
-              {m.detail_vocabularies()}
-              <span id="tooltip-vocabularies">
+          </h3>
+          <ul class="space-y-2">
+            {#each summary.vocabulary as vocab (vocab)}
+              <li class="flex items-center gap-2 text-sm">
+                <svg
+                  class="w-4 h-4 text-gray-600 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                  />
+                </svg>
+                <a
+                  href={vocab}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-blue-600 hover:underline dark:text-blue-400 break-all"
+                >
+                  {vocab}
+                  <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                </a>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
+
+      <!-- Terminology Sources Section -->
+      {#if linksets.length > 0}
+        <div class="mt-6">
+          <h3
+            class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
+          >
+            {m.detail_terminology_sources()}
+            <span id="tooltip-terminology-sources">
+              <QuestionCircleSolid
+                class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+              />
+            </span>
+            <Tooltip triggeredBy="#tooltip-terminology-sources"
+              >{m.detail_terminology_sources_description()}</Tooltip
+            >
+          </h3>
+          <ul class="space-y-2">
+            {#each linksets as linkset (linkset.$id)}
+              {#if linkset.objectsTarget}
+                <li class="flex items-center gap-2 text-sm">
+                  <a
+                    href={localizeHref(
+                      `/datasets?terminologySource=${encodeURIComponent(linkset.objectsTarget.$id)}`,
+                    )}
+                    class="inline-flex items-center gap-1.5 text-blue-600 hover:underline dark:text-blue-400 break-all"
+                  >
+                    <SearchOutline class="w-4 h-4 flex-shrink-0" />
+                    {linkset.objectsTarget.title
+                      ? getLocalizedValue(linkset.objectsTarget.title)
+                      : linkset.objectsTarget.$id}
+                  </a>
+                  {#if linkset.triples !== undefined && linkset.triples !== null}
+                    <span class="text-gray-500 dark:text-gray-400">
+                      ({linkset.triples.toLocaleString(getLocale())}
+                      {m.dataset_triples({ count: linkset.triples })})
+                    </span>
+                  {/if}
+                </li>
+              {/if}
+            {/each}
+          </ul>
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  <!-- Registration Section -->
+  <div class="mb-8">
+    <h2 class="mb-4 text-xl font-semibold text-gray-900 dark:text-white">
+      {m.detail_registration()}
+    </h2>
+    <div
+      class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+    >
+      <dl class="divide-y divide-gray-200 dark:divide-gray-700">
+        {#if dataset.subjectOf}
+          <div
+            class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+          >
+            <dt
+              class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1"
+            >
+              {m.detail_registered_url()}
+              <span id="tooltip-registered-url">
                 <QuestionCircleSolid
-                  class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+                  class="h-4.5 w-4.5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
                 />
               </span>
-              <Tooltip triggeredBy="#tooltip-vocabularies"
-                >{m.detail_vocabularies_description()}</Tooltip
+              <Tooltip triggeredBy="#tooltip-registered-url"
+                >{m.detail_registered_url_description()}</Tooltip
               >
-            </h3>
-            <ul class="space-y-2">
-              {#each summary.vocabulary as vocab (vocab)}
-                <li class="flex items-center gap-2 text-sm">
+            </dt>
+            <dd class="text-sm text-gray-700 dark:text-gray-300">
+              <div class="flex flex-wrap items-center gap-2">
+                <a
+                  href={dataset.subjectOf.$id}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-blue-600 hover:underline dark:text-blue-400 break-all"
+                >
+                  {dataset.subjectOf.$id}
+                  <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                </a>
+                <a
+                  href="https://datasetregister.netwerkdigitaalerfgoed.nl/validate.php?url={encodeURIComponent(
+                    dataset.subjectOf.$id,
+                  )}"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex flex-shrink-0 items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium text-white transition-colors {registrationStatus
+                    ? 'bg-red-600 hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600'
+                    : 'bg-green-600 hover:bg-green-700 dark:bg-green-500 dark:hover:bg-green-600'}"
+                >
                   <svg
-                    class="w-4 h-4 text-gray-600 dark:text-gray-400 flex-shrink-0"
+                    class="w-3.5 h-3.5"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -1172,178 +1258,78 @@
                       stroke-linecap="round"
                       stroke-linejoin="round"
                       stroke-width="2"
-                      d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
                     />
                   </svg>
-                  <a
-                    href={vocab}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-blue-600 hover:underline dark:text-blue-400 break-all"
-                  >
-                    {vocab}
-                  </a>
-                </li>
-              {/each}
-            </ul>
+                  {#if registrationStatus === 'gone'}
+                    {m.detail_gone()}
+                  {:else if registrationStatus === 'invalid'}
+                    {m.detail_invalid()}
+                  {:else}
+                    {m.detail_valid()}
+                  {/if}
+                  <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                </a>
+              </div>
+            </dd>
           </div>
         {/if}
 
-        <!-- Terminology Sources Section -->
-        {#if linksets.length > 0}
-          <div class="mt-6">
-            <h3
-              class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
+        {#if dataset.subjectOf?.datePosted}
+          <div
+            class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+          >
+            <dt
+              class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1"
             >
-              {m.detail_terminology_sources()}
-              <span id="tooltip-terminology-sources">
+              {m.detail_registered()}
+              <span id="tooltip-registered">
                 <QuestionCircleSolid
-                  class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+                  class="h-4.5 w-4.5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
                 />
               </span>
-              <Tooltip triggeredBy="#tooltip-terminology-sources"
-                >{m.detail_terminology_sources_description()}</Tooltip
+              <Tooltip triggeredBy="#tooltip-registered"
+                >{m.detail_registered_description()}</Tooltip
               >
-            </h3>
-            <ul class="space-y-2">
-              {#each linksets as linkset (linkset.$id)}
-                {#if linkset.objectsTarget}
-                  <li class="flex items-center gap-2 text-sm">
-                    <a
-                      href={localizeHref(
-                        `/datasets?terminologySource=${encodeURIComponent(linkset.objectsTarget.$id)}`,
-                      )}
-                      class="inline-flex items-center gap-1.5 text-blue-600 hover:underline dark:text-blue-400 break-all"
-                    >
-                      <SearchOutline class="w-4 h-4 flex-shrink-0" />
-                      {linkset.objectsTarget.title
-                        ? getLocalizedValue(linkset.objectsTarget.title)
-                        : linkset.objectsTarget.$id}
-                    </a>
-                    {#if linkset.triples !== undefined && linkset.triples !== null}
-                      <span class="text-gray-500 dark:text-gray-400">
-                        ({linkset.triples.toLocaleString(getLocale())}
-                        {m.dataset_triples({ count: linkset.triples })})
-                      </span>
-                    {/if}
-                  </li>
-                {/if}
-              {/each}
-            </ul>
+            </dt>
+            <dd class="text-sm text-gray-700 dark:text-gray-300">
+              {new Date(dataset.subjectOf.datePosted).toLocaleDateString(
+                getLocale(),
+                {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                },
+              )}
+            </dd>
           </div>
         {/if}
-      </div>
-    {/if}
 
-    <!-- Registration Section -->
-    <div class="mb-8">
-      <h2 class="mb-4 text-xl font-semibold text-gray-900 dark:text-white">
-        {m.detail_registration()}
-      </h2>
-      <div
-        class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
-      >
-        <dl class="divide-y divide-gray-200 dark:divide-gray-700">
-          {#if dataset.subjectOf}
-            <div
-              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+        {#if dataset.subjectOf?.dateRead}
+          <div
+            class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+          >
+            <dt
+              class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1"
             >
-              <dt
-                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1"
+              {m.detail_last_crawled()}
+              <span id="tooltip-last-crawled">
+                <QuestionCircleSolid
+                  class="h-4.5 w-4.5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+                />
+              </span>
+              <Tooltip triggeredBy="#tooltip-last-crawled"
+                >{m.detail_last_crawled_description()}</Tooltip
               >
-                {m.detail_registered_url()}
-                <button
-                  data-tooltip-target="tooltip-registered-url"
-                  data-tooltip-placement="bottom"
-                  type="button"
-                  class="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-                >
-                  <QuestionCircleSolid class="h-4.5 w-4.5" />
-                  <span class="sr-only">{m.detail_show_info()}</span>
-                </button>
-                <div
-                  id="tooltip-registered-url"
-                  role="tooltip"
-                  class="tooltip invisible absolute z-10 inline-block max-w-xs rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300 dark:bg-gray-700"
-                >
-                  {m.detail_registered_url_description()}
-                  <div class="tooltip-arrow" data-popper-arrow></div>
-                </div>
-              </dt>
-              <dd class="text-sm text-gray-700 dark:text-gray-300">
-                <div class="flex flex-wrap items-center gap-2">
-                  <a
-                    href={dataset.subjectOf.$id}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-blue-600 hover:underline dark:text-blue-400 break-all"
-                  >
-                    {dataset.subjectOf.$id}
-                  </a>
-                  <a
-                    href="https://datasetregister.netwerkdigitaalerfgoed.nl/validate.php?url={encodeURIComponent(
-                      dataset.subjectOf.$id,
-                    )}"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex flex-shrink-0 items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium text-white transition-colors {registrationStatus
-                      ? 'bg-red-600 hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600'
-                      : 'bg-green-600 hover:bg-green-700 dark:bg-green-500 dark:hover:bg-green-600'}"
-                  >
-                    <svg
-                      class="w-3.5 h-3.5"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                      />
-                    </svg>
-                    {#if registrationStatus === 'gone'}
-                      {m.detail_gone()}
-                    {:else if registrationStatus === 'invalid'}
-                      {m.detail_invalid()}
-                    {:else}
-                      {m.detail_valid()}
-                    {/if}
-                  </a>
-                </div>
-              </dd>
-            </div>
-          {/if}
-
-          {#if dataset.subjectOf?.datePosted}
-            <div
-              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-            >
-              <dt
-                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1"
-              >
-                {m.detail_registered()}
-                <button
-                  data-tooltip-target="tooltip-registered"
-                  data-tooltip-placement="bottom"
-                  type="button"
-                  class="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-                >
-                  <QuestionCircleSolid class="h-4.5 w-4.5" />
-                  <span class="sr-only">{m.detail_show_info()}</span>
-                </button>
-                <div
-                  id="tooltip-registered"
-                  role="tooltip"
-                  class="tooltip invisible absolute z-10 inline-block max-w-xs rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300 dark:bg-gray-700"
-                >
-                  {m.detail_registered_description()}
-                  <div class="tooltip-arrow" data-popper-arrow></div>
-                </div>
-              </dt>
-              <dd class="text-sm text-gray-700 dark:text-gray-300">
-                {new Date(dataset.subjectOf.datePosted).toLocaleDateString(
+            </dt>
+            <dd class="text-sm text-gray-700 dark:text-gray-300">
+              <span id="dateread-relative">
+                {getRelativeTimeString(dataset.subjectOf.dateRead)}
+              </span>
+              <Tooltip triggeredBy="#dateread-relative">
+                {new Date(dataset.subjectOf.dateRead).toLocaleDateString(
                   getLocale(),
                   {
                     year: 'numeric',
@@ -1353,115 +1339,60 @@
                     minute: '2-digit',
                   },
                 )}
-              </dd>
-            </div>
-          {/if}
+              </Tooltip>
+            </dd>
+          </div>
+        {/if}
 
-          {#if dataset.subjectOf?.dateRead}
-            <div
-              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+        {#if dataset.contentRating?.ratingValue !== undefined}
+          <div
+            class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+          >
+            <dt
+              class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1"
             >
-              <dt
-                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1"
+              {m.detail_quality_rating()}
+              <span id="tooltip-quality-rating">
+                <QuestionCircleSolid
+                  class="h-4.5 w-4.5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+                />
+              </span>
+              <Tooltip triggeredBy="#tooltip-quality-rating"
+                >{m.detail_quality_rating_description()}</Tooltip
               >
-                {m.detail_last_crawled()}
-                <button
-                  data-tooltip-target="tooltip-last-crawled"
-                  data-tooltip-placement="bottom"
-                  type="button"
-                  class="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-                >
-                  <QuestionCircleSolid class="h-4.5 w-4.5" />
-                  <span class="sr-only">{m.detail_show_info()}</span>
-                </button>
-                <div
-                  id="tooltip-last-crawled"
-                  role="tooltip"
-                  class="tooltip invisible absolute z-10 inline-block max-w-xs rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300 dark:bg-gray-700"
-                >
-                  {m.detail_last_crawled_description()}
-                  <div class="tooltip-arrow" data-popper-arrow></div>
-                </div>
-              </dt>
-              <dd class="text-sm text-gray-700 dark:text-gray-300">
-                <span id="dateread-relative">
-                  {getRelativeTimeString(dataset.subjectOf.dateRead)}
-                </span>
-                <Tooltip triggeredBy="#dateread-relative">
-                  {new Date(dataset.subjectOf.dateRead).toLocaleDateString(
-                    getLocale(),
-                    {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    },
-                  )}
-                </Tooltip>
-              </dd>
-            </div>
-          {/if}
-
-          {#if dataset.contentRating?.ratingValue !== undefined}
-            <div
-              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
-            >
-              <dt
-                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-1"
-              >
-                {m.detail_quality_rating()}
-                <button
-                  data-tooltip-target="tooltip-quality-rating"
-                  data-tooltip-placement="bottom"
-                  type="button"
-                  class="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-                >
-                  <QuestionCircleSolid class="h-4.5 w-4.5" />
-                  <span class="sr-only">{m.detail_show_info()}</span>
-                </button>
-                <div
-                  id="tooltip-quality-rating"
-                  role="tooltip"
-                  class="tooltip invisible absolute z-10 inline-block max-w-xs rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white opacity-0 shadow-sm transition-opacity duration-300 dark:bg-gray-700"
-                >
-                  {m.detail_quality_rating_description()}
-                  <div class="tooltip-arrow" data-popper-arrow></div>
-                </div>
-              </dt>
-              <dd class="text-sm text-gray-700 dark:text-gray-300">
-                <div class="flex items-center gap-3">
-                  <div class="flex items-center gap-2">
+            </dt>
+            <dd class="text-sm text-gray-700 dark:text-gray-300">
+              <div class="flex items-center gap-3">
+                <div class="flex items-center gap-2">
+                  <div
+                    class="h-2 w-24 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
+                  >
                     <div
-                      class="h-2 w-24 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
-                    >
-                      <div
-                        class="h-full rounded-full bg-green-600 dark:bg-green-500 transition-all duration-500"
-                        style="width: {dataset.contentRating.ratingValue}%"
-                      ></div>
-                    </div>
-                    <span class="font-semibold text-gray-900 dark:text-white"
-                      >{dataset.contentRating.ratingValue}%</span
-                    >
+                      class="h-full rounded-full bg-green-600 dark:bg-green-500 transition-all duration-500"
+                      style="width: {dataset.contentRating.ratingValue}%"
+                    ></div>
                   </div>
+                  <span class="font-semibold text-gray-900 dark:text-white"
+                    >{dataset.contentRating.ratingValue}%</span
+                  >
                 </div>
-                {#if dataset.contentRating.ratingExplanation}
-                  <div class="mt-2 flex flex-wrap gap-1.5">
-                    {m.missing_properties()}:
-                    {#each displayMissingProperties(dataset.contentRating.ratingExplanation) as prop (prop)}
-                      <span
-                        class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-400"
-                      >
-                        {prop}
-                      </span>
-                    {/each}
-                  </div>
-                {/if}
-              </dd>
-            </div>
-          {/if}
-        </dl>
-      </div>
+              </div>
+              {#if dataset.contentRating.ratingExplanation}
+                <div class="mt-2 flex flex-wrap gap-1.5">
+                  {m.missing_properties()}:
+                  {#each displayMissingProperties(dataset.contentRating.ratingExplanation) as prop (prop)}
+                    <span
+                      class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-400"
+                    >
+                      {prop}
+                    </span>
+                  {/each}
+                </div>
+              {/if}
+            </dd>
+          </div>
+        {/if}
+      </dl>
     </div>
-  {/if}
-</div>
+  </div>
+</main>


### PR DESCRIPTION
## Summary

- **`<main>` landmark**: wrap page content in `<main>` instead of `<div>` for screen reader navigation
- **Standardize tooltips**: replace all `data-tooltip-target` / `initFlowbite()` patterns with Flowbite Svelte `<Tooltip triggeredBy>` component for a consistent, declarative approach
- **External link indicators**: add sr-only `opens_in_new_tab` text (EN/NL) to all `target="_blank"` links for screen reader users
- **URI overflow**: change `truncate` to `break-all` on dataset URI, landing page, and license fields so long URIs wrap instead of being clipped
- **Remove redundant guard**: remove `{#if dataset}` wrapper (data is always present from page load) and move `hasVoidStats` `@const` to a `$derived` in the script block