### PR TITLE
feat(core): validate distribution encoding format as MIME type

### DIFF
--- a/packages/core/test/datasets/dataset-schema-org-invalid-encoding-format.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-invalid-encoding-format.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "name": "Alba amicorum van de Koninklijke Bibliotheek",
+  "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://example.com/publisher",
+    "name": "Koninklijke Bibliotheek"
+  },
+  "distribution": {
+    "@type": "DataDownload",
+    "contentUrl": "http://example.com/download",
+    "encodingFormat": "PDF"
+  }
+}

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -237,6 +237,16 @@ describe('Validator', () => {
     expectViolations(report, ['https://schema.org/sameAs'], 2);
   });
 
+  it('reports invalid encoding format', async () => {
+    const report = await validate(
+      'dataset-schema-org-invalid-encoding-format.jsonld',
+    );
+    expect(report.state).toBe('invalid');
+    expectViolations(report as InvalidDataset, [
+      'https://schema.org/encodingFormat',
+    ]);
+  });
+
   it('reports missing class', async () => {
     const report = await validate(
       'dataset-schema-missing-publisher-class.ttl',

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -146,6 +146,7 @@ reg:DistributionShape
         reg:DistributionContentUrlProperty,
         reg:DistributionContentUrlIriProperty,
         reg:DistributionEncodingFormatProperty,
+        reg:DistributionEncodingFormatPatternProperty,
         # Recommended properties
         reg:SchemaDistributionNameProperty,
         reg:SchemaNameUniqueLangProperty,
@@ -411,6 +412,12 @@ reg:DistributionEncodingFormatProperty a sh:PropertyShape ;
     """@en ;
     sh:message "Een distributie moet minimaal één encoderingsformaat hebben"@nl, "A distribution must have at least one encoding format"@en ;
 .
+
+reg:DistributionEncodingFormatPatternProperty a sh:PropertyShape ;
+    sh:path schema:encodingFormat ;
+    sh:pattern "^[a-zA-Z]+/[a-zA-Z0-9][a-zA-Z0-9!#$&\\-^_.+]*$" ;
+    sh:message "Het encoderingsformaat moet een geldig MIME-type zijn (bijv. application/ld+json)"@nl,
+        "The encoding format must be a valid MIME type (e.g. application/ld+json)"@en .
 
 reg:SchemaDatasetProperty a sh:PropertyShape ;
     sh:path schema:dataset ;


### PR DESCRIPTION
## Summary

- Add a `sh:pattern` constraint on `schema:encodingFormat` that validates the value matches MIME type format (`type/subtype`), rejecting values like `"PDF"` or `"xml"`
- The new `reg:DistributionEncodingFormatPatternProperty` is a separate property shape from the existing `sh:minCount` shape, per the SHACL convention of splitting constraints with different failure modes
- The pattern accepts any properly formatted MIME type including compression suffixes (e.g. `text/turtle+gzip`)
- Add test data file and validator test for invalid encoding format

Fix #177