### PR TITLE
feat(core): validate canonical license URIs

### DIFF
--- a/packages/core/test/datasets/catalog-dcat-valid.jsonld
+++ b/packages/core/test/datasets/catalog-dcat-valid.jsonld
@@ -14,7 +14,7 @@
       "dct:keyword": [
         "alba amicorum"
       ],
-      "dct:license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "dct:license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "dct:publisher": {
         "@type": "foaf:Organization",
         "@id": "https://kb.nl/",

--- a/packages/core/test/datasets/catalog-schema-org-invalid.jsonld
+++ b/packages/core/test/datasets/catalog-schema-org-invalid.jsonld
@@ -7,7 +7,7 @@
       "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
       "name": "Alba amicorum van de Koninklijke Bibliotheek",
       "description": "Alba amicorum van de Koninklijke Bibliotheek, een dataset gedefinieerd voor het Europeana Rise of Literacy project.",
-      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "publisher": {
         "@type": "Organization",
         "@id": "https://www.openarch.nl/",

--- a/packages/core/test/datasets/catalog-schema-org-valid.jsonld
+++ b/packages/core/test/datasets/catalog-schema-org-valid.jsonld
@@ -27,7 +27,7 @@
           "@value": "Alba in English."
         }
       ],
-      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "publisher": {
         "@type": "Organization",
         "@id": "https://www.openarch.nl/",
@@ -46,7 +46,7 @@
       "@id": "https://example.com/dataset2",
       "name": "Dataset 2",
       "description": "Description is a plain string",
-      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "publisher": {
         "@type": "Organization",
         "@id": "https://www.openarch.nl/",

--- a/packages/core/test/datasets/dataset-dcat-invalid.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-invalid.jsonld
@@ -11,7 +11,7 @@
   "dct:keyword": [
     "alba amicorum"
   ],
-  "dct:license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "dct:license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "dct:creator": {
     "@type": "foaf:Organization",
     "foaf:name": "Koninklijke Bibliotheek",

--- a/packages/core/test/datasets/dataset-dcat-valid-minimal.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-valid-minimal.jsonld
@@ -7,7 +7,7 @@
   "@type": "dcat:Dataset",
   "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
   "dct:title": "Alba amicorum van de Koninklijke Bibliotheek",
-  "dct:license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "dct:license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "dct:publisher": {
     "@id": "https://example.com/dataset-provider",
     "@type": "foaf:Person",

--- a/packages/core/test/datasets/dataset-http-schema-org-invalid.jsonld
+++ b/packages/core/test/datasets/dataset-http-schema-org-invalid.jsonld
@@ -8,7 +8,7 @@
   "keywords": [
     "alba amicorum"
   ],
-  "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "publisher": {
     "@type": "Organization",
     "@id": "this-is-no-http-iri",

--- a/packages/core/test/datasets/dataset-http-schema-org-valid.jsonld
+++ b/packages/core/test/datasets/dataset-http-schema-org-valid.jsonld
@@ -8,7 +8,7 @@
   "keywords": [
     "alba amicorum"
   ],
-  "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "publisher": {
     "@type": "Organization",
     "@id": "https://www.kb.nl/",

--- a/packages/core/test/datasets/dataset-http-schema-org-valid.ttl
+++ b/packages/core/test/datasets/dataset-http-schema-org-valid.ttl
@@ -8,7 +8,7 @@
   schema:dateModified "2021-09-05"^^xsd:date ;
   schema:datePublished "2021-09-05"^^xsd:date ;
   schema:description "Combinatie van kadastrale perceelnummers uit 1832 met Verpondingsnummers uit het verpondingsregister 1875 en de plaatselijke aanduiding uit het verpondingsregister." ;
-  schema:license "http://creativecommons.org/publicdomain/zero/1.0/deed.nl"@nl ;
+  schema:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
   schema:publisher <https://www.goudatijdmachine.nl/data/api/items/232> ;
   schema:distribution <https://www.goudatijdmachine.nl/data/api/items/144> .
 

--- a/packages/core/test/datasets/dataset-schema-missing-publisher-class.ttl
+++ b/packages/core/test/datasets/dataset-schema-missing-publisher-class.ttl
@@ -3,7 +3,7 @@
 <https://data.example.org/id/dataset/test-alternate-names>
     a schema:Dataset ;
     schema:name "Test" ;
-    schema:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    schema:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
     schema:creator <https://example.org/organization/kb> ;
     schema:publisher <https://example.org/organization/kb> ;
     schema:distribution [

--- a/packages/core/test/datasets/dataset-schema-org-invalid-contactpoint.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-invalid-contactpoint.jsonld
@@ -3,7 +3,7 @@
   "@type": "Dataset",
   "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
   "name": "Alba amicorum van de Koninklijke Bibliotheek",
-  "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "publisher": {
     "@type": "Organization",
     "@id": "https://example.com/publisher",

--- a/packages/core/test/datasets/dataset-schema-org-invalid-encoding-format.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-invalid-encoding-format.jsonld
@@ -3,7 +3,7 @@
   "@type": "Dataset",
   "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
   "name": "Alba amicorum van de Koninklijke Bibliotheek",
-  "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "publisher": {
     "@type": "Organization",
     "@id": "https://example.com/publisher",

--- a/packages/core/test/datasets/dataset-schema-org-invalid-sameas.ttl
+++ b/packages/core/test/datasets/dataset-schema-org-invalid-sameas.ttl
@@ -3,7 +3,7 @@
 <https://data.example.org/id/dataset/test-sameas>
     a schema:Dataset ;
     schema:name "Test" ;
-    schema:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    schema:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
     schema:creator <https://example.org/organization/test> ;
     schema:publisher <https://example.org/organization/test> ;
     schema:distribution [

--- a/packages/core/test/datasets/dataset-schema-org-invalid.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-invalid.jsonld
@@ -12,7 +12,7 @@
   "dateCreated": "not a valid date",
   "datePublished": "2023-06-01T12:15",
   "dateModified": "2023-06-01 12:15",
-  "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "publisher": {
     "@type": "Organization",
     "url": "https://www.kb.nl/",

--- a/packages/core/test/datasets/dataset-schema-org-multiple-alternate-names.ttl
+++ b/packages/core/test/datasets/dataset-schema-org-multiple-alternate-names.ttl
@@ -3,7 +3,7 @@
 <https://data.example.org/id/dataset/test-alternate-names>
     a schema:Dataset ;
     schema:name "Test" ;
-    schema:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+    schema:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
     schema:creator <https://example.org/organization/kb> ;
     schema:publisher <https://example.org/organization/kb> ;
     schema:distribution [

--- a/packages/core/test/datasets/dataset-schema-org-valid-microdata.html
+++ b/packages/core/test/datasets/dataset-schema-org-valid-microdata.html
@@ -7,7 +7,7 @@
     >
       <span itemprop="name">Alba amicorum van de Koninklijke Bibliotheek</span>
       <span
-        itemid="http://creativecommons.org/publicdomain/zero/1.0/"
+        itemid="https://creativecommons.org/publicdomain/zero/1.0/"
         itemprop="license"
         >CC-0</span
       >

--- a/packages/core/test/datasets/dataset-schema-org-valid-minimal.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-valid-minimal.jsonld
@@ -3,7 +3,7 @@
   "@type": "Dataset",
   "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
   "name": "Alba amicorum van de Koninklijke Bibliotheek",
-  "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "publisher": {
     "@type": "Organization",
     "@id": "https://example.com/publisher",

--- a/packages/core/test/datasets/dataset-schema-org-valid-no-publisher.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-valid-no-publisher.jsonld
@@ -8,7 +8,7 @@
   "keywords": [
     "alba amicorum"
   ],
-  "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "creator": {
     "@type": "Organization",
     "@id": "https://www.kb.nl/",

--- a/packages/core/test/datasets/dataset-schema-org-valid-plus-organization.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-valid-plus-organization.jsonld
@@ -9,7 +9,7 @@
       "keywords": [
          "alba amicorum"
       ],
-      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "publisher": {
          "@id": "https://www.kb.nl/",
          "@type": "Organization",

--- a/packages/core/test/datasets/dataset-schema-org-valid-rdfa.html
+++ b/packages/core/test/datasets/dataset-schema-org-valid-rdfa.html
@@ -7,7 +7,7 @@
     >
       <span property="name">Alba amicorum van de Koninklijke Bibliotheek</span>
       <span
-        itemid="http://creativecommons.org/publicdomain/zero/1.0/"
+        itemid="https://creativecommons.org/publicdomain/zero/1.0/"
         property="license"
         >CC-0</span
       >

--- a/packages/core/test/datasets/dataset-schema-org-valid.ttl
+++ b/packages/core/test/datasets/dataset-schema-org-valid.ttl
@@ -8,7 +8,7 @@
   schema:dateModified "2021-09-05"^^xsd:date ;
   schema:datePublished "2021-09-05"^^xsd:date ;
   schema:description "Combinatie van kadastrale perceelnummers uit 1832 met Verpondingsnummers uit het verpondingsregister 1875 en de plaatselijke aanduiding uit het verpondingsregister." ;
-  schema:license "http://creativecommons.org/publicdomain/zero/1.0/deed.nl"@nl ;
+  schema:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
   schema:publisher <https://www.goudatijdmachine.nl/data/api/items/232> ;
   schema:distribution <https://www.goudatijdmachine.nl/data/api/items/144> .
 

--- a/packages/core/test/datasets/datasets-dcat-invalid.jsonld
+++ b/packages/core/test/datasets/datasets-dcat-invalid.jsonld
@@ -13,7 +13,7 @@
       "dct:keyword": [
         "alba amicorum"
       ],
-      "dct:license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "dct:license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "dct:creator": {
         "@type": "foaf:Organization",
         "foaf:name": "Koninklijke Bibliotheek",

--- a/packages/core/test/datasets/datasets-dcat-valid.jsonld
+++ b/packages/core/test/datasets/datasets-dcat-valid.jsonld
@@ -13,7 +13,7 @@
       "dct:keyword": [
         "alba amicorum"
       ],
-      "dct:license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "dct:license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "dct:publisher": {
         "@id": "https://www.kb.nl/",
         "@type": "foaf:Organization",

--- a/packages/core/test/datasets/datasets-schema-org-invalid.jsonld
+++ b/packages/core/test/datasets/datasets-schema-org-invalid.jsonld
@@ -7,7 +7,7 @@
       "name": "Valid dataset",
       "description": "Alba amicorum van de Koninklijke Bibliotheek, een dataset gedefinieerd voor het Europeana Rise of Literacy project.",
       "identifier": "http://data.bibliotheken.nl/id/dataset/rise-alba",
-      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "publisher": {
         "@type": "Organization",
         "url": "https://www.kb.nl/",

--- a/packages/core/test/datasets/datasets-schema-org-valid.jsonld
+++ b/packages/core/test/datasets/datasets-schema-org-valid.jsonld
@@ -7,7 +7,7 @@
       "name": "First valid dataset",
       "description": "Alba amicorum van de Koninklijke Bibliotheek, een dataset gedefinieerd voor het Europeana Rise of Literacy project.",
       "identifier": "http://data.bibliotheken.nl/id/dataset/rise-alba",
-      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "publisher": {
         "@type": "Organization",
         "@id": "https://www.kb.nl/",
@@ -28,7 +28,7 @@
       "name": "Second valid dataset",
       "description": "Alba amicorum van de Koninklijke Bibliotheek, een dataset gedefinieerd voor het Europeana Rise of Literacy project.",
       "identifier": "http://data.bibliotheken.nl/id/dataset/rise-alba",
-      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "publisher": {
         "@type": "Organization",
         "@id": "https://www.kb.nl/",

--- a/packages/core/test/datasets/hydra-page1.jsonld
+++ b/packages/core/test/datasets/hydra-page1.jsonld
@@ -32,7 +32,7 @@
           "@type": "Dataset",
           "@id": "https://example.com/dataset/1",
           "name": "Dataset 1",
-          "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+          "license": "https://creativecommons.org/publicdomain/zero/1.0/",
           "publisher": {
             "@id": "/publisher"
           }
@@ -41,7 +41,7 @@
           "@type": "Dataset",
           "@id": "https://example.com/dataset/2",
           "name": "Dataset 2",
-          "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+          "license": "https://creativecommons.org/publicdomain/zero/1.0/",
           "publisher": {
             "@id": "/publisher"
           }

--- a/packages/core/test/datasets/hydra-page2.jsonld
+++ b/packages/core/test/datasets/hydra-page2.jsonld
@@ -32,7 +32,7 @@
           "@type": "Dataset",
           "@id": "https://example.com/dataset/3",
           "name": "Dataset 3",
-          "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+          "license": "https://creativecommons.org/publicdomain/zero/1.0/",
           "publisher": {
             "@id": "/publisher"
           }

--- a/packages/core/test/datasets/hydra-page2.ttl
+++ b/packages/core/test/datasets/hydra-page2.ttl
@@ -25,7 +25,7 @@
   schema:dateModified "2021-09-05"^^xsd:date ;
   schema:datePublished "2022-09-05"^^xsd:date ;
   schema:description "Combinatie van kadastrale perceelnummers uit 1832 met Verpondingsnummers uit het verpondingsregister 1875 en de plaatselijke aanduiding uit het verpondingsregister." ;
-  schema:license <http://creativecommons.org/publicdomain/zero/1.0/deed.nl> ;
+  schema:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
   schema:publisher <https://www.goudatijdmachine.nl/data/api/items/232> ;
     schema:distribution <https://www.goudatijdmachine.nl/data/api/items/144> .
 

--- a/requirements/examples/dataset-schema-org-valid.jsonld
+++ b/requirements/examples/dataset-schema-org-valid.jsonld
@@ -22,7 +22,7 @@
       "genre": "Interesting data",
       "url": "https://www.kb.nl/bronnen-zoekwijzers/kb-collecties/moderne-handschriften-vanaf-ca-1550/alba-amicorum",
       "identifier": "http://data.bibliotheken.nl/id/dataset/rise-alba",
-      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
       "inLanguage": [
         "nl-NL",
         "en-GB"

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -264,7 +264,7 @@ reg:OrganizationShape
             sh:path schema:identifier ;
             sh:or (
                 [ sh:datatype xsd:string ]
-                [ 
+                [
                   sh:node reg:IdentifierShape ;
                   sh:class schema:PropertyValue ;
                ]
@@ -556,6 +556,10 @@ reg:SchemaDatasetLicenseProperty a sh:PropertyShape ;
     sh:nodeKind sh:IRIOrLiteral ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
+    sh:node _:LicenseCreativeCommonsHttpShape,
+        _:LicenseCreativeCommonsTrailingSlashShape,
+        _:LicenseNotOpenDefinitionShape,
+        _:LicenseOpenDataCommonsShape ;
     sh:name "Licentie"@nl, "License"@en ;
     sh:description "Licentie die van toepassing is op de dataset"@nl, """
         Publishers *MUST* make known under which [[DWBP#licenses|license]] the dataset may be used.
@@ -575,6 +579,40 @@ reg:SchemaDatasetLicenseProperty a sh:PropertyShape ;
         of https://creativecommons.org/publicdomain/zero/1.0/deed.nl.
         """@en ;
     sh:message "Een datasetbeschrijving moet één licentie bevatten (in de vorm van een URI)"@nl, "A dataset description must contain one license (in the form of a URI)"@en ;
+.
+
+_:LicenseCreativeCommonsHttpShape a sh:NodeShape ;
+    sh:not [ sh:pattern "^http://creativecommons\\.org/" ] ;
+    sh:severity sh:Warning ;
+    sh:message "Gebruik de canonieke Creative Commons licentie-URI met https:// (bijv. https://creativecommons.org/publicdomain/zero/1.0/)"@nl,
+        "Use the canonical Creative Commons license URI with https:// (e.g. https://creativecommons.org/publicdomain/zero/1.0/)"@en ;
+.
+
+_:LicenseCreativeCommonsTrailingSlashShape a sh:NodeShape ;
+    sh:or (
+        [ sh:not [ sh:pattern "^https://creativecommons\\.org/" ] ]
+        [ sh:pattern "^https://creativecommons\\.org/.+/$" ]
+    ) ;
+    sh:severity sh:Warning ;
+    sh:message "Gebruik de canonieke Creative Commons licentie-URI met een afsluitende slash (bijv. https://creativecommons.org/licenses/by/4.0/)"@nl,
+        "Use the canonical Creative Commons license URI with a trailing slash (e.g. https://creativecommons.org/licenses/by/4.0/)"@en ;
+.
+
+_:LicenseNotOpenDefinitionShape a sh:NodeShape ;
+    sh:not [ sh:pattern "^https?://www\\.opendefinition\\.org/licenses/" ] ;
+    sh:severity sh:Warning ;
+    sh:message "Gebruik de canonieke licentie-URI van de licentiegever zelf (bijv. https://creativecommons.org/licenses/by/4.0/), niet een opendefinition.org-alias"@nl,
+        "Use the canonical license URI from the license issuer itself (e.g. https://creativecommons.org/licenses/by/4.0/), not an opendefinition.org alias"@en ;
+.
+
+_:LicenseOpenDataCommonsShape a sh:NodeShape ;
+    sh:or (
+        [ sh:not [ sh:pattern "opendatacommons\\.org" ] ]
+        [ sh:pattern "^http://opendatacommons\\.org/licenses/[^/]+/[0-9]+\\.[0-9]+/$" ]
+    ) ;
+    sh:severity sh:Warning ;
+    sh:message "Gebruik de canonieke OpenDataCommons licentie-URI met versienummer (bijv. http://opendatacommons.org/licenses/odbl/1.0/)"@nl,
+        "Use the canonical OpenDataCommons license URI with version number (e.g. http://opendatacommons.org/licenses/odbl/1.0/)"@en ;
 .
 
 reg:SchemaDistributionLicenseProperty a sh:PropertyShape ;
@@ -664,7 +702,11 @@ dcat:DatasetShape
     [
         sh:minCount 1 ;
         sh:maxCount 1 ;
-        sh:path dc:license
+        sh:path dc:license ;
+        sh:node _:LicenseCreativeCommonsHttpShape,
+            _:LicenseCreativeCommonsTrailingSlashShape,
+            _:LicenseNotOpenDefinitionShape,
+            _:LicenseOpenDataCommonsShape ;
     ],
     [
         sh:path dc:created ;


### PR DESCRIPTION
Adds SHACL warning shapes to detect non-canonical license URIs, addressing #1141 and related patterns discovered by querying the public SPARQL endpoint.

## Changes

**`requirements/shacl.ttl`** — four new local blank-node shapes applied to both `schema:license` (Schema.org) and `dc:license` (DCAT):

- `_:LicenseCreativeCommonsHttpShape` — warns when a Creative Commons URI uses `http://` instead of the canonical `https://` (58 affected datasets in the register)
- `_:LicenseCreativeCommonsTrailingSlashShape` — warns when a Creative Commons URI is missing a trailing slash, e.g. `https://creativecommons.org/licenses/by/4.0` (11 datasets)
- `_:LicenseNotOpenDefinitionShape` — warns when an `opendefinition.org` alias is used instead of the canonical URI from the license issuer (29 datasets)
- `_:LicenseOpenDataCommonsShape` — warns when an OpenDataCommons URI doesn't follow the canonical form `http://opendatacommons.org/licenses/<name>/<version>/` (18 datasets)

All shapes use `sh:severity sh:Warning` and local blank nodes (`_:`) rather than named `reg:` IRIs, since they are internal constraints not intended for external reference.

**Test fixtures and examples** — all occurrences of `http://creativecommons.org/publicdomain/zero/1.0/` (including `deed.nl` variants) replaced with the canonical `https://creativecommons.org/publicdomain/zero/1.0/`.

Fix #1141
