### PR TITLE
fix(requirements): use component-prefixed release-please tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "include-component-in-tag": false,
+  "include-component-in-tag": true,
   "include-v-in-tag": false,
   "bump-minor-pre-major": true,
   "packages": {


### PR DESCRIPTION
Set `include-component-in-tag: true` so the tag is `requirements-1.0.0` instead of `1.0.0`, avoiding collisions with other components in the monorepo.

After merging, create a `requirements-1.0.0` tag on main to bootstrap the baseline so release-please only tracks commits after it. Then close #1678.