### PR TITLE
fix(browser): query knowledge graph directly instead of via QLever SERVICE

### DIFF
--- a/apps/browser/src/lib/components/RunSparqlButton.svelte
+++ b/apps/browser/src/lib/components/RunSparqlButton.svelte
@@ -13,21 +13,21 @@
 
   const ITEMS_PER_PAGE = 24;
 
-  // Generate SPARQL query from search request
-  const query = $derived(
-    datasetCardsQuery(searchRequest, ITEMS_PER_PAGE, 0, 'title', getLocale()),
-  );
+  let sparqlUrl = $state('');
 
-  // Clean and URL encode the query (preserving formatting)
-  const sparqlUrl = $derived(() => {
-    const cleanedQuery = cleanSparqlQuery(query);
-    const encodedQuery = encodeURIComponent(cleanedQuery);
-    return `https://qlever.netwerkdigitaalerfgoed.nl/?query=${encodedQuery}&exec=true`;
+  $effect(() => {
+    datasetCardsQuery(searchRequest, ITEMS_PER_PAGE, 0, 'title', getLocale())
+      .then((query) => {
+        const cleanedQuery = cleanSparqlQuery(query);
+        const encodedQuery = encodeURIComponent(cleanedQuery);
+        sparqlUrl = `https://qlever.netwerkdigitaalerfgoed.nl/?query=${encodedQuery}&exec=true`;
+      });
   });
 </script>
 
+{#if sparqlUrl}
 <a
-  href={sparqlUrl()}
+  href={sparqlUrl}
   target="_blank"
   rel="noopener noreferrer"
   class="group relative inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 border border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 rounded transition-colors focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
@@ -56,3 +56,4 @@
     />
   </svg>
 </a>
+{/if}

--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -3,10 +3,8 @@ import { dcterms, foaf, ldkit, schema, xsd } from 'ldkit/namespaces';
 import { createLens, type SchemaInterface } from 'ldkit';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { facetConfigs, type Facets, fetchFacets } from '$lib/services/facets';
-import {
-  PUBLIC_SPARQL_ENDPOINT,
-  PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
-} from '$env/static/public';
+// TODO: re-import PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT when fetchDatasetSizes is re-enabled
+import { PUBLIC_SPARQL_ENDPOINT } from '$env/static/public';
 import { voidNs } from '../rdf.js';
 import { getLocale } from '$lib/paraglide/runtime';
 import { normalizeMediaType } from '$lib/utils/sparql';

--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -3,7 +3,10 @@ import { dcterms, foaf, ldkit, schema, xsd } from 'ldkit/namespaces';
 import { createLens, type SchemaInterface } from 'ldkit';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { facetConfigs, type Facets, fetchFacets } from '$lib/services/facets';
-import { PUBLIC_SPARQL_ENDPOINT } from '$env/static/public';
+import {
+  PUBLIC_SPARQL_ENDPOINT,
+  PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+} from '$env/static/public';
 import { voidNs } from '../rdf.js';
 import { getLocale } from '$lib/paraglide/runtime';
 import { normalizeMediaType } from '$lib/utils/sparql';
@@ -170,7 +173,6 @@ export function datasetCardsQuery(
       dct:publisher ?publisher ;
       dct:license ?license ;
       dcat:distribution ?distribution ;
-      void:triples ?size ;
       schema:status ?status ;
       schema:datePosted ?datePosted .
     ?publisher a foaf:Agent ;
@@ -244,13 +246,6 @@ export function datasetCardsQuery(
       }
     }
 
-    # Fetch dataset size from Dataset Knowledge Graph via SPARQL Federation
-    OPTIONAL {
-      SERVICE <https://triplestore.netwerkdigitaalerfgoed.nl/repositories/dataset-knowledge-graph> {
-        ?dataset a void:Dataset ;
-          void:triples ?size .
-      }
-    }
   }
   ORDER BY ${orderByClause}
 `;
@@ -269,6 +264,40 @@ export interface SearchResults {
   facets: Facets;
   total: number;
   time: number;
+}
+
+async function fetchDatasetSizes(
+  datasetIris: string[],
+): Promise<Map<string, number>> {
+  if (datasetIris.length === 0) return new Map();
+
+  const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
+  const query = `
+    PREFIX void: <http://rdfs.org/ns/void#>
+    SELECT ?dataset ?size WHERE {
+      VALUES ?dataset { ${values} }
+      ?dataset a void:Dataset ;
+        void:triples ?size .
+    }
+  `;
+
+  const sizeMap = new Map<string, number>();
+  try {
+    const bindings = await fetcher.fetchBindings(
+      PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+      query,
+    );
+    for await (const binding of bindings) {
+      const typedBinding = binding as unknown as {
+        dataset: { value: string };
+        size: { value: string };
+      };
+      sizeMap.set(typedBinding.dataset.value, parseInt(typedBinding.size.value));
+    }
+  } catch (error) {
+    console.error('Dataset sizes query failed:', error);
+  }
+  return sizeMap;
 }
 
 async function fetchDatasetCards(
@@ -309,8 +338,15 @@ export async function fetchDatasets(
     fetchFacets(searchFilters),
   ]);
 
+  // Fetch dataset sizes from knowledge graph (sequential: needs dataset IRIs)
+  const sizes = await fetchDatasetSizes(datasets.map((d) => d.$id));
+  const datasetsWithSizes = datasets.map((dataset) => {
+    const size = sizes.get(dataset.$id);
+    return size !== undefined ? { ...dataset, size } : dataset;
+  });
+
   return {
-    datasets,
+    datasets: datasetsWithSizes,
     facets,
     total,
     time: performance.now() - startTime,

--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -2,7 +2,12 @@ import { dcat } from '@lde/dataset-registry-client';
 import { dcterms, foaf, ldkit, schema, xsd } from 'ldkit/namespaces';
 import { createLens, type SchemaInterface } from 'ldkit';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
-import { facetConfigs, type Facets, fetchFacets } from '$lib/services/facets';
+import {
+  facetConfigs,
+  fetchDatasetIrisFromKnowledgeGraph,
+  type Facets,
+  fetchFacets,
+} from '$lib/services/facets';
 import {
   PUBLIC_SPARQL_ENDPOINT,
   PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
@@ -127,11 +132,12 @@ export interface SearchRequest {
 }
 
 async function countDatasets(filters: SearchRequest) {
+  const filterQuery = await filterDatasets(filters);
   const query = `
   ${prefixes}
 
   SELECT (COUNT(DISTINCT ?dataset) as ?count) WHERE {
-    ${filterDatasets(filters)}
+    ${filterQuery}
   }`;
 
   try {
@@ -152,7 +158,7 @@ async function countDatasets(filters: SearchRequest) {
 
 export type OrderBy = 'title' | 'datePosted';
 
-export function datasetCardsQuery(
+export async function datasetCardsQuery(
   filters: SearchRequest,
   limit: number,
   offset = 0,
@@ -161,6 +167,7 @@ export function datasetCardsQuery(
 ) {
   const orderByClause =
     orderBy === 'datePosted' ? 'DESC(?datePosted)' : `?status ?titleForSort`;
+  const filterQuery = await filterDatasets(filters);
 
   return `
   ${prefixes}
@@ -185,7 +192,7 @@ export function datasetCardsQuery(
     # Inside the default graph, which contains the registry's metadata.
     {
       SELECT ?dataset ${orderBy === 'title' ? '(SAMPLE(?title_) AS ?titleForSort)' : '(SAMPLE(?datePosted_) AS ?datePosted)'} WHERE {
-        ${filterDatasets(filters)}
+        ${filterQuery}
 
         OPTIONAL {
           ?registrationUrl schema:validUntil ?validUntil .
@@ -251,12 +258,15 @@ export function datasetCardsQuery(
 `;
 }
 
-export const filterDatasets = (filters: SearchRequest, skipDefaults = false) =>
+export const filterDatasets = async (
+  filters: SearchRequest,
+  skipDefaults = false,
+) =>
   `?dataset a dcat:Dataset ;
     schema:subjectOf ?registrationUrl .
   filter(isuri(?dataset))
 
-  ${filterClauses(filters, skipDefaults)}
+  ${await filterClauses(filters, skipDefaults)}
 `;
 
 export interface SearchResults {
@@ -310,7 +320,7 @@ async function fetchDatasetCards(
   orderBy: OrderBy,
   locale: string,
 ): Promise<DatasetCard[]> {
-  const query = datasetCardsQuery(
+  const query = await datasetCardsQuery(
     searchFilters,
     limit,
     offset,
@@ -356,12 +366,12 @@ export async function fetchDatasets(
   };
 }
 
-function filterClauses(searchFilters: SearchRequest, skipDefaults = false) {
+async function filterClauses(searchFilters: SearchRequest, skipDefaults = false) {
   if (!searchFilters) {
     return '';
   }
 
-  const filterClausesArray: string[] = [];
+  const filterClausesArray: (string | Promise<string>)[] = [];
 
   const {
     query,
@@ -416,28 +426,25 @@ function filterClauses(searchFilters: SearchRequest, skipDefaults = false) {
   }
 
   if (size.min !== undefined || size.max !== undefined) {
+    // Query the knowledge graph directly instead of via QLever SERVICE federation.
     const sizeFilters: string[] = [];
-
-    // When filtering by size, require datasets to have size data (not OPTIONAL).
-    // This ensures only datasets with known sizes are returned in filtered results.
-    filterClausesArray.push(`
-      SERVICE <https://triplestore.netwerkdigitaalerfgoed.nl/repositories/dataset-knowledge-graph> {
-        ?dataset a void:Dataset ;
-          void:triples ?datasetSize .
-      }
-    `);
-
     if (size.min !== undefined) {
       sizeFilters.push(`?datasetSize >= ${size.min}`);
     }
     if (size.max !== undefined) {
       sizeFilters.push(`?datasetSize <= ${size.max}`);
     }
+    const sizeFilter =
+      sizeFilters.length > 0 ? `FILTER(${sizeFilters.join(' && ')})` : '';
 
-    if (sizeFilters.length > 0) {
-      filterClausesArray.push(`FILTER(${sizeFilters.join(' && ')})`);
-    }
+    filterClausesArray.push(
+      fetchDatasetIrisFromKnowledgeGraph(`
+        ?dataset a void:Dataset ;
+          void:triples ?datasetSize .
+        ${sizeFilter}
+      `),
+    );
   }
 
-  return filterClausesArray.join('\n  ');
+  return (await Promise.all(filterClausesArray)).join('\n  ');
 }

--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -9,7 +9,7 @@ import {
 } from '$env/static/public';
 import { voidNs } from '../rdf.js';
 import { getLocale } from '$lib/paraglide/runtime';
-import { normalizeMediaType } from '$lib/utils/sparql';
+import { inIris, normalizeMediaType } from '$lib/utils/sparql';
 
 export const SPARQL_ENDPOINT = PUBLIC_SPARQL_ENDPOINT;
 const fetcher = new SparqlEndpointFetcher();
@@ -271,7 +271,7 @@ async function fetchDatasetSizes(
 ): Promise<Map<string, number>> {
   if (datasetIris.length === 0) return new Map();
 
-  const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
+  const values = inIris(datasetIris);
   const query = `
     PREFIX void: <http://rdfs.org/ns/void#>
     SELECT ?dataset ?size WHERE {
@@ -292,7 +292,10 @@ async function fetchDatasetSizes(
         dataset: { value: string };
         size: { value: string };
       };
-      sizeMap.set(typedBinding.dataset.value, parseInt(typedBinding.size.value));
+      sizeMap.set(
+        typedBinding.dataset.value,
+        parseInt(typedBinding.size.value),
+      );
     }
   } catch (error) {
     console.error('Dataset sizes query failed:', error);

--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -266,39 +266,43 @@ export interface SearchResults {
   time: number;
 }
 
-async function fetchDatasetSizes(
-  datasetIris: string[],
-): Promise<Map<string, number>> {
-  if (datasetIris.length === 0) return new Map();
-
-  const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
-  const query = `
-    PREFIX void: <http://rdfs.org/ns/void#>
-    SELECT ?dataset ?size WHERE {
-      VALUES ?dataset { ${values} }
-      ?dataset a void:Dataset ;
-        void:triples ?size .
-    }
-  `;
-
-  const sizeMap = new Map<string, number>();
-  try {
-    const bindings = await fetcher.fetchBindings(
-      PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
-      query,
-    );
-    for await (const binding of bindings) {
-      const typedBinding = binding as unknown as {
-        dataset: { value: string };
-        size: { value: string };
-      };
-      sizeMap.set(typedBinding.dataset.value, parseInt(typedBinding.size.value));
-    }
-  } catch (error) {
-    console.error('Dataset sizes query failed:', error);
-  }
-  return sizeMap;
-}
+// TODO: re-enable once SERVICE federation OOM is resolved
+// async function fetchDatasetSizes(
+//   datasetIris: string[],
+// ): Promise<Map<string, number>> {
+//   if (datasetIris.length === 0) return new Map();
+//
+//   const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
+//   const query = `
+//     PREFIX void: <http://rdfs.org/ns/void#>
+//     SELECT ?dataset ?size WHERE {
+//       VALUES ?dataset { ${values} }
+//       ?dataset a void:Dataset ;
+//         void:triples ?size .
+//     }
+//   `;
+//
+//   const sizeMap = new Map<string, number>();
+//   try {
+//     const bindings = await fetcher.fetchBindings(
+//       PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+//       query,
+//     );
+//     for await (const binding of bindings) {
+//       const typedBinding = binding as unknown as {
+//         dataset: { value: string };
+//         size: { value: string };
+//       };
+//       sizeMap.set(
+//         typedBinding.dataset.value,
+//         parseInt(typedBinding.size.value),
+//       );
+//     }
+//   } catch (error) {
+//     console.error('Dataset sizes query failed:', error);
+//   }
+//   return sizeMap;
+// }
 
 async function fetchDatasetCards(
   searchFilters: SearchRequest,
@@ -338,15 +342,15 @@ export async function fetchDatasets(
     fetchFacets(searchFilters),
   ]);
 
-  // Fetch dataset sizes from knowledge graph (sequential: needs dataset IRIs)
-  const sizes = await fetchDatasetSizes(datasets.map((d) => d.$id));
-  const datasetsWithSizes = datasets.map((dataset) => {
-    const size = sizes.get(dataset.$id);
-    return size !== undefined ? { ...dataset, size } : dataset;
-  });
+  // TODO: re-enable once SERVICE federation OOM is resolved
+  // const sizes = await fetchDatasetSizes(datasets.map((d) => d.$id));
+  // const datasetsWithSizes = datasets.map((dataset) => {
+  //   const size = sizes.get(dataset.$id);
+  //   return size !== undefined ? { ...dataset, size } : dataset;
+  // });
 
   return {
-    datasets: datasetsWithSizes,
+    datasets,
     facets,
     total,
     time: performance.now() - startTime,

--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -3,8 +3,10 @@ import { dcterms, foaf, ldkit, schema, xsd } from 'ldkit/namespaces';
 import { createLens, type SchemaInterface } from 'ldkit';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { facetConfigs, type Facets, fetchFacets } from '$lib/services/facets';
-// TODO: re-import PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT when fetchDatasetSizes is re-enabled
-import { PUBLIC_SPARQL_ENDPOINT } from '$env/static/public';
+import {
+  PUBLIC_SPARQL_ENDPOINT,
+  PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+} from '$env/static/public';
 import { voidNs } from '../rdf.js';
 import { getLocale } from '$lib/paraglide/runtime';
 import { normalizeMediaType } from '$lib/utils/sparql';
@@ -220,22 +222,22 @@ export function datasetCardsQuery(
 
     ${orderBy === 'datePosted' ? 'OPTIONAL { ?registrationUrl schema:datePosted ?datePosted }' : ''}
 
-    OPTIONAL { 
-      ?registrationUrl schema:validUntil ?validUntil . 
-      BIND("archived" as ?status)  
+    OPTIONAL {
+      ?registrationUrl schema:validUntil ?validUntil .
+      BIND("archived" as ?status)
     }
-  
+
     # Inside the dataset named graph.
     GRAPH ?g {
       ?dataset dct:title ?title ;
         dct:publisher ?publisher .
-        
+
       ?publisher foaf:name ?publisherName .
-      
+
       OPTIONAL { ?dataset dct:description ?description }
       OPTIONAL { ?dataset dct:language ?language }
       OPTIONAL { ?dataset dct:license ?license }
-                 
+
       OPTIONAL {
         ?dataset dcat:distribution ?distribution .
         ?distribution dcat:mediaType ?rawMediaType .
@@ -264,43 +266,39 @@ export interface SearchResults {
   time: number;
 }
 
-// TODO: re-enable once SERVICE federation OOM is resolved
-// async function fetchDatasetSizes(
-//   datasetIris: string[],
-// ): Promise<Map<string, number>> {
-//   if (datasetIris.length === 0) return new Map();
-//
-//   const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
-//   const query = `
-//     PREFIX void: <http://rdfs.org/ns/void#>
-//     SELECT ?dataset ?size WHERE {
-//       VALUES ?dataset { ${values} }
-//       ?dataset a void:Dataset ;
-//         void:triples ?size .
-//     }
-//   `;
-//
-//   const sizeMap = new Map<string, number>();
-//   try {
-//     const bindings = await fetcher.fetchBindings(
-//       PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
-//       query,
-//     );
-//     for await (const binding of bindings) {
-//       const typedBinding = binding as unknown as {
-//         dataset: { value: string };
-//         size: { value: string };
-//       };
-//       sizeMap.set(
-//         typedBinding.dataset.value,
-//         parseInt(typedBinding.size.value),
-//       );
-//     }
-//   } catch (error) {
-//     console.error('Dataset sizes query failed:', error);
-//   }
-//   return sizeMap;
-// }
+async function fetchDatasetSizes(
+  datasetIris: string[],
+): Promise<Map<string, number>> {
+  if (datasetIris.length === 0) return new Map();
+
+  const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
+  const query = `
+    PREFIX void: <http://rdfs.org/ns/void#>
+    SELECT ?dataset ?size WHERE {
+      VALUES ?dataset { ${values} }
+      ?dataset a void:Dataset ;
+        void:triples ?size .
+    }
+  `;
+
+  const sizeMap = new Map<string, number>();
+  try {
+    const bindings = await fetcher.fetchBindings(
+      PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+      query,
+    );
+    for await (const binding of bindings) {
+      const typedBinding = binding as unknown as {
+        dataset: { value: string };
+        size: { value: string };
+      };
+      sizeMap.set(typedBinding.dataset.value, parseInt(typedBinding.size.value));
+    }
+  } catch (error) {
+    console.error('Dataset sizes query failed:', error);
+  }
+  return sizeMap;
+}
 
 async function fetchDatasetCards(
   searchFilters: SearchRequest,
@@ -340,15 +338,15 @@ export async function fetchDatasets(
     fetchFacets(searchFilters),
   ]);
 
-  // TODO: re-enable once SERVICE federation OOM is resolved
-  // const sizes = await fetchDatasetSizes(datasets.map((d) => d.$id));
-  // const datasetsWithSizes = datasets.map((dataset) => {
-  //   const size = sizes.get(dataset.$id);
-  //   return size !== undefined ? { ...dataset, size } : dataset;
-  // });
+  // Fetch dataset sizes directly from knowledge graph (not via QLever SERVICE)
+  const sizes = await fetchDatasetSizes(datasets.map((d) => d.$id));
+  const datasetsWithSizes = datasets.map((dataset) => {
+    const size = sizes.get(dataset.$id);
+    return size !== undefined ? { ...dataset, size } : dataset;
+  });
 
   return {
-    datasets,
+    datasets: datasetsWithSizes,
     facets,
     total,
     time: performance.now() - startTime,

--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -16,6 +16,7 @@ import { getLocale } from '$lib/paraglide/runtime';
 
 const fetcher = new SparqlEndpointFetcher();
 
+
 const FacetSchema = {
   '@type': voidNs.Dataset,
   value: rdf.value,
@@ -374,26 +375,30 @@ export const facetQuery = (facet: string, searchFiltersQuery: string) => `
 export async function fetchFacets(
   searchFilters: SearchRequest,
 ): Promise<Facets> {
-  // class, terminologySource, and sizeHistogram disabled: their SERVICE
-  // federation queries OOM QLever.
+  // class and terminologySource use dedicated two-step functions that query
+  // the knowledge graph directly (not via QLever SERVICE federation).
   const facetKeys = (Object.keys(facetConfigs) as Array<FacetKey>).filter(
     (key) => key !== 'class' && key !== 'terminologySource',
   );
 
-  // Fetch all facets in parallel and build the result object in one pass
-  const [facetEntries, sizeRange] = await Promise.all([
-    Promise.all(
-      facetKeys.map(
-        async (key) =>
-          [key, await fetchFacetValues(key, searchFilters)] as const,
+  const [facetEntries, classFacet, terminologySourceFacet, sizeRange, sizeHistogram] =
+    await Promise.all([
+      Promise.all(
+        facetKeys.map(
+          async (key) =>
+            [key, await fetchFacetValues(key, searchFilters)] as const,
+        ),
       ),
-    ),
-    fetchSizeRange(),
-  ]);
-  const sizeHistogram: HistogramBin[] = [];
+      fetchClassFacetValues(searchFilters),
+      fetchTerminologySourceFacetValues(searchFilters),
+      fetchSizeRange(),
+      fetchSizeHistogram(searchFilters),
+    ]);
 
   return {
     ...Object.fromEntries(facetEntries),
+    class: classFacet,
+    terminologySource: terminologySourceFacet,
     size: {
       range: sizeRange,
       bins: sizeHistogram,
@@ -425,6 +430,164 @@ export async function fetchFacetValues(
       '\nQuery:',
       query,
     );
+    return [];
+  }
+}
+
+/**
+ * Get filtered dataset IRIs from QLever (no SERVICE).
+ * Used as input for two-step facet queries that need knowledge graph data.
+ */
+async function fetchFilteredDatasetIris(
+  searchFilters: SearchRequest,
+  facet: string,
+): Promise<string[]> {
+  const searchFiltersExcludingFacet = { ...searchFilters, [facet]: [] };
+  const facetConfig = facetConfigs[facet as keyof typeof facetConfigs];
+  const skipDefaults = facetConfig?.defaultClause !== undefined;
+  const searchFiltersQuery = filterDatasets(
+    searchFiltersExcludingFacet,
+    skipDefaults,
+  );
+
+  const query = `
+    ${prefixes}
+    SELECT DISTINCT ?dataset WHERE {
+      ${searchFiltersQuery}
+    }
+  `;
+
+  const iris: string[] = [];
+  try {
+    const bindings = await fetcher.fetchBindings(PUBLIC_SPARQL_ENDPOINT, query);
+    for await (const binding of bindings) {
+      const typedBinding = binding as unknown as {
+        dataset: { value: string };
+      };
+      iris.push(typedBinding.dataset.value);
+    }
+  } catch (error) {
+    console.error(`Failed to fetch filtered dataset IRIs for "${facet}":`, error);
+  }
+  return iris;
+}
+
+/**
+ * Fetch class facet values by querying the knowledge graph directly.
+ * Two-step: get filtered dataset IRIs from QLever, then count classes from KG.
+ */
+async function fetchClassFacetValues(
+  searchFilters: SearchRequest,
+): Promise<CountedFacetValue[]> {
+  const datasetIris = await fetchFilteredDatasetIris(searchFilters, 'class');
+  if (datasetIris.length === 0) return [];
+
+  const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
+  const classGroupQueries = Object.keys(classGroups)
+    .map(
+      (group) => `UNION {
+        VALUES ?dataset { ${values} }
+        ?dataset void:classPartition ?partition .
+        ?partition void:class ?class .
+        FILTER(?class IN (${classGroups[group as keyof typeof classGroups].map((c) => `<${c}>`).join(', ')}))
+        BIND("${group}" AS ?value)
+      }`,
+    )
+    .join('\n');
+
+  const query = `
+    PREFIX void: <http://rdfs.org/ns/void#>
+    SELECT ?value (COUNT(DISTINCT ?dataset) AS ?count) WHERE {
+      {
+        VALUES ?dataset { ${values} }
+        ?dataset void:classPartition ?partition .
+        ?partition void:class ?value .
+      }
+      ${classGroupQueries}
+    }
+    GROUP BY ?value
+    ORDER BY DESC(?count) ?value
+  `;
+
+  try {
+    const bindings = await fetcher.fetchBindings(
+      PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+      query,
+    );
+
+    const results: CountedFacetValue[] = [];
+    for await (const binding of bindings) {
+      const typedBinding = binding as unknown as {
+        value: { value: string };
+        count: { value: string };
+      };
+      results.push({
+        $id: `urn:facet:${encodeURIComponent(typedBinding.value.value)}`,
+        value: typedBinding.value.value,
+        count: parseInt(typedBinding.count.value),
+      } as CountedFacetValue);
+    }
+    return results;
+  } catch (error) {
+    console.error('Class facet query failed:', error);
+    return [];
+  }
+}
+
+/**
+ * Fetch terminology source facet values by querying the knowledge graph directly.
+ * Two-step: get filtered dataset IRIs from QLever, then count terminology sources from KG.
+ */
+async function fetchTerminologySourceFacetValues(
+  searchFilters: SearchRequest,
+): Promise<CountedFacetValue[]> {
+  const datasetIris = await fetchFilteredDatasetIris(
+    searchFilters,
+    'terminologySource',
+  );
+  if (datasetIris.length === 0) return [];
+
+  const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
+  const query = `
+    PREFIX void: <http://rdfs.org/ns/void#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    SELECT ?value ?label (COUNT(DISTINCT ?dataset) AS ?count) WHERE {
+      VALUES ?dataset { ${values} }
+      [] a void:Linkset ;
+        void:subjectsTarget ?dataset ;
+        void:objectsTarget ?value .
+      OPTIONAL { ?value dct:title ?label }
+    }
+    GROUP BY ?value ?label
+    ORDER BY DESC(?count) ?value
+  `;
+
+  try {
+    const bindings = await fetcher.fetchBindings(
+      PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+      query,
+    );
+
+    const results: CountedFacetValue[] = [];
+    for await (const binding of bindings) {
+      const typedBinding = binding as unknown as {
+        value: { value: string };
+        label?: { value: string; 'xml:lang'?: string };
+        count: { value: string };
+      };
+      const label = typedBinding.label
+        ? { [typedBinding.label['xml:lang'] ?? '']: typedBinding.label.value }
+        : undefined;
+      results.push({
+        $id: `urn:facet:${encodeURIComponent(typedBinding.value.value)}`,
+        value: typedBinding.value.value,
+        label,
+        count: parseInt(typedBinding.count.value),
+      } as CountedFacetValue);
+    }
+    return results;
+  } catch (error) {
+    console.error('Terminology source facet query failed:', error);
     return [];
   }
 }
@@ -490,6 +653,10 @@ export async function fetchSizeRange(): Promise<FacetValueRange> {
  * Fetches histogram data showing the distribution of dataset sizes across logarithmic bins.
  * Applies current search filters (publisher, format, search query) but excludes size filters
  * to show the full distribution of matching datasets.
+ *
+ * Two-step approach to avoid QLever SERVICE federation OOM:
+ * 1. Get filtered dataset IRIs from QLever
+ * 2. Query knowledge graph directly for sizes, then bin client-side
  */
 export async function fetchSizeHistogram(
   searchFilters: SearchRequest,
@@ -500,52 +667,81 @@ export async function fetchSizeHistogram(
     size: { min: undefined, max: undefined },
   };
 
-  const query = `
+  // Step 1: Get filtered dataset IRIs from QLever
+  const datasetQuery = `
     ${prefixes}
-
-    SELECT ?bin (COUNT(DISTINCT ?dataset) as ?count) WHERE {
+    SELECT DISTINCT ?dataset WHERE {
       ${filterDatasets(filtersWithoutSize)}
-
-      SERVICE <${PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT}> {
-        ?dataset a void:Dataset ;
-          void:triples ?size .
-      }
-
-      # Bin sizes into logarithmic buckets using nested IF conditions
-      BIND(
-        IF(?size < 10, 0,
-        IF(?size < 100, 1,
-        IF(?size < 1000, 2,
-        IF(?size < 10000, 3,
-        IF(?size < 100000, 4,
-        IF(?size < 1000000, 5,
-        IF(?size < 10000000, 6,
-        IF(?size < 100000000, 7,
-        IF(?size < 1000000000, 8, 9)))))))))
-      as ?bin)
     }
-    GROUP BY ?bin
-    ORDER BY ?bin
   `;
 
   try {
-    const bindings = await fetcher.fetchBindings(PUBLIC_SPARQL_ENDPOINT, query);
+    const datasetBindings = await fetcher.fetchBindings(
+      PUBLIC_SPARQL_ENDPOINT,
+      datasetQuery,
+    );
 
-    const histogram: HistogramBin[] = [];
-    for await (const binding of bindings) {
+    const datasetIris: string[] = [];
+    for await (const binding of datasetBindings) {
       const typedBinding = binding as unknown as {
-        bin: { value: string };
-        count: { value: string };
+        dataset: { value: string };
       };
-      histogram.push({
-        bin: parseInt(typedBinding.bin.value),
-        count: parseInt(typedBinding.count.value),
-      });
+      datasetIris.push(typedBinding.dataset.value);
     }
 
-    return histogram;
+    if (datasetIris.length === 0) return [];
+
+    // Step 2: Query knowledge graph directly for sizes
+    const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
+    const sizeQuery = `
+      PREFIX void: <http://rdfs.org/ns/void#>
+      SELECT ?dataset ?size WHERE {
+        VALUES ?dataset { ${values} }
+        ?dataset a void:Dataset ;
+          void:triples ?size .
+      }
+    `;
+
+    const sizeBindings = await fetcher.fetchBindings(
+      PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+      sizeQuery,
+    );
+
+    // Step 3: Bin sizes client-side
+    const binCounts = new Map<number, number>();
+    for await (const binding of sizeBindings) {
+      const typedBinding = binding as unknown as {
+        size: { value: string };
+      };
+      const size = parseInt(typedBinding.size.value);
+      const bin =
+        size < 10
+          ? 0
+          : size < 100
+            ? 1
+            : size < 1000
+              ? 2
+              : size < 10000
+                ? 3
+                : size < 100000
+                  ? 4
+                  : size < 1000000
+                    ? 5
+                    : size < 10000000
+                      ? 6
+                      : size < 100000000
+                        ? 7
+                        : size < 1000000000
+                          ? 8
+                          : 9;
+      binCounts.set(bin, (binCounts.get(bin) ?? 0) + 1);
+    }
+
+    return Array.from(binCounts.entries())
+      .map(([bin, count]) => ({ bin, count }))
+      .sort((a, b) => a.bin - b.bin);
   } catch (error) {
-    console.error('Size histogram query failed:', error, '\nQuery:', query);
+    console.error('Size histogram query failed:', error);
     return [];
   }
 }

--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -374,11 +374,11 @@ export const facetQuery = (facet: string, searchFiltersQuery: string) => `
 export async function fetchFacets(
   searchFilters: SearchRequest,
 ): Promise<Facets> {
-  // TODO: re-enable class, terminologySource, and sizeHistogram once SERVICE
-  // federation OOM is resolved — all three use SERVICE through QLever.
-  const facetKeys = (
-    Object.keys(facetConfigs) as Array<FacetKey>
-  ).filter((key) => key !== 'class' && key !== 'terminologySource');
+  // class, terminologySource, and sizeHistogram disabled: their SERVICE
+  // federation queries OOM QLever.
+  const facetKeys = (Object.keys(facetConfigs) as Array<FacetKey>).filter(
+    (key) => key !== 'class' && key !== 'terminologySource',
+  );
 
   // Fetch all facets in parallel and build the result object in one pass
   const [facetEntries, sizeRange] = await Promise.all([

--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -16,6 +16,44 @@ import { getLocale } from '$lib/paraglide/runtime';
 
 const fetcher = new SparqlEndpointFetcher();
 
+/**
+ * Query the knowledge graph directly for dataset IRIs matching a pattern,
+ * and return a VALUES clause for use in QLever queries.
+ * Replaces SERVICE federation which causes QLever OOM.
+ */
+export async function fetchDatasetIrisFromKnowledgeGraph(
+  whereClause: string,
+): Promise<string> {
+  const query = `
+    PREFIX void: <http://rdfs.org/ns/void#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    SELECT DISTINCT ?dataset WHERE {
+      ${whereClause}
+    }
+  `;
+
+  try {
+    const bindings = await fetcher.fetchBindings(
+      PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+      query,
+    );
+
+    const iris: string[] = [];
+    for await (const binding of bindings) {
+      const typedBinding = binding as unknown as {
+        dataset: { value: string };
+      };
+      iris.push(typedBinding.dataset.value);
+    }
+
+    if (iris.length === 0) return 'FILTER(false)';
+    return `VALUES ?dataset { ${inIris(iris)} }`;
+  } catch (error) {
+    console.error('Knowledge graph filter query failed:', error);
+    return 'FILTER(false)';
+  }
+}
+
 const FacetSchema = {
   '@type': voidNs.Dataset,
   value: rdf.value,
@@ -159,7 +197,7 @@ interface FacetConfig {
   /**
    * Function that takes selected values and returns a SPARQL FILTER clause.
    */
-  filterClause: (values: string[]) => string;
+  filterClause: (values: string[]) => string | Promise<string>;
 
   /**
    * Default SPARQL clause applied when filter is empty (for dataset queries only).
@@ -303,11 +341,11 @@ export const facetConfigs: Record<string, FacetConfig> = {
 
       const classValues = selectedClasses.map((c) => `<${c}>`).join(', ');
 
-      return `SERVICE <${PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT}> {
+      return fetchDatasetIrisFromKnowledgeGraph(`
         ?dataset void:classPartition ?partition .
         ?partition void:class ?class .
         FILTER(?class IN (${classValues}))
-      }`;
+      `);
     },
   },
   terminologySource: {
@@ -326,12 +364,12 @@ export const facetConfigs: Record<string, FacetConfig> = {
 
       const sourceValues = values.map((s) => `<${s}>`).join(', ');
 
-      return `SERVICE <${PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT}> {
+      return fetchDatasetIrisFromKnowledgeGraph(`
         [] a void:Linkset ;
           void:subjectsTarget ?dataset ;
           void:objectsTarget ?terminologySource .
         FILTER(?terminologySource IN (${sourceValues}))
-      }`;
+      `);
     },
   },
 };
@@ -419,7 +457,7 @@ export async function fetchFacetValues(
   // Skip defaultClause for facets that have one (so they can show all values)
   const facetConfig = facetConfigs[facet as keyof typeof facetConfigs];
   const skipDefaults = facetConfig?.defaultClause !== undefined;
-  const searchFiltersQuery = filterDatasets(
+  const searchFiltersQuery = await filterDatasets(
     searchFiltersExcludingFacet,
     skipDefaults,
   );
@@ -449,7 +487,7 @@ async function fetchFilteredDatasetIris(
   const searchFiltersExcludingFacet = { ...searchFilters, [facet]: [] };
   const facetConfig = facetConfigs[facet as keyof typeof facetConfigs];
   const skipDefaults = facetConfig?.defaultClause !== undefined;
-  const searchFiltersQuery = filterDatasets(
+  const searchFiltersQuery = await filterDatasets(
     searchFiltersExcludingFacet,
     skipDefaults,
   );
@@ -672,11 +710,13 @@ export async function fetchSizeHistogram(
     ...searchFilters,
     size: { min: undefined, max: undefined },
   };
-  const datasetIris = await fetchFilteredDatasetIris(filtersWithoutSize, 'size');
+  const datasetIris = await fetchFilteredDatasetIris(
+    filtersWithoutSize,
+    'size',
+  );
   if (datasetIris.length === 0) return [];
 
   try {
-
     // Step 2: Query knowledge graph directly for sizes
     const values = inIris(datasetIris);
     const sizeQuery = `

--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -11,11 +11,10 @@ import { getLocalizedValue } from '$lib/utils/i18n';
 import * as m from '$lib/paraglide/messages';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { voidNs } from '../rdf.js';
-import { inLiterals, normalizeMediaType } from '$lib/utils/sparql';
+import { inIris, inLiterals, normalizeMediaType } from '$lib/utils/sparql';
 import { getLocale } from '$lib/paraglide/runtime';
 
 const fetcher = new SparqlEndpointFetcher();
-
 
 const FacetSchema = {
   '@type': voidNs.Dataset,
@@ -381,19 +380,24 @@ export async function fetchFacets(
     (key) => key !== 'class' && key !== 'terminologySource',
   );
 
-  const [facetEntries, classFacet, terminologySourceFacet, sizeRange, sizeHistogram] =
-    await Promise.all([
-      Promise.all(
-        facetKeys.map(
-          async (key) =>
-            [key, await fetchFacetValues(key, searchFilters)] as const,
-        ),
+  const [
+    facetEntries,
+    classFacet,
+    terminologySourceFacet,
+    sizeRange,
+    sizeHistogram,
+  ] = await Promise.all([
+    Promise.all(
+      facetKeys.map(
+        async (key) =>
+          [key, await fetchFacetValues(key, searchFilters)] as const,
       ),
-      fetchClassFacetValues(searchFilters),
-      fetchTerminologySourceFacetValues(searchFilters),
-      fetchSizeRange(),
-      fetchSizeHistogram(searchFilters),
-    ]);
+    ),
+    fetchClassFacetValues(searchFilters),
+    fetchTerminologySourceFacetValues(searchFilters),
+    fetchSizeRange(),
+    fetchSizeHistogram(searchFilters),
+  ]);
 
   return {
     ...Object.fromEntries(facetEntries),
@@ -467,7 +471,10 @@ async function fetchFilteredDatasetIris(
       iris.push(typedBinding.dataset.value);
     }
   } catch (error) {
-    console.error(`Failed to fetch filtered dataset IRIs for "${facet}":`, error);
+    console.error(
+      `Failed to fetch filtered dataset IRIs for "${facet}":`,
+      error,
+    );
   }
   return iris;
 }
@@ -482,12 +489,10 @@ async function fetchClassFacetValues(
   const datasetIris = await fetchFilteredDatasetIris(searchFilters, 'class');
   if (datasetIris.length === 0) return [];
 
-  const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
-  const classGroupQueries = Object.keys(classGroups)
+  const values = inIris(datasetIris);
+  const classGroupBinds = Object.keys(classGroups)
     .map(
       (group) => `UNION {
-        VALUES ?dataset { ${values} }
-        ?dataset void:classPartition ?partition .
         ?partition void:class ?class .
         FILTER(?class IN (${classGroups[group as keyof typeof classGroups].map((c) => `<${c}>`).join(', ')}))
         BIND("${group}" AS ?value)
@@ -498,12 +503,12 @@ async function fetchClassFacetValues(
   const query = `
     PREFIX void: <http://rdfs.org/ns/void#>
     SELECT ?value (COUNT(DISTINCT ?dataset) AS ?count) WHERE {
+      VALUES ?dataset { ${values} }
+      ?dataset void:classPartition ?partition .
       {
-        VALUES ?dataset { ${values} }
-        ?dataset void:classPartition ?partition .
         ?partition void:class ?value .
       }
-      ${classGroupQueries}
+      ${classGroupBinds}
     }
     GROUP BY ?value
     ORDER BY DESC(?count) ?value
@@ -547,18 +552,18 @@ async function fetchTerminologySourceFacetValues(
   );
   if (datasetIris.length === 0) return [];
 
-  const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
+  const values = inIris(datasetIris);
   const query = `
     PREFIX void: <http://rdfs.org/ns/void#>
     PREFIX dct: <http://purl.org/dc/terms/>
-    SELECT ?value ?label (COUNT(DISTINCT ?dataset) AS ?count) WHERE {
+    SELECT ?value (SAMPLE(?label_) AS ?label) (COUNT(DISTINCT ?dataset) AS ?count) WHERE {
       VALUES ?dataset { ${values} }
       [] a void:Linkset ;
         void:subjectsTarget ?dataset ;
         void:objectsTarget ?value .
-      OPTIONAL { ?value dct:title ?label }
+      OPTIONAL { ?value dct:title ?label_ }
     }
-    GROUP BY ?value ?label
+    GROUP BY ?value
     ORDER BY DESC(?count) ?value
   `;
 
@@ -661,38 +666,19 @@ export async function fetchSizeRange(): Promise<FacetValueRange> {
 export async function fetchSizeHistogram(
   searchFilters: SearchRequest,
 ): Promise<HistogramBin[]> {
-  // Remove size filters for histogram - we want to show full distribution
+  // Remove size filters for histogram - we want to show full distribution.
+  // Use a dummy facet key so fetchFilteredDatasetIris clears it.
   const filtersWithoutSize = {
     ...searchFilters,
     size: { min: undefined, max: undefined },
   };
-
-  // Step 1: Get filtered dataset IRIs from QLever
-  const datasetQuery = `
-    ${prefixes}
-    SELECT DISTINCT ?dataset WHERE {
-      ${filterDatasets(filtersWithoutSize)}
-    }
-  `;
+  const datasetIris = await fetchFilteredDatasetIris(filtersWithoutSize, 'size');
+  if (datasetIris.length === 0) return [];
 
   try {
-    const datasetBindings = await fetcher.fetchBindings(
-      PUBLIC_SPARQL_ENDPOINT,
-      datasetQuery,
-    );
-
-    const datasetIris: string[] = [];
-    for await (const binding of datasetBindings) {
-      const typedBinding = binding as unknown as {
-        dataset: { value: string };
-      };
-      datasetIris.push(typedBinding.dataset.value);
-    }
-
-    if (datasetIris.length === 0) return [];
 
     // Step 2: Query knowledge graph directly for sizes
-    const values = datasetIris.map((iri) => `<${iri}>`).join(' ');
+    const values = inIris(datasetIris);
     const sizeQuery = `
       PREFIX void: <http://rdfs.org/ns/void#>
       SELECT ?dataset ?size WHERE {
@@ -714,26 +700,7 @@ export async function fetchSizeHistogram(
         size: { value: string };
       };
       const size = parseInt(typedBinding.size.value);
-      const bin =
-        size < 10
-          ? 0
-          : size < 100
-            ? 1
-            : size < 1000
-              ? 2
-              : size < 10000
-                ? 3
-                : size < 100000
-                  ? 4
-                  : size < 1000000
-                    ? 5
-                    : size < 10000000
-                      ? 6
-                      : size < 100000000
-                        ? 7
-                        : size < 1000000000
-                          ? 8
-                          : 9;
+      const bin = Math.min(Math.floor(Math.log10(Math.max(size, 1))), 9);
       binCounts.set(bin, (binCounts.get(bin) ?? 0) + 1);
     }
 

--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -374,10 +374,14 @@ export const facetQuery = (facet: string, searchFiltersQuery: string) => `
 export async function fetchFacets(
   searchFilters: SearchRequest,
 ): Promise<Facets> {
-  const facetKeys = Object.keys(facetConfigs) as Array<FacetKey>;
+  // TODO: re-enable class, terminologySource, and sizeHistogram once SERVICE
+  // federation OOM is resolved — all three use SERVICE through QLever.
+  const facetKeys = (
+    Object.keys(facetConfigs) as Array<FacetKey>
+  ).filter((key) => key !== 'class' && key !== 'terminologySource');
 
   // Fetch all facets in parallel and build the result object in one pass
-  const [facetEntries, sizeRange, sizeHistogram] = await Promise.all([
+  const [facetEntries, sizeRange] = await Promise.all([
     Promise.all(
       facetKeys.map(
         async (key) =>
@@ -385,8 +389,8 @@ export async function fetchFacets(
       ),
     ),
     fetchSizeRange(),
-    fetchSizeHistogram(searchFilters),
   ]);
+  const sizeHistogram: HistogramBin[] = [];
 
   return {
     ...Object.fromEntries(facetEntries),

--- a/apps/browser/src/lib/utils/sparql.ts
+++ b/apps/browser/src/lib/utils/sparql.ts
@@ -45,6 +45,9 @@ function isIriTerm(term: unknown): term is IriTerm {
 export const inLiterals = (values: string[]) =>
   values.map((v) => `"${v}"`).join(', ');
 
+export const inIris = (iris: string[]) =>
+  iris.map((iri) => `<${iri}>`).join(' ');
+
 const IANA_MEDIA_TYPES_PREFIX = 'https://www.iana.org/assignments/media-types/';
 
 /**


### PR DESCRIPTION
## Summary

- Remove all SPARQL `SERVICE` federation from browser queries to prevent QLever OOM crashes
- Query the Dataset Knowledge Graph endpoint directly from the browser instead
- All knowledge graph queries use `VALUES` clauses scoped to relevant dataset IRIs

## Changes

### Dataset card sizes (`datasets.ts`)
- Remove `OPTIONAL { SERVICE ... }` for `void:triples` from the CONSTRUCT query
- Add `fetchDatasetSizes()` that queries the knowledge graph directly, scoped to the current page's dataset IRIs

### Facet counts (`facets.ts`)
- Add `fetchClassFacetValues()` and `fetchTerminologySourceFacetValues()` as two-step functions: get filtered IRIs from QLever, then count from knowledge graph
- Rewrite `fetchSizeHistogram()` with client-side logarithmic binning
- Add shared `fetchFilteredDatasetIris()` and `fetchDatasetIrisFromKnowledgeGraph()` helpers
- Fix terminology source duplicate keys (`SAMPLE(?label)` + `GROUP BY ?value`)
- Fix class facet 413 error (VALUES clause once instead of in every UNION branch)

### Filter clauses (`datasets.ts`)
- Make `filterDatasets()` and `filterClauses()` async
- Replace `SERVICE` in class, terminology source, and size filter clauses with `VALUES` from direct knowledge graph queries

### Other
- Extract `inIris()` utility for SPARQL VALUES formatting (`sparql.ts`)
- Update `RunSparqlButton.svelte` for async `datasetCardsQuery()`
- Replace nested ternary binning with `Math.log10`

## Prerequisites

Requires CORS headers on `triplestore.netwerkdigitaalerfgoed.nl` (deployed via infrastructure PRs #188, #189, #190).
