### PR TITLE
ci: use shared workflows for dependabot, nx-migrate, and release-please

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,22 +1,9 @@
-name: Dependabot auto-merge
-on: pull_request_target
+name: Auto-merge Dependabot PRs
 
-permissions:
-  pull-requests: write
-  contents: write
+on:
+  pull_request:
 
 jobs:
-  dependabot:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2.5.0
-        with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-      - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  auto-merge:
+    uses: netwerk-digitaal-erfgoed/workflows/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit

--- a/.github/workflows/nx-migrate.yml
+++ b/.github/workflows/nx-migrate.yml
@@ -1,0 +1,11 @@
+name: Nx migrate
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    uses: netwerk-digitaal-erfgoed/workflows/.github/workflows/nx-migrate.yml@main
+    secrets: inherit

--- a/.github/workflows/requirements-release-please.yml
+++ b/.github/workflows/requirements-release-please.yml
@@ -6,14 +6,9 @@ on:
       - main
       - release-please--branches--main**
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     uses: netwerk-digitaal-erfgoed/workflows/.github/workflows/release-please.yml@main
     with:
       working-directory: requirements
-    secrets:
-      token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
Use shared workflows from netwerk-digitaal-erfgoed/workflows: replace standalone dependabot auto-merge, add nx-migrate caller, and switch release-please to secrets: inherit.