### PR TITLE
fix(requirements): set explicit component name for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "packages": {
     "requirements": {
       "release-type": "simple",
+      "component": "requirements",
       "initial-version": "1.0.0",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
Without an explicit `component` setting, Release Please doesn\u2019t apply the `requirements-` prefix when resolving the previous release tag for changelog generation. This causes the release PR (#1688) to compare against a non-existent `1.0.0` tag instead of `requirements-1.0.0`, pulling in the entire commit history.

After merging, close #1688 so Release Please regenerates it with the correct changelog.