### PR TITLE
fix(browser): limit distributions on dataset detail page

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -180,6 +180,7 @@
   "detail_gone": "Gone",
   "detail_verified_tooltip": "This distribution has been validated by the Dataset Knowledge Graph.",
   "detail_distributions_tooltip": "Distributions provide access to the data.",
+  "detail_distributions_showing": "Showing {shown} of {total} distributions.",
   "lang_badge_also_in": "Also in {lang}:",
   "lang_badge_unspecified": "Unspecified",
   "detail_is_part_of": "Part of",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -180,6 +180,7 @@
   "detail_gone": "Verdwenen",
   "detail_verified_tooltip": "Deze distributie is gevalideerd door de Dataset Knowledge Graph.",
   "detail_distributions_tooltip": "Distributies geven toegang tot de data.",
+  "detail_distributions_showing": "{shown} van {total} distributies getoond.",
   "lang_badge_also_in": "Ook in het {lang}:",
   "lang_badge_unspecified": "Niet gespecificeerd",
   "detail_is_part_of": "Onderdeel van",

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -1,6 +1,7 @@
 import { dcat } from '@lde/dataset-registry-client';
 import { dcterms, foaf, ldkit, schema, xsd } from 'ldkit/namespaces';
 import { createLens, type SchemaInterface } from 'ldkit';
+import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { error } from '@sveltejs/kit';
 import { owlNs, voidExtNs, voidNs } from '../rdf.js';
 import { BaseDatasetSchema, BaseDistributionSchema } from './datasets.js';
@@ -111,12 +112,6 @@ export const DatasetDetailSchema = {
   landingPage: {
     '@id': 'http://www.w3.org/ns/dcat#landingPage',
     '@optional': true,
-  },
-  distribution: {
-    '@id': dcat.distribution,
-    '@optional': true,
-    '@array': true,
-    '@schema': DetailDistributionSchema,
   },
   publisher: {
     '@id': dcterms.publisher,
@@ -348,10 +343,30 @@ export type DatasetSummary = SchemaInterface<typeof DatasetSummarySchema> & {
   classPartition: ClassPartitionResult['classPartition'] | null;
 };
 
+const DISTRIBUTION_LIMIT = 20;
+
 export interface DatasetDetailResult {
   dataset: DatasetDetail;
+  distributions: DistributionDetail[];
+  totalDistributions: number;
   summary: DatasetSummary | null;
   linksets: Linkset[];
+}
+
+const fetcher = new SparqlEndpointFetcher();
+
+async function fetchDistributionCount(query: string): Promise<number> {
+  const bindingsStream = await fetcher.fetchBindings(
+    PUBLIC_SPARQL_ENDPOINT,
+    query,
+  );
+  for await (const bindings of bindingsStream) {
+    const count = bindings['count'];
+    if (count && 'value' in count) {
+      return parseInt(count.value as string, 10);
+    }
+  }
+  return 0;
 }
 
 // Main function to fetch all dataset detail data
@@ -380,8 +395,66 @@ export async function fetchDatasetDetail(
     sources: [PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT],
   });
 
-  const [dataset, summary, linksets, classPartitionResult] = await Promise.all([
+  const distributionLens = createLens(DetailDistributionSchema, {
+    sources: [PUBLIC_SPARQL_ENDPOINT],
+  });
+
+  const distributionQuery = `
+    PREFIX dcat: <http://www.w3.org/ns/dcat#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX ldkit: <https://ldkit.io/ontology/>
+
+    CONSTRUCT {
+      ?distribution a dcat:Distribution, ldkit:Resource ;
+        dcat:accessURL ?accessURL ;
+        dct:title ?title ;
+        dct:description ?description ;
+        dcat:mediaType ?rawMediaType ;
+        dct:format ?format ;
+        dct:issued ?issued ;
+        dct:modified ?modified ;
+        dcat:byteSize ?byteSize ;
+        dct:conformsTo ?conformsTo ;
+        dct:license ?license .
+    }
+    WHERE {
+      GRAPH ?g {
+        <${datasetUri}> dcat:distribution ?distribution .
+        ?distribution dcat:accessURL ?accessURL .
+        OPTIONAL { ?distribution dct:title ?title }
+        OPTIONAL { ?distribution dct:description ?description }
+        OPTIONAL { ?distribution dcat:mediaType ?rawMediaType }
+        OPTIONAL { ?distribution dct:format ?format }
+        OPTIONAL { ?distribution dct:issued ?issued }
+        OPTIONAL { ?distribution dct:modified ?modified }
+        OPTIONAL { ?distribution dcat:byteSize ?byteSize }
+        OPTIONAL { ?distribution dct:conformsTo ?conformsTo }
+        OPTIONAL { ?distribution dct:license ?license }
+      }
+    }
+    LIMIT ${DISTRIBUTION_LIMIT}
+  `;
+
+  const distributionCountQuery = `
+    SELECT (COUNT(DISTINCT ?distribution) AS ?count)
+    WHERE {
+      GRAPH ?g {
+        <${datasetUri}> <http://www.w3.org/ns/dcat#distribution> ?distribution .
+      }
+    }
+  `;
+
+  const [
+    dataset,
+    distributions,
+    totalDistributions,
+    summary,
+    linksets,
+    classPartitionResult,
+  ] = await Promise.all([
     detailLens.findByIri(datasetUri),
+    distributionLens.query(distributionQuery),
+    fetchDistributionCount(distributionCountQuery),
     summaryLens.findByIri(datasetUri).catch((e: unknown) => {
       console.error(
         'Summary query failed:',
@@ -407,6 +480,8 @@ export async function fetchDatasetDetail(
 
   return {
     dataset,
+    distributions,
+    totalDistributions,
     summary: summaryWithClassPartition,
     linksets,
   };

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -43,6 +43,8 @@
   // Data is loaded server-side via +page.ts for SEO
   const { data }: { data: DatasetDetailResult } = $props();
   const dataset = $derived(data.dataset);
+  const distributions = $derived(data.distributions);
+  const totalDistributions = $derived(data.totalDistributions);
   const summary = $derived(data.summary);
   const linksets = $derived(data.linksets);
 
@@ -101,22 +103,20 @@
 
   // Sort distributions: SPARQL first, then RDF (verified first), then others
   const sortedDistributions = $derived(
-    dataset.distribution
-      ? [...dataset.distribution].sort((a, b) => {
-          // Priority: SPARQL (2) > RDF (1) > other (0), then verified first
-          const priority = (d: typeof a) => {
-            if (isSparqlDistribution(d)) return 2;
-            if (isRdfDistribution(d)) return 1;
-            return 0;
-          };
-          const isVerified = (d: typeof a) => verifiedUrls.has(d.accessURL);
+    [...distributions].sort((a, b) => {
+      // Priority: SPARQL (2) > RDF (1) > other (0), then verified first
+      const priority = (d: typeof a) => {
+        if (isSparqlDistribution(d)) return 2;
+        if (isRdfDistribution(d)) return 1;
+        return 0;
+      };
+      const isVerified = (d: typeof a) => verifiedUrls.has(d.accessURL);
 
-          return (
-            priority(b) - priority(a) ||
-            Number(isVerified(b)) - Number(isVerified(a))
-          );
-        })
-      : [],
+      return (
+        priority(b) - priority(a) ||
+        Number(isVerified(b)) - Number(isVerified(a))
+      );
+    }),
   );
 
   const sparqlDistributions = $derived(
@@ -1136,6 +1136,14 @@
           </div>
         {/if}
       </div>
+      {#if totalDistributions > sortedDistributions.length}
+        <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+          {m.detail_distributions_showing({
+            shown: sortedDistributions.length.toString(),
+            total: totalDistributions.toString(),
+          })}
+        </p>
+      {/if}
     </div>
   {/if}
 


### PR DESCRIPTION
## Summary

- Fix 500 error on dataset detail page for datasets with many distributions (e.g. 13,789 for `https://hdl.handle.net/10622/LVXSBW`)
- Split distribution fetching into a separate CONSTRUCT query with `LIMIT 20`, since LDkit's `findByIri` doesn't support limiting nested results
- Add a COUNT query to retrieve the total number of distributions
- Show "Showing X of Y distributions" when the result is truncated

Fix #1686
