### PR TITLE
fix(browser): add +/− indicators to 'show more/less' buttons

### DIFF
--- a/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
+++ b/apps/browser/src/lib/components/ClassPropertiesWidget.svelte
@@ -982,11 +982,13 @@
 
       {#if hasMoreClasses}
         <button
-          class="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline font-medium transition-colors cursor-pointer"
+          class="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium transition-colors cursor-pointer"
           onclick={() => (classesExpanded = !classesExpanded)}
           type="button"
         >
-          {classesExpanded ? `− ${m.facets_show_less()}` : `+ ${m.facets_show_more()}`}
+          {classesExpanded
+            ? `− ${m.facets_show_less()}`
+            : `+ ${m.facets_show_more()}`}
         </button>
       {/if}
     </div>
@@ -1138,11 +1140,13 @@
 
         {#if hasMoreProperties}
           <button
-            class="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline font-medium transition-colors cursor-pointer"
+            class="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium transition-colors cursor-pointer"
             onclick={() => (propertiesExpanded = !propertiesExpanded)}
             type="button"
           >
-            {propertiesExpanded ? `− ${m.facets_show_less()}` : `+ ${m.facets_show_more()}`}
+            {propertiesExpanded
+              ? `− ${m.facets_show_less()}`
+              : `+ ${m.facets_show_more()}`}
           </button>
         {/if}
       </div>
@@ -1400,11 +1404,13 @@
 
         {#if hasMoreValueTypes}
           <button
-            class="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline font-medium transition-colors cursor-pointer"
+            class="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium transition-colors cursor-pointer"
             onclick={() => (valueTypesExpanded = !valueTypesExpanded)}
             type="button"
           >
-            {valueTypesExpanded ? `− ${m.facets_show_less()}` : `+ ${m.facets_show_more()}`}
+            {valueTypesExpanded
+              ? `− ${m.facets_show_less()}`
+              : `+ ${m.facets_show_more()}`}
           </button>
         {/if}
       </div>

--- a/apps/browser/src/lib/components/SearchFacet.svelte
+++ b/apps/browser/src/lib/components/SearchFacet.svelte
@@ -173,7 +173,7 @@
 
   {#if hasMore()}
     <button
-      class="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline font-medium transition-colors cursor-pointer"
+      class="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-medium transition-colors cursor-pointer"
       onclick={toggleExpanded}
       type="button"
     >


### PR DESCRIPTION
## Summary
- Add `+` / `−` indicators alongside 'show more' / 'show less' labels to make the toggle state clearer

Closes #1697