### PR TITLE
feat(requirements): express future requirement changes in SHACL and spec

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -7,7 +7,7 @@ This is the source code for the public document available at https://docs.nde.nl
 Build the spec:
 
 ```shell
-npx --yes @lde/docgen@latest from-shacl shacl.ttl index.bs.liquid > index.bs
+npx --yes @lde/docgen@latest from-shacl -f shacl.frame.jsonld shacl.ttl index.bs.liquid > index.bs
 make spec
 ```
 

--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -69,6 +69,16 @@
                 {% else -%}
                     Recommended
                 {% endif -%}
+                {% if property['nde:futureChange'] -%}
+                    {% assign change = property['nde:futureChange'] -%}
+                    <br><small>v{{ change['nde:version'] }}:
+                    {% if change.datatype -%}
+                        must be {{ change.datatype | replace: 'http://www.w3.org/2001/XMLSchema#', 'xsd:' }}
+                    {% elsif change.severity == "Violation" -%}
+                        becomes required
+                    {% endif -%}
+                    </small>
+                {% endif -%}
             </td>
         </tr>
         {% endfor %}

--- a/requirements/index.bs.liquid
+++ b/requirements/index.bs.liquid
@@ -509,6 +509,11 @@ The distributions are then included under the `distribution` attribute with the 
 
 See [[#distribution-attributes]] for a full overview.
 
+<div class="advisement">
+    In v2.0 of this specification, <code>contentUrl</code> *MUST* be an <code>xsd:anyURI</code> literal.
+    IRIs will no longer be accepted.
+</div>
+
 ### Creation and modification dates ### {#distribution-date}
 
 Publishers *SHOULD* make known when the [=distribution=] was originally created and when it was last updated,

--- a/requirements/shacl.frame.jsonld
+++ b/requirements/shacl.frame.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "@vocab": "http://www.w3.org/ns/shacl#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "schema": "http://schema.org/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "nde": "https://def.nde.nl#",
+    "targetClass": { "@type": "@id" },
+    "datatype": { "@type": "@id" },
+    "path": { "@type": "@id" },
+    "class": { "@type": "@id" },
+    "or": { "@container": "@list" },
+    "node": { "@type": "@id" },
+    "nodeKind": { "@type": "@vocab" },
+    "severity": { "@type": "@vocab" },
+    "nde:futureChange": {},
+    "nde:version": {}
+  },
+  "@type": "NodeShape"
+}

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -6,6 +6,7 @@
 @prefix dc: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix reg: <http://terms.netwerkdigitaalerfgoed.nl/ns/register#> .
+@prefix nde: <https://def.nde.nl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 ##
@@ -236,6 +237,10 @@ reg:OrganizationShape
             sh:minCount 1 ;
             sh:maxCount 1 ;
             sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
             sh:node [
                 a sh:NodeShape ;
                 sh:targetClass schema:ContactPoint ;
@@ -271,6 +276,10 @@ reg:OrganizationShape
               ) ;
             sh:minCount 1 ;
             sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
             sh:name "Identifier"@en ;
             sh:description """
                 Identifier(s) of the organization, at least its <a href="https://www.nationaalarchief.nl/archiveren/kennisbank/isil-codes">ISIL code</a>.
@@ -392,7 +401,12 @@ reg:DistributionContentUrlIriProperty a sh:PropertyShape ;
         [ sh:nodeKind sh:IRI ]          # IRI left for backward compatibility
     ) ;
     sh:pattern "^https?://" ;
-    sh:severity sh:Warning ;  # will become a sh:Violation in near future, to be communicated
+    sh:severity sh:Warning ;
+    nde:futureChange [
+        nde:version "2.0" ;
+        sh:datatype xsd:anyURI ;
+        sh:severity sh:Violation ;
+    ] ;
     sh:description "De URL waar de distributie rechtstreeks toegankelijk is."@nl, "The URL where the distribution may be directly accessed."@en ;
     sh:message "De URL van de distributie kan een IRI zijn of een letterlijke waarde van type xsd:anyURI."@nl, "The distribution’s content URL can be an IRI or a literal of type xsd:anyURI."@en ;
 .
@@ -517,6 +531,10 @@ reg:SchemaCreatorProperty a sh:PropertyShape ;
     sh:path schema:creator ;
     sh:minCount 1 ;
     sh:severity sh:Info ;
+    nde:futureChange [
+        nde:version "2.0" ;
+        sh:severity sh:Violation ;
+    ] ;
     sh:or (
         [
             sh:node reg:OrganizationShape ;
@@ -620,6 +638,11 @@ reg:SchemaDistributionLicenseProperty a sh:PropertyShape ;
     sh:nodeKind sh:IRIOrLiteral ;
     sh:minCount 0 ;
     sh:maxCount 1 ;
+    nde:futureChange [
+        nde:version "2.0" ;
+        sh:minCount 1 ;
+        sh:severity sh:Violation ;
+    ] ;
     sh:description "Licentie die van toepassing is op de datasetdistributie."@nl, "License applicable to the dataset distribution."@en ;
     sh:message "Een distributie mag maximaal één licentie bevatten (in de vorm van een IRI)"@nl, "A distribution may contain at most one license (as a IRI)"@en ;
 .
@@ -772,6 +795,10 @@ dcat:DatasetShape
         sh:path dc:creator ;
         sh:minCount 1 ;
         sh:severity sh:Info ;
+        nde:futureChange [
+            nde:version "2.0" ;
+            sh:severity sh:Violation ;
+        ] ;
         sh:or (
             [
                  sh:class foaf:Organization ;


### PR DESCRIPTION
## Summary

Express future requirement changes directly in the SHACL shapes so the rendered spec auto-generates migration guidance for publishers moving towards DCAT-AP-NL 3.0.

Introduces a `nde:futureChange` blank node model at namespace `https://def.nde.nl#` — each annotated shape carries a blank node with only the SHACL properties that will change in v2.0. The Liquid template reads these structured properties and auto-generates display text ("becomes required", "must be xsd:anyURI") in the attribute tables.

- **2 custom properties only**: `nde:futureChange` and `nde:version`
- **6 shapes annotated**: creator, contactPoint, identifier, distribution license, contentUrl type, DCAT creator
- **Custom JSON-LD frame** (`shacl.frame.jsonld`) exposes `nde:` properties to Liquid via docgen's `-f` flag
- **Advisement block** in spec prose for the contentUrl type change

The annotations don't affect live SHACL validation — they're ignored by validators. When v2.0 is ready, a single PR applies the described changes and removes the annotations.

Fix #1646
