### PR TITLE
fix(browser): limit dataset card description to two lines

### DIFF
--- a/apps/browser/src/lib/components/DatasetCard.svelte
+++ b/apps/browser/src/lib/components/DatasetCard.svelte
@@ -89,7 +89,10 @@
   {/if}
 
   {#if dataset.description}
-    <p class="mb-4 line-clamp-5 text-gray-700 dark:text-gray-300">
+    <p
+      class="mb-4 line-clamp-2 text-gray-700 dark:text-gray-300"
+      title={getLocalizedValue(dataset.description)}
+    >
       {getLocalizedValue(dataset.description)}
     </p>
   {/if}


### PR DESCRIPTION
Limit dataset card descriptions to two lines (from five) using Tailwind's `line-clamp-2`, making search results easier to scan. The full description is available on hover via a `title` attribute.

Fix #1696
