### PR TITLE
fix(browser): remove unused publisher identifier from detail schema

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -61,10 +61,6 @@ const DetailPublisherSchema = {
     '@optional': true,
     '@multilang': true,
   },
-  identifier: {
-    '@id': dcterms.identifier,
-    '@optional': true,
-  },
   email: {
     '@id': foaf.mbox,
     '@optional': true,


### PR DESCRIPTION
## Summary

- Removes the `identifier` property from `DetailPublisherSchema` in the dataset detail service.
- The property was fetched but never displayed in the UI.
- Some publishers (e.g. from ldmax.nl) have `dct:identifier` values that are blank nodes (`schema:PropertyValue`), which LDkit can’t decode as a plain literal, causing a 500 Internal Error.

Fix #1717.

## Test plan

- [ ] Verify that https://datasetregister.netwerkdigitaalerfgoed.nl/datasets/https://n2t.net/ark:/11978/dataset no longer returns 500
- [ ] Verify that https://datasetregister.netwerkdigitaalerfgoed.nl/datasets/https://n2t.net/ark:/61567/dataset no longer returns 500
- [ ] Verify that dataset detail pages with literal identifiers still render correctly