### PR TITLE
ci(requirements): use GitHub App for docs deployment

### DIFF
--- a/.github/workflows/requirements-publish.yml
+++ b/.github/workflows/requirements-publish.yml
@@ -48,8 +48,8 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.NDE_APP_ID }}
-          private-key: ${{ secrets.NDE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: netwerk-digitaal-erfgoed
           repositories: netwerk-digitaal-erfgoed.github.io
 


### PR DESCRIPTION
## Summary

- Replace the nde-bot personal access token (PAT) with the org's GitHub App for deploying requirements to docs.nde.nl
- Generate a scoped token via `actions/create-github-app-token`, limited to the `netwerk-digitaal-erfgoed.github.io` repository
- Remove hardcoded nde-bot user identity from the deploy step

The `DATASET_REGISTER_PUBLISH_REQUIREMENTS` secret can be removed after merging.
