### PR TITLE
fix(requirements): pass JSON-LD frame to docgen in CI

### DIFF
--- a/.github/workflows/requirements-publish.yml
+++ b/.github/workflows/requirements-publish.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: lts/*
           cache: 'npm'
-      - run: npx --yes @lde/docgen@latest from-shacl shacl.ttl index.bs.liquid > index.bs
+      - run: npx --yes @lde/docgen@latest from-shacl -f shacl.frame.jsonld shacl.ttl index.bs.liquid > index.bs
 
       - name: Build and validate
         uses: w3c/spec-prod@v2


### PR DESCRIPTION
## Summary

The `requirements-publish` workflow was missing the `-f shacl.frame.jsonld` flag when invoking `@lde/docgen`, so the custom JSON-LD context (`nde:futureChange`, `nde:version`) wasn't passed to the framing step. This meant future-change annotations in `shacl.ttl` were silently dropped from the published spec.

- Add `-f shacl.frame.jsonld` to the `docgen from-shacl` invocation in CI, matching the local build command documented in the README
