### PR TITLE
ci: ignore Nx packages in Dependabot and fix browser ESLint config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: 'nx' # Handled by the Nx migrate workflow, which also runs code migrations.
+      - dependency-name: '@nx/*' # Handled by the Nx migrate workflow, which also runs code migrations.
     groups:
       comunica:
         patterns:
@@ -22,10 +25,6 @@ updates:
         patterns:
           - '@fastify/*'
           - 'fastify'
-      nx:
-        patterns:
-          - '@nx/*'
-          - 'nx'
       vitest:
         patterns:
           - '@vitest/*'

--- a/apps/browser/eslint.config.js
+++ b/apps/browser/eslint.config.js
@@ -22,6 +22,9 @@ export default defineConfig(
   {
     languageOptions: {
       globals: { ...globals.browser, ...globals.node },
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       '@nx/dependency-checks': [


### PR DESCRIPTION
## Summary

- Ignore `nx` and `@nx/*` in Dependabot – these are handled by the [Nx migrate workflow](https://github.com/netwerk-digitaal-erfgoed/dataset-register/blob/main/.github/workflows/nx-migrate.yml), which also runs code migrations
- Remove the now-unnecessary `nx` Dependabot group
- Add `tsconfigRootDir` to the browser ESLint config to fix `typescript-eslint` parsing errors ("No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs are present") that occur with newer `@nx/eslint` versions
