### PR TITLE
Preserve usageInfo on download distributions and add OpenAPI protocol

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -51,6 +51,7 @@ const publisherSameAs = 'publisher_sameAs';
 const distributionUrl = 'distribution_url';
 const distributionMediaType = 'distribution_mediaType';
 const distributionConformsTo = 'distribution_conformsTo';
+const distributionConformsToProtocol = 'distribution_conformsTo_protocol';
 const distributionConformsToSparql = 'distribution_conformsTo_sparql';
 const distributionDatePublished = 'distribution_datePublished';
 const distributionDateModified = 'distribution_dateModified';
@@ -64,6 +65,26 @@ const distributionDownloadUrl = 'distribution_downloadUrl';
 const distributionMediaTypeForDownload = 'distribution_mediaType_download';
 const distributionCompressFormatForDownload =
   'distribution_compressFormat_download';
+
+/**
+ * Known web API protocol specification URLs, used to distinguish API distributions
+ * from download distributions. Only distributions whose conformsTo/usageInfo matches
+ * one of these are classified as APIs; other conformsTo values (application profiles,
+ * vocabularies, ontologies) are preserved on download distributions.
+ *
+ * @see https://docs.nde.nl/requirements-datasets/#developer-docs
+ */
+const apiProtocolUrls = [
+  'http://www.openarchives.org/pmh/',
+  'https://www.w3.org/TR/sparql11-protocol/',
+  'https://linkeddatafragments.org/specification/triple-pattern-fragments/',
+  'https://developers.arcgis.com/rest/',
+  'https://www.ogc.org/standards/wms/',
+  'https://spec.openapis.org/oas/v3.2.0.html',
+  'https://spec.graphql.org/',
+];
+
+const apiProtocolValues = apiProtocolUrls.map((url) => `<${url}>`).join(' ');
 
 /** Generates a prefixed SPARQL variable name, e.g. odrlVar('perm', 'action') → 'perm_action'. */
 const odrlVar = (prefix: string, prop: string) => `${prefix}_${prop}`;
@@ -229,6 +250,10 @@ export const constructQuery = `
           ?${distribution} dcat:mediaType ${normalizeMediaType(distributionMediaType)} .
           ?${distribution} dcat:accessURL ${convertToIri(distributionUrl)} .
           OPTIONAL { ?${distribution} dct:conformsTo ?${distributionConformsTo} . }
+          OPTIONAL {
+            ?${distribution} dct:conformsTo ?${distributionConformsToProtocol} .
+            VALUES ?${distributionConformsToProtocol} { ${apiProtocolValues} }
+          }
           BIND(
             IF(
               CONTAINS(STR(?${distributionMediaType}), "sparql"),
@@ -260,7 +285,7 @@ export const constructQuery = `
             ${odrlRuleWhere('policy', 'obligation', 'obligation', 'oblig')}
           }
         }
-        ${downloadOnlyProperties(distributionConformsTo, distributionConformsToSparql, distributionUrl, distributionMediaType, distributionCompressFormat, distributionDownloadUrl, distributionMediaTypeForDownload, distributionCompressFormatForDownload)}
+        ${downloadOnlyProperties(distributionConformsToProtocol, distributionConformsToSparql, distributionUrl, distributionMediaType, distributionCompressFormat, distributionDownloadUrl, distributionMediaTypeForDownload, distributionCompressFormatForDownload)}
 
         OPTIONAL { ?${dataset} dct:description ?${description} }
         BIND(STR(?${dataset}) AS ?${identifier})
@@ -387,8 +412,12 @@ function schemaOrgQuery(prefix: string): string {
         ?${distribution} ${prefix}:usageInfo ?${distributionConformsTo} .
         FILTER(isIRI(?${distributionConformsTo}))
       }
+      OPTIONAL {
+        ?${distribution} ${prefix}:usageInfo ?${distributionConformsToProtocol} .
+        VALUES ?${distributionConformsToProtocol} { ${apiProtocolValues} }
+      }
     }
-    ${downloadOnlyProperties(distributionConformsTo, distributionConformsToSparql, distributionUrl, distributionMediaType, distributionCompressFormat, distributionDownloadUrl, distributionMediaTypeForDownload, distributionCompressFormatForDownload)}
+    ${downloadOnlyProperties(distributionConformsToProtocol, distributionConformsToSparql, distributionUrl, distributionMediaType, distributionCompressFormat, distributionDownloadUrl, distributionMediaTypeForDownload, distributionCompressFormatForDownload)}
 
     OPTIONAL { ?${dataset} ${prefix}:description ?${description} }
     BIND(STR(?${dataset}) AS ?${identifier})
@@ -430,12 +459,12 @@ function schemaOrgQuery(prefix: string): string {
 }
 
 /**
- * For download distributions (no conformsTo protocol), emit downloadURL, mediaType,
- * and compressFormat. For API distributions (conformsTo bound), suppress all three —
- * they are meaningless for APIs.
+ * For download distributions (no known protocol in conformsTo), emit downloadURL,
+ * mediaType, and compressFormat. For API distributions (conformsTo matches a known
+ * protocol URL), suppress all three — they are meaningless for APIs.
  */
 function downloadOnlyProperties(
-  conformsToVariable: string,
+  conformsToProtocolVariable: string,
   conformsToSparqlVariable: string,
   urlVariable: string,
   mediaTypeVariable: string,
@@ -444,7 +473,7 @@ function downloadOnlyProperties(
   mediaTypeOutput: string,
   compressFormatOutput: string,
 ): string {
-  const isApi = `BOUND(?${conformsToVariable}) || BOUND(?${conformsToSparqlVariable})`;
+  const isApi = `BOUND(?${conformsToProtocolVariable}) || BOUND(?${conformsToSparqlVariable})`;
   return `BIND(IF(${isApi}, ?unbound, ?${urlVariable}) AS ?${downloadUrlOutput})
   BIND(IF(${isApi}, ?unbound, ?${mediaTypeVariable}) AS ?${mediaTypeOutput})
   BIND(IF(${isApi}, ?unbound, ?${compressFormatVariable}) AS ?${compressFormatOutput})`;

--- a/packages/core/test/datasets/dataset-dcat-valid.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-valid.jsonld
@@ -103,6 +103,9 @@
         "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba.jsonld"
       },
       "dcat:byteSize": "14M",
+      "dct:conformsTo": {
+        "@id": "https://docs.nde.nl/schema-profile/"
+      },
       "dct:description": "JSON-LD dump",
       "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" }
     },

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -77,6 +77,30 @@ describe('Fetch', () => {
       ),
     ).toBe(true);
 
+    // Non-protocol conformsTo (application profile) must be preserved on download distributions.
+    expect(
+      dataset.has(
+        factory.quad(
+          distributions[1].object as BlankNode,
+          dct('conformsTo'),
+          factory.namedNode('https://docs.nde.nl/schema-profile/'),
+        ),
+      ),
+    ).toBe(true);
+
+    // Download distribution with non-protocol conformsTo must still have a downloadURL.
+    expect(
+      dataset.has(
+        factory.quad(
+          distributions[1].object as BlankNode,
+          dcat('downloadURL'),
+          factory.namedNode(
+            'http://data.bibliotheken.nl/id/dataset/rise-alba.jsonld',
+          ),
+        ),
+      ),
+    ).toBe(true);
+
     // Existing distributions must not have compressFormat.
     for (const dist of distributions.slice(0, 3)) {
       expect([
@@ -333,6 +357,30 @@ describe('Fetch', () => {
         ),
     );
     expect(sparqlConformsToTriples).toHaveLength(1);
+
+    // Check that non-protocol conformsTo (application profile) is preserved on download distributions
+    const schemaProfileTriples = [...dataset].filter(
+      (quad) =>
+        quad.predicate.equals(dct('conformsTo')) &&
+        quad.object.equals(
+          factory.namedNode('https://docs.nde.nl/schema-profile/'),
+        ),
+    );
+    expect(schemaProfileTriples).toHaveLength(1);
+
+    // Verify the download distribution with the application profile still has a downloadURL
+    const jsonLdDownloadUrl = [...dataset].filter(
+      (quad) =>
+        quad.predicate.equals(
+          factory.namedNode('http://www.w3.org/ns/dcat#downloadURL'),
+        ) &&
+        quad.object.equals(
+          factory.namedNode(
+            'http://data.bibliotheken.nl/id/dataset/rise-alba.jsonld',
+          ),
+        ),
+    );
+    expect(jsonLdDownloadUrl).toHaveLength(1);
 
     expect(
       dataset.has(

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 94.76,
-        functions: 92.92,
+        lines: 94.89,
+        functions: 93.04,
         branches: 80.15,
-        statements: 94.62,
+        statements: 94.75,
       },
     },
   },

--- a/requirements/examples/dataset-schema-org-valid.jsonld
+++ b/requirements/examples/dataset-schema-org-valid.jsonld
@@ -76,6 +76,7 @@
           "@type": "DataDownload",
           "encodingFormat": "application/ld+json",
           "contentUrl": "http://data.bibliotheken.nl/id/dataset/rise-alba.jsonld",
+          "usageInfo": "https://docs.nde.nl/schema-profile/",
           "description": "JSON-LD dump"
         },
         {

--- a/requirements/index.bs.liquid
+++ b/requirements/index.bs.liquid
@@ -537,12 +537,16 @@ but simple dates (`2019-04-14`) are also allowed.
 
 ### Developer documentation ### {#developer-docs}
 
-Publishers *SHOULD* link to documentation URLs via the [https://schema.org/usageInfo](https://schema.org/usageInfo) attribute. For datadumps this should be documentation about the
-data model. For [=web APIs=] this should be documentation about the specific capabilities of the API (like content-type support) *AND* the generic specification of the
-protocol which also types the distribution such as OAI-PMH, SPARQL and REST.
+Publishers *SHOULD* link to documentation URLs via the [https://schema.org/usageInfo](https://schema.org/usageInfo) attribute.
+
+For downloads, this *SHOULD* be documentation about the data model,
+such as the application profile, vocabulary or ontology that the data conforms to.
+
+For [=web APIs=], this *SHOULD* be documentation about the specific capabilities of the API (like content-type support) *AND* the generic specification of the
+protocol which also types the distribution as an API (such as OAI-PMH, SPARQL and REST).
 
 <table>
-    <caption>Recommended URIs for typing</caption>
+    <caption>Recommended URIs for typing API distributions</caption>
     <thead>
         <tr>
             <th>Protocol</th>
@@ -568,7 +572,11 @@ protocol which also types the distribution such as OAI-PMH, SPARQL and REST.
         </tr>
         <tr>
             <th scope="row">WMS</th>
-            <td>http://www.opengeospatial.org/standards/wms</td>
+            <td>https://www.ogc.org/standards/wms/</td>
+        </tr>
+        <tr>
+            <th scope="row">OpenAPI</th>
+            <td>https://spec.openapis.org/oas/v3.2.0.html</td>
         </tr>
         <tr>
             <th scope="row">GraphQL</th>
@@ -578,15 +586,28 @@ protocol which also types the distribution such as OAI-PMH, SPARQL and REST.
 </table>
 
 <div class="example">
-    A distribution with a link to the generic documentation and the protocol specification (typing the distribution as SPARQL-endpoint).
+    A download distribution that conforms to the NDE Schema.org Application Profile:
 
     <pre highlight=json-ld>
         {
           "@context": "https://schema.org/",
           "@type": "DataDownload",
-          "encodingFormat": "application/sparql-results+json",
-          "contentUrl": "http://vocab.getty.edu/sparql",
-          "usageInfo": [ "https://www.w3.org/TR/sparql11-protocol/", "https://vocab.getty.edu/" ]
+          "encodingFormat": "application/ld+json",
+          "contentUrl": "https://example.com/data.jsonld",
+          "usageInfo": "https://docs.nde.nl/schema-profile/"
+        }
+    </pre>
+</div>
+
+<div class="example">
+    A SPARQL distribution that returns RDF in the NDE Schema.org Application Profile:
+
+    <pre highlight=json-ld>
+        {
+          "@context": "https://schema.org/",
+          "@type": "DataDownload",
+          "contentUrl": "https://example.com/sparql",
+          "usageInfo": [ "https://www.w3.org/TR/sparql11-protocol/", "https://docs.nde.nl/schema-profile/" ]
         }
     </pre>
 </div>

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -349,12 +349,13 @@ nde-dataset:DistributionShape
                 ] ]
             ) ;
             sh:description """
-                Het MIME-formaat van de distributie of een link naar de API-documentatie.
-                Voor downloads: gebruik een waarde uit de [[IANA-MEDIA-TYPES]] lijst.
-                Voor API's (zoals SPARQL of OAI-PMH): gebruik schema:usageInfo met een link naar de protocolspecificatie."""@nl ,
-            """The distribution's MIME format or a link to the API documentation.
+                Het MIME-formaat van de distributie of een link naar de documentatie.
+                Voor downloads: gebruik een waarde uit de [[IANA-MEDIA-TYPES]] lijst. Gebruik optioneel schema:usageInfo om te verwijzen naar het applicatieprofiel, vocabulaire of ontologie.
+                Voor API\u2019s (zoals SPARQL of OAI-PMH): gebruik schema:usageInfo met een link naar de protocolspecificatie."""@nl ,
+            """The distribution\u2019s MIME format or a link to the documentation.
             For downloads: use a value from the [[IANA-MEDIA-TYPES]] list.
             The value should indicate the media type of the response of the schema:contentUrl when no Accept header is included in the request.
+            Optionally use schema:usageInfo to reference the application profile, vocabulary or ontology the data conforms to.
             For APIs (such as SPARQL or OAI-PMH): use schema:usageInfo with a link to the protocol specification.
             When the distribution is compressed, the compression format (e.g. zip, gzip) should be added to the `schema:encodingFormat` (e.g. `text/turtle+gzip`).
             """@en ;
@@ -456,7 +457,7 @@ nde-dataset:DistributionShape
                 sh:severity sh:Violation ;
             ] ;
             sh:minCount 0 ;
-            sh:description "A link to the [=web API=] documentation; see [[#developer-docs]]."@en ;
+            sh:description "A link to the documentation: for downloads, the application profile, vocabulary or ontology; for [=web APIs=], the protocol specification. See [[#developer-docs]]."@en ;
             sh:message "usageInfo zou een IRI moeten zijn"@nl, "usageInfo should be an IRI"@en ;
         ] ,
         nde-dataset:SchemaDescriptionPropertyShouldExist ;


### PR DESCRIPTION
## Summary

- Previously, any `usageInfo`/`dct:conformsTo` value on a distribution caused it to be classified as an API, suppressing `downloadURL`, `mediaType`, and `compressFormat`. Now only known protocol specification URLs (SPARQL, OAI-PMH, TPF, ArcGIS REST, WMS, OpenAPI, GraphQL) trigger API classification.
- Non-protocol `conformsTo` values (application profiles, vocabularies, ontologies) are preserved on download distributions alongside their download properties.
- Add OpenAPI (`https://spec.openapis.org/oas/v3.2.0.html`) as a recognised API protocol.
- Update WMS URL from `http://www.opengeospatial.org/standards/wms` to `https://www.ogc.org/standards/wms/`.
- Update spec and SHACL descriptions to clarify that `usageInfo` is recommended on download distributions too, for referencing the data model or application profile.

Fix #1178
