### PR TITLE
ci(dependabot): group typescript with eslint dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
           - '@typescript-eslint/*'
           - 'eslint'
           - 'eslint-plugin-svelte'
+          - 'typescript'
       fastify:
         patterns:
           - '@fastify/*'


### PR DESCRIPTION
## Summary

- Add `typescript` to the Dependabot `eslint` group so it's upgraded together with `@typescript-eslint/*`
- Prevents standalone TypeScript major version PRs that fail due to peer dependency conflicts (e.g. #1753)
