### PR TITLE
feat: remove dct:title from Distribution

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -17,11 +17,6 @@ const DetailDistributionSchema = {
   accessURL: {
     '@id': dcat.accessURL,
   },
-  title: {
-    '@id': dcterms.title,
-    '@optional': true,
-    '@multilang': true,
-  },
   description: {
     '@id': dcterms.description,
     '@optional': true,
@@ -403,7 +398,6 @@ export async function fetchDatasetDetail(
     CONSTRUCT {
       ?distribution a dcat:Distribution, ldkit:Resource ;
         dcat:accessURL ?accessURL ;
-        dct:title ?title ;
         dct:description ?description ;
         dcat:mediaType ?rawMediaType ;
         dct:format ?format ;
@@ -417,7 +411,6 @@ export async function fetchDatasetDetail(
       GRAPH ?g {
         <${datasetUri}> dcat:distribution ?distribution .
         ?distribution dcat:accessURL ?accessURL .
-        OPTIONAL { ?distribution dct:title ?title }
         OPTIONAL { ?distribution dct:description ?description }
         OPTIONAL { ?distribution dcat:mediaType ?rawMediaType }
         OPTIONAL { ?distribution dct:format ?format }

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -297,7 +297,9 @@
   distIndex: number,
 )}
   {@const isVerified = verifiedUrls.has(distribution.accessURL)}
-  <DropdownItem classes={{ item: "flex flex-col items-start gap-1 !whitespace-normal" }}>
+  <DropdownItem
+    classes={{ item: 'flex flex-col items-start gap-1 !whitespace-normal' }}
+  >
     <div class="flex w-full items-center gap-2">
       {#if distribution.mediaType}
         <span
@@ -319,11 +321,6 @@
       {/if}
       {@render copyButton(distribution.accessURL)}
     </div>
-    {#if distribution.title}
-      <span class="text-sm font-medium text-gray-900 dark:text-white">
-        {getLocalizedValue(distribution.title)}
-      </span>
-    {/if}
     <a
       href={distribution.accessURL}
       target="_blank"
@@ -1055,7 +1052,9 @@
             {#each sparqlDistributions as distribution, distIndex (distribution.$id)}
               {@const isVerified = verifiedUrls.has(distribution.accessURL)}
               <DropdownItem
-                classes={{ item: "flex flex-col items-start gap-1 !whitespace-normal" }}
+                classes={{
+                  item: 'flex flex-col items-start gap-1 !whitespace-normal',
+                }}
               >
                 <div class="flex w-full items-center gap-2">
                   <span
@@ -1070,13 +1069,6 @@
                   {/if}
                   {@render copyButton(distribution.accessURL)}
                 </div>
-                {#if distribution.title}
-                  <span
-                    class="text-sm font-medium text-gray-900 dark:text-white"
-                  >
-                    {getLocalizedValue(distribution.title)}
-                  </span>
-                {/if}
                 <a
                   href={yasguiUrl(distribution.accessURL)}
                   target="_blank"

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -58,7 +58,6 @@ const distributionDateModified = 'distribution_dateModified';
 const distributionDescription = 'distribution_description';
 const distributionLanguage = 'distribution_language';
 const distributionLicense = 'distribution_license';
-const distributionName = 'distribution_name';
 const distributionSize = 'distribution_size';
 const distributionCompressFormat = 'distribution_compressFormat';
 const distributionDownloadUrl = 'distribution_downloadUrl';
@@ -196,7 +195,6 @@ export const constructQuery = `
       dct:description ?${distributionDescription} ;
       dct:language ?${distributionLanguage} ;
       dct:license ?${distributionLicense} ;
-      dct:title ?${distributionName} ;
       dcat:byteSize ?${distributionSize} ;
       odrl:hasPolicy ?policy .
 
@@ -274,7 +272,6 @@ export const constructQuery = `
             ${normalizeLanguage(`?${distributionLanguage}Raw`, distributionLanguage)}
           }
           OPTIONAL { ?${distribution} dct:license ${normalizeLicense(distributionLicense)} }
-          OPTIONAL { ?${distribution} dct:title ?${distributionName} }
           OPTIONAL { ?${distribution} dcat:byteSize ?${distributionSize} }
           OPTIONAL {
             ?${distribution} odrl:hasPolicy ?policy .
@@ -406,7 +403,6 @@ function schemaOrgQuery(prefix: string): string {
       }
       OPTIONAL { ?${distribution} ${prefix}:license ${normalizeLicense(distributionLicense + 'Provided')} }
       BIND(COALESCE(?${distributionLicense}Provided, ?${license}) AS ?${distributionLicense})
-      OPTIONAL { ?${distribution} ${prefix}:name ?${distributionName} }
       OPTIONAL { ?${distribution} ${prefix}:contentSize ?${distributionSize} }
       OPTIONAL {
         ?${distribution} ${prefix}:usageInfo ?${distributionConformsTo} .

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 94.87,
+        lines: 94.86,
         functions: 93.04,
         branches: 80.15,
-        statements: 94.75,
+        statements: 94.73,
       },
     },
   },

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -375,18 +375,6 @@ nde-dataset:DistributionShape
         ] ,
         # Recommended properties
         [
-            sh:path schema:name ;
-            sh:or (
-                [ sh:datatype xsd:string ]
-                [ sh:datatype rdf:langString ]
-            ) ;
-            sh:minCount 0 ;
-            sh:maxCount 1 ;
-            sh:description "Name of the distribution, depicting the type of distribution."@en ;
-            sh:message "Een distributie mag maximaal één naam bevatten"@nl, "A distribution may have at most one name"@en ;
-        ] ,
-        nde-dataset:SchemaNameUniqueLangProperty,
-        [
             sh:path schema:description ;
             sh:or (
                 [ sh:datatype xsd:string ]


### PR DESCRIPTION
## Summary

- Stop mapping `schema:name` on `DataDownload` to `dct:title` on `dcat:Distribution` in the SPARQL CONSTRUCT query
- Remove `schema:name` from the Distribution SHACL shape (it will also be excluded from the generated requirements spec)
- Remove distribution title display from the browser detail page

## Context

Distribution titles are not part of DCAT-AP-NL 3.0. In practice, values are mostly filenames or repository names rather than meaningful descriptions. `dct:description` on Distribution remains and is more useful.

Part of DCAT-AP-NL 3.0 alignment (#1101). Fix #1730.

## Test plan

- [x] Core tests pass (103/103)
- [x] API tests pass
- [x] Browser builds successfully
- [ ] Verify that the generated requirements spec no longer lists `schema:name` for Distribution
