### PR TITLE
feat: validate includedInDataCatalog as HTTP IRI

### DIFF
--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -662,15 +662,19 @@
                 >
               </dt>
               <dd class="text-sm text-gray-700 dark:text-gray-300">
-                <a
-                  href={`https://datasetregister.netwerkdigitaalerfgoed.nl/catalog.php?lang=${getLocale()}&uri=${encodeURIComponent(dataset.isPartOf)}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="text-blue-600 hover:underline dark:text-blue-400"
-                >
+                {#if dataset.isPartOf.startsWith('http://') || dataset.isPartOf.startsWith('https://')}
+                  <a
+                    href={`https://datasetregister.netwerkdigitaalerfgoed.nl/catalog.php?lang=${getLocale()}&uri=${encodeURIComponent(dataset.isPartOf)}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {dataset.isPartOf}
+                    <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                  </a>
+                {:else}
                   {dataset.isPartOf}
-                  <span class="sr-only"> ({m.opens_in_new_tab()})</span>
-                </a>
+                {/if}
               </dd>
             </div>
           {/if}

--- a/packages/core/test/datasets/dataset-schema-org-invalid-included-in-data-catalog.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-invalid-included-in-data-catalog.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "name": "Alba amicorum van de Koninklijke Bibliotheek",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://example.com/publisher",
+    "name": "Koninklijke Bibliotheek"
+  },
+  "includedInDataCatalog": "Special Collections Maastricht University"
+}

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -225,6 +225,15 @@ describe('Validator', () => {
     ).toEqual(0);
   });
 
+  it('reports includedInDataCatalog as string literal instead of IRI', async () => {
+    const report = (await validate(
+      'dataset-schema-org-invalid-included-in-data-catalog.jsonld',
+    )) as Valid;
+
+    expect(report.state).toEqual('valid');
+    expectViolations(report, ['https://schema.org/includedInDataCatalog'], 2);
+  });
+
   it('reports sameAs as string literal instead of IRI', async () => {
     const report = (await validate(
       'dataset-schema-org-invalid-sameas.ttl',

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -301,10 +301,18 @@ nde-dataset:DatasetShape
         [
             a sh:PropertyShape ;
             sh:path schema:includedInDataCatalog ;
+            sh:nodeKind sh:IRI ;
+            sh:pattern "^https?://" ;
             sh:minCount 0 ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
             sh:description """
                 The HTTP [[IRI]] of the data catalog(s) that the dataset belongs to.
             """@en ;
+            sh:message "De datacatalogus moet een IRI zijn, geen tekst"@nl, "The data catalog must be an IRI, not a string literal"@en ;
         ] ,
         nde-dataset:AccessRightsProperty
 .


### PR DESCRIPTION
## Summary

- Add SHACL constraints (`sh:nodeKind sh:IRI`, `sh:pattern "^https?://"`) to `schema:includedInDataCatalog` with `sh:severity sh:Warning` and `nde:futureChange` to `sh:Violation` in v2.0
- Only render the catalog link in the dataset browser when `isPartOf` is an HTTP IRI; show plain text otherwise to prevent broken links (e.g. `/catalog.php?uri=Special%20Collections%20...`)
- Add test dataset and validator test case for string literal `includedInDataCatalog`

Fix #1648
