### PR TITLE
feat: validate spatialCoverage and dct:spatial as HTTP IRI

### DIFF
--- a/packages/core/test/datasets/dataset-schema-org-invalid-spatial-coverage.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-invalid-spatial-coverage.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "name": "Alba amicorum van de Koninklijke Bibliotheek",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://example.com/publisher",
+    "name": "Koninklijke Bibliotheek"
+  },
+  "spatialCoverage": "Netherlands"
+}

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -234,6 +234,15 @@ describe('Validator', () => {
     expectViolations(report, ['https://schema.org/includedInDataCatalog'], 2);
   });
 
+  it('reports spatialCoverage as string literal instead of IRI', async () => {
+    const report = (await validate(
+      'dataset-schema-org-invalid-spatial-coverage.jsonld',
+    )) as Valid;
+
+    expect(report.state).toEqual('valid');
+    expectViolations(report, ['https://schema.org/spatialCoverage'], 2);
+  });
+
   it('reports sameAs as string literal instead of IRI', async () => {
     const report = (await validate(
       'dataset-schema-org-invalid-sameas.ttl',

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -278,8 +278,23 @@ nde-dataset:DatasetShape
             sh:severity sh:Info ;
             sh:description """
                 Indicates the place(s) which are the focus of the dataset.
+                Use an IRI from a controlled vocabulary such as [GeoNames](https://www.geonames.org/).
+                Find place IRIs via the [Network of Terms](https://termennetwerk.netwerkdigitaalerfgoed.nl/).
             """@en ;
             sh:message "Een datasetbeschrijving zou een gebiedsaanduiding moeten bevatten"@nl, "A dataset description should contain spatial coverage"@en ;
+        ] ,
+        [
+            sh:path schema:spatialCoverage ;
+            sh:nodeKind sh:IRI ;
+            sh:pattern "^https?://" ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:description "Spatial coverage must be an HTTP(S) IRI, for example from [GeoNames](https://www.geonames.org/)."@en ;
+            sh:message "Gebiedsaanduiding moet een HTTP(S)-IRI zijn (bijv. https://sws.geonames.org/2750405/)"@nl,
+                "Spatial coverage must be an HTTP(S) IRI (e.g. https://sws.geonames.org/2750405/)"@en ;
         ] ,
         [
             sh:path schema:temporalCoverage ;
@@ -822,8 +837,26 @@ dcat:DatasetShape
         sh:path dc:spatial ;
         sh:minCount 1 ;
         sh:severity sh:Info ;
-        sh:description "Het geografische gebied waarop de gegevens in de dataset betrekking hebben."@nl, "The geographical area to which the data in the dataset pertains."@en ;
+        sh:description """Het geografische gebied waarop de gegevens in de dataset betrekking hebben.
+            Gebruik een IRI uit een gecontroleerd vocabulaire zoals [GeoNames](https://www.geonames.org/).
+            Zoek plaats-IRI's via het [Termennetwerk](https://termennetwerk.netwerkdigitaalerfgoed.nl/)."""@nl,
+            """The geographical area to which the data in the dataset pertains.
+            Use an IRI from a controlled vocabulary such as [GeoNames](https://www.geonames.org/).
+            Find place IRIs via the [Network of Terms](https://termennetwerk.netwerkdigitaalerfgoed.nl/)."""@en ;
         sh:message "Datasetbeschrijving zou een gebiedsaanduiding moeten bevatten"@nl, "Dataset description should contain spatial coverage"@en ;
+    ],
+    [
+        sh:path dc:spatial ;
+        sh:nodeKind sh:IRI ;
+        sh:pattern "^https?://" ;
+        sh:severity sh:Warning ;
+        nde:futureChange [
+            nde:version "2.0" ;
+            sh:severity sh:Violation ;
+        ] ;
+        sh:description "Geographical coverage must be an HTTP(S) IRI, for example from [GeoNames](https://www.geonames.org/)."@en ;
+        sh:message "Gebiedsaanduiding moet een HTTP(S)-IRI zijn (bijv. https://sws.geonames.org/2750405/)"@nl,
+            "Geographical coverage must be an HTTP(S) IRI (e.g. https://sws.geonames.org/2750405/)"@en ;
     ],
     [
         sh:path dc:temporal ;


### PR DESCRIPTION
## Summary

- Add SHACL range validation for `schema:spatialCoverage` and `dct:spatial`, requiring values to be HTTP(S) IRIs (`sh:nodeKind sh:IRI` + `sh:pattern "^https?://"`), aligning with [DCAT-AP-NL 3.0](https://docs.geostandaarden.nl/dcat/dcat-ap-nl30/#dataset-geographical-coverage) which specifies `dct:Location` as range
- Set severity to `sh:Warning` now, with `nde:futureChange` to `sh:Violation` in v2.0
- Update `sh:description` on existing minCount shapes with vocabulary guidance ([GeoNames](https://www.geonames.org/)) and [Network of Terms](https://termennetwerk.netwerkdigitaalerfgoed.nl/) links
- Add test fixture and test case for literal `spatialCoverage` values

Fix #1632
