### PR TITLE
feat: preserve user-provided dcat:theme from DCAT input

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -164,6 +164,7 @@ export const constructQuery = `
       dct:isReferencedBy ?${isReferencedBy} ;
       dct:accessRights ?${accessRights} ;
       dcat:theme ?theme ;
+      dcat:theme ?themeDefault ;
       dct:publisher ?${publisher} ;
       dct:creator ?${creator} ;
       dcat:contactPoint ?${contactPoint} ;
@@ -312,7 +313,8 @@ export const constructQuery = `
         OPTIONAL { ?${dataset} dcat:landingPage ?${mainEntityOfPage} }
         OPTIONAL { ?${dataset} dct:accessRights ?${accessRights}Provided }
         BIND(COALESCE(?${accessRights}Provided, <http://publications.europa.eu/resource/authority/access-right/PUBLIC>) AS ?${accessRights})
-        BIND(<http://publications.europa.eu/resource/authority/data-theme/EDUC> AS ?theme)
+        OPTIONAL { ?${dataset} dcat:theme ?theme }
+        BIND(<http://publications.europa.eu/resource/authority/data-theme/EDUC> AS ?themeDefault)
       }
     }
     LIMIT ${sparqlLimit}
@@ -450,7 +452,7 @@ function schemaOrgQuery(prefix: string): string {
     OPTIONAL { ?${dataset} ${prefix}:mainEntityOfPage ?${mainEntityOfPage} }
     OPTIONAL { ?${dataset} dct:accessRights ?${accessRights}Provided }
     BIND(COALESCE(?${accessRights}Provided, <http://publications.europa.eu/resource/authority/access-right/PUBLIC>) AS ?${accessRights})
-    BIND(<http://publications.europa.eu/resource/authority/data-theme/EDUC> AS ?theme)
+    BIND(<http://publications.europa.eu/resource/authority/data-theme/EDUC> AS ?themeDefault)
 `;
 }
 

--- a/packages/core/test/datasets/dataset-dcat-valid.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-valid.jsonld
@@ -64,6 +64,9 @@
       "@id": "https://example.com/publisher"
     }
   ],
+  "dcat:theme": {
+    "@id": "http://publications.europa.eu/resource/authority/data-theme/EDUC"
+  },
   "dct:language": ["nl-NL", "en-GB"],
   "dct:spatial": {
     "@id": "https://sws.geonames.org/2750405/"

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -132,6 +132,19 @@ describe('Fetch', () => {
         ),
       ),
     ).toBe(true);
+
+    // User-provided dcat:theme must be preserved.
+    expect(
+      dataset.has(
+        factory.quad(
+          datasetUri,
+          dcat('theme'),
+          factory.namedNode(
+            'http://publications.europa.eu/resource/authority/data-theme/EDUC',
+          ),
+        ),
+      ),
+    ).toBe(true);
   });
 
   it('preserves ODRL policy on DCAT distributions', async () => {
@@ -304,6 +317,38 @@ describe('Fetch', () => {
     ).toBe(true);
   });
 
+  it('preserves user-provided themes alongside default EDUC theme', async () => {
+    const response = await file('dataset-dcat-valid-minimal.jsonld');
+    const datasetWithTheme = response.replace(
+      '"dct:title"',
+      '"dcat:theme": {"@id": "http://publications.europa.eu/resource/authority/data-theme/TECH"}, "dct:title"',
+    );
+    nock('https://example.com')
+      .defaultReplyHeaders({'Content-Type': 'application/ld+json'})
+      .get('/dcat-with-theme')
+      .reply(200, datasetWithTheme);
+
+    const datasets = await fetchDatasetsAsArray(
+      new URL('https://example.com/dcat-with-theme'),
+    );
+
+    expect(datasets).toHaveLength(1);
+    const dataset = datasets[0];
+    const datasetUri = factory.namedNode(
+      'http://data.bibliotheken.nl/id/dataset/rise-alba',
+    );
+
+    const themes = [...dataset.match(datasetUri, dcat('theme'), null)].map(
+      (quad) => quad.object.value,
+    );
+    expect(themes).toContain(
+      'http://publications.europa.eu/resource/authority/data-theme/TECH',
+    );
+    expect(themes).toContain(
+      'http://publications.europa.eu/resource/authority/data-theme/EDUC',
+    );
+  });
+
   it('accepts minimal valid Schema.org dataset', async () => {
     const response = await file('dataset-schema-org-valid-minimal.jsonld');
     nock('https://example.com')
@@ -343,8 +388,9 @@ describe('Fetch', () => {
     // dcat:contactPoint, a vcard:Kind, vcard:fn, vcard:hasEmail), and dcat:theme.
     // The DCAT file has a 4th gzip distribution (5 triples incl. downloadURL),
     // an extra byteSize triple, one more propagated license (4 vs 3 distributions),
-    // and a mediaType on the SPARQL distribution (suppressed for API distributions).
-    expect(dataset.size).toEqual(dcatEquivalent.size + 7 - 8);
+    // a mediaType on the SPARQL distribution (suppressed for API distributions),
+    // and a dcat:theme triple (auto-assigned for Schema.org, explicit in DCAT).
+    expect(dataset.size).toEqual(dcatEquivalent.size + 7 - 9);
 
     // Check that SPARQL endpoint has conformsTo triple
     const sparqlConformsToTriples = [...dataset].filter(

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -958,10 +958,14 @@ dcat:DatasetShape
     [
         sh:path dcat:theme ;
         sh:nodeKind sh:IRI ;
+        sh:pattern "^https?://" ;
         sh:description """De categorie van de dataset. Gebruik minimaal een waarde uit het Europese Dataset Theme Vocabulary.
-        Aanbevolen wordt om daarnaast waarden op te nemen uit domeinspecifieke vocabulaires."""@nl,
+        Aanbevolen wordt om daarnaast waarden op te nemen uit domeinspecifieke vocabulaires.
+        Standaard wordt 'Education, culture and sport' (data-theme/EDUC) toegevoegd."""@nl,
             """The category of the dataset. Use at least one value from the European Dataset Theme Vocabulary.
-        It is recommended to also include values from domain-specific vocabularies."""@en ;
+        It is recommended to also include values from domain-specific vocabularies.
+        The default theme 'Education, culture and sport' (data-theme/EDUC) is auto-assigned."""@en ;
+        sh:message "Thema moet een HTTP(S)-IRI zijn"@nl, "Theme must be an HTTP(S) IRI"@en ;
     ],
     [
         sh:path dcat:distribution ;


### PR DESCRIPTION
## Summary

Previously, `dcat:theme` was hardcoded to `data-theme/EDUC` and any user-provided themes in DCAT input were discarded. DCAT-AP-NL 3.0 requires at least one EU Data Theme and recommends additional domain-specific themes.

- **query.ts**: Read `dcat:theme` from DCAT input via OPTIONAL, while still auto-assigning EDUC as a default. Schema.org input continues to get only the EDUC default (no Schema.org equivalent for `dcat:theme`).
- **SHACL**: Add validation that `dcat:theme` values must be HTTP(S) IRIs. No `sh:minCount` since EDUC is auto-assigned.
- **Tests**: Verify user-provided themes are preserved alongside the default EDUC theme.

Partial fix for #1101.
