### PR TITLE
feat: skip SHACL validation of inline DataCatalog references

### DIFF
--- a/packages/core/test/datasets/dataset-schema-org-valid-included-in-data-catalog.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-valid-included-in-data-catalog.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "@id": "https://data.labs.kadaster.nl/kadaster/bag2",
+  "name": "BAG 2.0",
+  "description": "Basisregistratie Adressen en Gebouwen",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://www.kadaster.nl/",
+    "name": "Kadaster"
+  },
+  "includedInDataCatalog": {
+    "@type": "DataCatalog",
+    "@id": "https://data.labs.kadaster.nl"
+  }
+}

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -225,6 +225,14 @@ describe('Validator', () => {
     ).toEqual(0);
   });
 
+  it('does not validate inline DataCatalog from includedInDataCatalog', async () => {
+    const report = await validate(
+      'dataset-schema-org-valid-included-in-data-catalog.jsonld',
+    );
+
+    expect(report.state).toEqual('valid');
+  });
+
   it('reports includedInDataCatalog as string literal instead of IRI', async () => {
     const report = (await validate(
       'dataset-schema-org-invalid-included-in-data-catalog.jsonld',

--- a/requirements/index.bs.liquid
+++ b/requirements/index.bs.liquid
@@ -758,7 +758,7 @@ This is an overview of required and recommended attributes.
 {% assign distributionShape = nodeShapes| where: 'targetClass', 'https://schema.org/DataDownload' | first -%}
 {% render 'attributes', name: 'Distribution', nodeShape: distributionShape %}
 
-{% assign catalogShape = nodeShapes | where: 'targetClass', 'https://schema.org/DataCatalog' | first -%}
+{% assign catalogShape = nodeShapes | where: 'class', 'https://schema.org/DataCatalog' | first -%}
 {% render 'attributes', name: 'DataCatalog', nodeShape: catalogShape %}
 
 ### Full example ### {#dataset-example}

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -20,7 +20,8 @@
 
 nde-dataset:DatacatalogShape
     a sh:NodeShape ;
-    sh:targetClass schema:DataCatalog ;
+    sh:targetSubjectsOf schema:dataset ;
+    sh:class schema:DataCatalog ;
     rdfs:label "Datacatalogus"@nl, "Data catalog"@en ;
     sh:description "Een datacatalogus bestaat uit een set van datasetbeschrijvingen"@nl, "A data catalog consists of a set of dataset descriptions"@en ;
     sh:property
@@ -1028,7 +1029,8 @@ dcat:DistributionShape
 
 dcat:CatalogShape
     a sh:NodeShape ;
-    sh:targetClass dcat:Catalog ;
+    sh:targetSubjectsOf dcat:dataset ;
+    sh:class dcat:Catalog ;
     sh:property [
         sh:path dc:title ;
         sh:minCount 1 ;


### PR DESCRIPTION
## Summary

- Replace `sh:targetClass` with `sh:targetSubjectsOf schema:dataset`/`dcat:dataset` on catalog shapes, so only standalone catalogs (that have datasets) are validated – inline DataCatalog nodes from `includedInDataCatalog` are no longer targeted
- Add `sh:class` to catalog shapes so the docgen template can still look up shapes by class

Fix #1176
