### PR TITLE
feat: add maxCount 1 as future change for encodingFormat and mediaType

### DIFF
--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -79,6 +79,8 @@
                         must match <code>{{ change.pattern }}</code>
                     {% elsif change.nodeKind == "IRI" and change.severity != "Violation" -%}
                         must be IRI
+                    {% elsif change.maxCount -%}
+                        max {{ change.maxCount }}
                     {% elsif change.severity == "Violation" -%}
                         becomes required
                     {% endif -%}

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -388,6 +388,10 @@ nde-dataset:DistributionShape
         [
             sh:path schema:encodingFormat ;
             sh:pattern "^[a-zA-Z]+/[a-zA-Z0-9][a-zA-Z0-9!#$&\\-^_.+]*$" ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:maxCount 1 ;
+            ] ;
             sh:description """Het mediatype van het downloadbare bestand.
                 Gebruik een waarde uit de [[IANA-MEDIA-TYPES]] lijst.
                 Bij gecomprimeerde distributies moet het compressieformaat (bijv. zip, gzip) worden toegevoegd (bijv. text/turtle+gzip)."""@nl ,
@@ -1004,6 +1008,10 @@ dcat:DistributionShape
         [ sh:property [
             sh:minCount 1 ;
             sh:path dcat:mediaType ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:maxCount 1 ;
+            ] ;
             sh:description "Het mediatype van de distributie conform de IANA-indeling."@nl, "The media type of the distribution according to the IANA classification."@en ;
         ] ]
         [ sh:property [


### PR DESCRIPTION
## Summary

- Add `nde:futureChange` with `sh:maxCount 1` (v2.0) to `schema:encodingFormat` and `dcat:mediaType` on Distribution shapes, aligning with DCAT-AP's 0..1 cardinality
- Add `maxCount` rendering branch to `attributes.liquid` so the future change displays as 'max 1' in the spec table

Fix #1174
Ref #1101