### PR TITLE
feat: add dct:accrualPeriodicity support for datasets

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -34,6 +34,7 @@ const includedInDataCatalog = 'includedInDataCatalog';
 const hasPart = 'hasPart';
 const isReferencedBy = 'isReferencedBy';
 const accessRights = 'accessRights';
+const accrualPeriodicity = 'accrualPeriodicity';
 
 const creatorName = 'creator_name';
 const creatorType = 'creator_type';
@@ -165,6 +166,7 @@ export const constructQuery = `
       dct:accessRights ?${accessRights} ;
       dcat:theme ?theme ;
       dcat:theme ?themeDefault ;
+      dct:accrualPeriodicity ?${accrualPeriodicity} ;
       dct:publisher ?${publisher} ;
       dct:creator ?${creator} ;
       dcat:contactPoint ?${contactPoint} ;
@@ -313,6 +315,7 @@ export const constructQuery = `
         OPTIONAL { ?${dataset} dcat:landingPage ?${mainEntityOfPage} }
         OPTIONAL { ?${dataset} dct:accessRights ?${accessRights}Provided }
         BIND(COALESCE(?${accessRights}Provided, <http://publications.europa.eu/resource/authority/access-right/PUBLIC>) AS ?${accessRights})
+        OPTIONAL { ?${dataset} dct:accrualPeriodicity ?${accrualPeriodicity} }
         OPTIONAL { ?${dataset} dcat:theme ?theme }
         BIND(<http://publications.europa.eu/resource/authority/data-theme/EDUC> AS ?themeDefault)
       }
@@ -452,6 +455,7 @@ function schemaOrgQuery(prefix: string): string {
     OPTIONAL { ?${dataset} ${prefix}:mainEntityOfPage ?${mainEntityOfPage} }
     OPTIONAL { ?${dataset} dct:accessRights ?${accessRights}Provided }
     BIND(COALESCE(?${accessRights}Provided, <http://publications.europa.eu/resource/authority/access-right/PUBLIC>) AS ?${accessRights})
+    OPTIONAL { ?${dataset} dct:accrualPeriodicity ?${accrualPeriodicity} }
     BIND(<http://publications.europa.eu/resource/authority/data-theme/EDUC> AS ?themeDefault)
 `;
 }

--- a/packages/core/test/datasets/dataset-dcat-valid-accrual-periodicity.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-valid-accrual-periodicity.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "@type": "dcat:Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "dct:accrualPeriodicity": {"@id": "http://publications.europa.eu/resource/authority/frequency/WEEKLY"},
+  "dct:title": "Alba amicorum van de Koninklijke Bibliotheek",
+  "dct:license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "dct:publisher": {
+    "@id": "https://example.com/dataset-provider",
+    "@type": "foaf:Person",
+    "foaf:name": "Dataset Provider"
+  }
+}

--- a/packages/core/test/datasets/dataset-schema-org-valid-accrual-periodicity.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-valid-accrual-periodicity.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "@vocab": "https://schema.org/",
+    "dct": "http://purl.org/dc/terms/"
+  },
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "dct:accrualPeriodicity": {"@id": "http://publications.europa.eu/resource/authority/frequency/DAILY"},
+  "name": "Alba amicorum van de Koninklijke Bibliotheek",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://example.com/publisher",
+    "name": "Koninklijke Bibliotheek"
+  }
+}

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -350,6 +350,70 @@ describe('Fetch', () => {
     );
   });
 
+  it('preserves dct:accrualPeriodicity from DCAT input', async () => {
+    const response = await file(
+      'dataset-dcat-valid-accrual-periodicity.jsonld',
+    );
+    nock('https://example.com')
+      .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
+      .get('/dcat-with-frequency')
+      .reply(200, response);
+
+    const datasets = await fetchDatasetsAsArray(
+      new URL('https://example.com/dcat-with-frequency'),
+    );
+
+    expect(datasets).toHaveLength(1);
+    const dataset = datasets[0];
+    const datasetUri = factory.namedNode(
+      'http://data.bibliotheken.nl/id/dataset/rise-alba',
+    );
+
+    expect(
+      dataset.has(
+        factory.quad(
+          datasetUri,
+          dct('accrualPeriodicity'),
+          factory.namedNode(
+            'http://publications.europa.eu/resource/authority/frequency/WEEKLY',
+          ),
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('preserves dct:accrualPeriodicity from Schema.org input', async () => {
+    const response = await file(
+      'dataset-schema-org-valid-accrual-periodicity.jsonld',
+    );
+    nock('https://example.com')
+      .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
+      .get('/schema-org-with-frequency')
+      .reply(200, response);
+
+    const datasets = await fetchDatasetsAsArray(
+      new URL('https://example.com/schema-org-with-frequency'),
+    );
+
+    expect(datasets).toHaveLength(1);
+    const dataset = datasets[0];
+    const datasetUri = factory.namedNode(
+      'http://data.bibliotheken.nl/id/dataset/rise-alba',
+    );
+
+    expect(
+      dataset.has(
+        factory.quad(
+          datasetUri,
+          dct('accrualPeriodicity'),
+          factory.namedNode(
+            'http://publications.europa.eu/resource/authority/frequency/DAILY',
+          ),
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it('accepts minimal valid Schema.org dataset', async () => {
     const response = await file('dataset-schema-org-valid-minimal.jsonld');
     nock('https://example.com')

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 94.69,
+        lines: 94.7,
         functions: 93.1,
         branches: 79.68,
-        statements: 94.57,
+        statements: 94.58,
       },
     },
   },

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -334,6 +334,22 @@ nde-dataset:DatasetShape
             """@en ;
             sh:message "De datacatalogus moet een IRI zijn, geen tekst"@nl, "The data catalog must be an IRI, not a string literal"@en ;
         ] ,
+        [
+            a sh:PropertyShape ;
+            sh:path dc:accrualPeriodicity ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:pattern "^http://publications\\.europa\\.eu/resource/authority/frequency/" ;
+            sh:severity sh:Warning ;
+            sh:name "Updatefrequentie"@nl, "Accrual periodicity"@en ;
+            sh:description """Hoe vaak de dataset wordt bijgewerkt.
+                Gebruik een waarde uit de EU-frequentielijst,
+                bijvoorbeeld http://publications.europa.eu/resource/authority/frequency/WEEKLY ."""@nl,
+                """How often the dataset is updated.
+                Use a value from the EU frequency list,
+                for example http://publications.europa.eu/resource/authority/frequency/WEEKLY ."""@en ;
+            sh:message "Updatefrequentie moet een IRI zijn uit de EU-frequentielijst"@nl, "Accrual periodicity must be an IRI from the EU frequency list"@en ;
+        ] ,
         nde-dataset:AccessRightsProperty
 .
 
@@ -1059,6 +1075,22 @@ dcat:DatasetShape
         sh:severity sh:Info ;
         sh:description "Een beschikbare representatie van de dataset."@nl, "An available representation of the dataset."@en ;
         sh:message "Datasetbeschrijving zou minstens één distributie moeten bevatten"@nl, "Dataset description should contain at least one distribution"@en ;
+    ] ,
+    [
+        a sh:PropertyShape ;
+        sh:path dc:accrualPeriodicity ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:pattern "^http://publications\\.europa\\.eu/resource/authority/frequency/" ;
+        sh:severity sh:Warning ;
+        sh:name "Updatefrequentie"@nl, "Accrual periodicity"@en ;
+        sh:description """Hoe vaak de dataset wordt bijgewerkt.
+            Gebruik een waarde uit de EU-frequentielijst,
+            bijvoorbeeld http://publications.europa.eu/resource/authority/frequency/WEEKLY ."""@nl,
+            """How often the dataset is updated.
+            Use a value from the EU frequency list,
+            for example http://publications.europa.eu/resource/authority/frequency/WEEKLY ."""@en ;
+        sh:message "Updatefrequentie moet een IRI zijn uit de EU-frequentielijst"@nl, "Accrual periodicity must be an IRI from the EU frequency list"@en ;
     ] ,
     nde-dataset:AccessRightsProperty ;
     sh:targetClass dcat:Dataset ;


### PR DESCRIPTION
## Summary

- Add `dct:accrualPeriodicity` as an optional property on datasets, accepted from both Schema.org and DCAT input
- Validate against the EU frequency Named Authority List (e.g. `http://publications.europa.eu/resource/authority/frequency/WEEKLY`)
- SHACL constraints: max 1 value, must be an IRI matching the EU NAL pattern, severity Warning

Since Schema.org has no equivalent property for dataset update frequency, `dct:accrualPeriodicity` is accepted directly on Schema.org input alongside Schema.org properties.

Fix #772
