### PR TITLE
Add GET /allowed-domains endpoint

### DIFF
--- a/apps/api/src/assets/api.yaml
+++ b/apps/api/src/assets/api.yaml
@@ -158,6 +158,27 @@ paths:
           description: The URL cannot be resolved.
         406:
           description: The URL can be resolved but it contains no datasets.
+  /allowed-domains:
+    get:
+      summary: Check whether a URL's domain is on the allow list
+      description: |-
+        Check whether the domain of the given URL is on the allow list.
+        Only URLs on allowed domains can be registered via POST /datasets.
+      parameters:
+        - name: url
+          in: query
+          required: true
+          schema:
+            type: string
+          description: URL whose domain to check
+          example: 'https://example.com/dataset.ttl'
+      responses:
+        200:
+          description: The URL's domain is on the allow list.
+        400:
+          description: Missing or invalid URL parameter.
+        404:
+          description: The URL's domain is not on the allow list.
   /shacl:
     get:
       summary: Get the SHACL shape that is used to validate dataset descriptions.

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -250,6 +250,26 @@ export async function server(
     return reply.sendRdf(shacl);
   });
 
+  server.get('/allowed-domains', async (request, reply) => {
+    const { url: urlParam } = request.query as { url?: string };
+    if (!urlParam) {
+      return reply.code(400).send();
+    }
+
+    let url: URL;
+    try {
+      url = new URL(urlParam);
+    } catch {
+      return reply.code(400).send();
+    }
+
+    if (await domainIsAllowed(url)) {
+      return reply.code(200).send();
+    }
+
+    return reply.code(404).send();
+  });
+
   // Protected routes requiring API access token
   if (apiAccessToken) {
     await server.register(async function protectedRoutes(protectedServer) {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -324,6 +324,46 @@ describe('Server', () => {
     expect(response.statusCode).toEqual(202);
   });
 
+  it('returns 200 for a URL on an allowed domain', async () => {
+    const response = await httpServer.inject({
+      method: 'GET',
+      url: '/allowed-domains?url=https://netwerkdigitaalerfgoed.nl/dataset',
+    });
+    expect(response.statusCode).toEqual(200);
+  });
+
+  it('returns 200 for a URL on a subdomain of an allowed domain', async () => {
+    const response = await httpServer.inject({
+      method: 'GET',
+      url: '/allowed-domains?url=https://sub.netwerkdigitaalerfgoed.nl/dataset',
+    });
+    expect(response.statusCode).toEqual(200);
+  });
+
+  it('returns 404 for a URL on a disallowed domain', async () => {
+    const response = await httpServer.inject({
+      method: 'GET',
+      url: '/allowed-domains?url=https://not-allowed.com/dataset',
+    });
+    expect(response.statusCode).toEqual(404);
+  });
+
+  it('returns 400 when url parameter is missing', async () => {
+    const response = await httpServer.inject({
+      method: 'GET',
+      url: '/allowed-domains',
+    });
+    expect(response.statusCode).toEqual(400);
+  });
+
+  it('returns 400 for an invalid url parameter', async () => {
+    const response = await httpServer.inject({
+      method: 'GET',
+      url: '/allowed-domains?url=not-a-url',
+    });
+    expect(response.statusCode).toEqual(400);
+  });
+
   it('responds with validation errors when adding an invalid dataset', async () => {
     const { nockDone } = await nock.back('invalid-dataset.json');
     const response = await httpServer.inject({

--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -16,10 +16,10 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
       thresholds: {
         autoUpdate: true,
-        lines: 96.77,
+        lines: 97.08,
         functions: 100,
-        branches: 81.81,
-        statements: 96.77,
+        branches: 83.33,
+        statements: 97.08,
       },
     },
   },


### PR DESCRIPTION
## Summary

- Add `GET /allowed-domains?url=<url>` endpoint that checks whether a URL's domain is on the allow list
- Returns 200 if allowed, 404 if not, 400 if the URL is missing or invalid
- Reuses existing `domainIsAllowed()` logic (including subdomain support via `psl`)
- Add OpenAPI spec and tests

Fix #430
