### PR TITLE
Fix v2.0 annotation for IRI-constrained properties in spec

### DIFF
--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -81,6 +81,8 @@
                         must be IRI
                     {% elsif change.maxCount -%}
                         max {{ change.maxCount }}
+                    {% elsif change.severity == "Violation" and property.nodeKind == "IRI" -%}
+                        must be IRI
                     {% elsif change.severity == "Violation" -%}
                         becomes required
                     {% endif -%}


### PR DESCRIPTION
## Summary

- Fix the Liquid template logic that generates v2.0 annotations in the spec: when a future change escalates severity to Violation on a property that has `nodeKind == "IRI"`, display "must be IRI" instead of "becomes required"
- Affects spatialCoverage, includedInDataCatalog, and usageInfo – all have IRI format constraints whose severity changes in v2.0, but the properties themselves remain optional
