### PR TITLE
fix(browser): complete flowbite-svelte v2 init and fix tooltip visibility

### DIFF
--- a/apps/browser/src/app.css
+++ b/apps/browser/src/app.css
@@ -1,24 +1,14 @@
 @import 'tailwindcss';
+@import '../../../node_modules/flowbite-svelte/dist/theme-selector/themes/default.css';
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
 @plugin 'flowbite/plugin';
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @source "../../../node_modules/flowbite-svelte/dist";
 @source "../../../node_modules/flowbite-svelte-icons/dist";
 @source "../../../node_modules/@flowbite-svelte-plugins/chart/dist";
-
-/* Prevent horizontal scrolling on mobile - fixes tooltip overflow issues */
-html,
-body {
-  overflow-x: hidden;
-}
-
-/* Enable dark mode based on OS preference */
-@media (prefers-color-scheme: dark) {
-  :root {
-    color-scheme: dark;
-  }
-}
 
 /* Shimmer animation for skeleton loading */
 @keyframes shimmer {
@@ -35,20 +25,20 @@ body {
   animation: shimmer 1.5s infinite;
 }
 
-/* Fix Flowbite tooltip popover background: browsers apply a white background to [popover]
-   elements via the UA stylesheet, overriding Tailwind bg-* classes. This makes dark tooltips
-   invisible in light mode (white text on white) and causes a white arrow in dark mode.
-   See https://github.com/themesberg/flowbite-svelte/issues/1941 */
-[popover][data-scope='popper'] {
-  background: transparent;
+/* Flowbite Svelte tooltip overrides:
+   1. The dark variant has no border utility, so `border-color` defaults to currentColor
+      (white). The arrow uses `border-inherit`, so without this override the arrow picks
+      up a white border that shows through its clip-path in dark mode.
+   2. The default `bg-dark` (gray-800) matches our card backgrounds in dark mode, so
+      tooltips blend in. Use a lighter shade (gray-700) to make them stand out. */
+[popover][role='tooltip'] {
+  border: 1px solid var(--color-gray-700);
 }
-
-/* Fix Flowbite tooltip hover gap - creates invisible bridge between trigger and tooltip */
-.tooltip::before {
-  content: '';
-  position: absolute;
-  top: -10px;
-  left: 0;
-  right: 0;
-  height: 10px;
+.dark [popover][role='tooltip'] {
+  background-color: var(--color-gray-600);
+  border-color: var(--color-gray-400);
+}
+.dark [popover][role='tooltip'] .popover-arrow {
+  background-color: var(--color-gray-600);
+  border-color: var(--color-gray-400);
 }

--- a/apps/browser/src/app.css
+++ b/apps/browser/src/app.css
@@ -35,6 +35,14 @@ body {
   animation: shimmer 1.5s infinite;
 }
 
+/* Fix Flowbite tooltip popover background: browsers apply a white background to [popover]
+   elements via the UA stylesheet, overriding Tailwind bg-* classes. This makes dark tooltips
+   invisible in light mode (white text on white) and causes a white arrow in dark mode.
+   See https://github.com/themesberg/flowbite-svelte/issues/1941 */
+[popover][data-scope='popper'] {
+  background: transparent;
+}
+
 /* Fix Flowbite tooltip hover gap - creates invisible bridge between trigger and tooltip */
 .tooltip::before {
   content: '';

--- a/apps/browser/src/app.html
+++ b/apps/browser/src/app.html
@@ -3,6 +3,18 @@
   <head>
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1" name="viewport" />
+    <script>
+      // Apply dark mode based on OS preference before first paint to avoid FOUC.
+      // Flowbite Svelte v2 uses the .dark class to toggle dark mode.
+      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.documentElement.classList.add('dark');
+      }
+      window
+        .matchMedia('(prefers-color-scheme: dark)')
+        .addEventListener('change', (event) => {
+          document.documentElement.classList.toggle('dark', event.matches);
+        });
+    </script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
## Summary

Complete the flowbite-svelte v2 initialization and fix tooltip visibility in both light and dark mode.

The upgrade to flowbite-svelte v2.0.0-next.10 (#1774) was missing the theme CSS import and `dark:` variant configuration required by v2. As a result:

- **Light mode**: tooltips were invisible – white text on white background, because the `[popover]` UA stylesheet overrode Tailwind’s `bg-*` classes.
- **Dark mode**: the tooltip arrow showed a white triangle, because the dark tooltip theme has no `border-*` utility and the arrow’s `border-inherit` picked up `currentColor` (white).
- The tooltip’s `bg-dark` (gray-800) also matched our card backgrounds, so tooltips blended in.

## Changes

`apps/browser/src/app.css`:
- Import `flowbite-svelte/dist/theme-selector/themes/default.css` (defines CSS custom properties like `--color-dark` that v2 components reference).
- Add `@custom-variant dark (&:where(.dark, .dark *))` so Tailwind’s `dark:` variants respond to the `.dark` class.
- Add a tooltip border with explicit color so the arrow inherits a proper border color instead of white.
- In dark mode, override tooltip `background-color` to gray-600 with a gray-400 border so tooltips stand out from gray-800 cards. Text-on-bg contrast is 7.56:1 (AAA) and border-vs-card is 5.64:1 (AA).
- Remove the old `[popover][data-scope='popper'] { background: transparent }` workaround, the `.tooltip::before` hover bridge, the `overflow-x: hidden` mobile workaround, and the `prefers-color-scheme` `color-scheme` block – all no longer needed.

`apps/browser/src/app.html`:
- Add an inline script that toggles the `.dark` class on `<html>` based on `prefers-color-scheme: dark`, before first paint to avoid FOUC, and on OS preference changes.

Fix #1827

Filed upstream: themesberg/flowbite-svelte#1941
