### PR TITLE
docs(spec): compact dcterms URIs to dct: prefix in attribute tables

### DIFF
--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -2,7 +2,7 @@
 
 <table>
     {% assign class = nodeShape.targetClass | default: nodeShape.class | default: targetClass -%}
-    <caption>[{{ class | replace: 'https://schema.org/', 'https://schema.org/' }}]({{ class }}) properties</caption>
+    <caption>[{{ class }}]({{ class }}) properties</caption>
     <thead>
         <tr>
             <th>Property</th>
@@ -24,7 +24,7 @@
         {% for property in merged_properties %}
         {% unless property.path %}{% continue %}{% endunless %}
         <tr>
-            <th scope="row">[{{ property.path | replace: 'https://schema.org/', 'schema:' }}]({{ property.path }})</th>
+            <th scope="row">[{{ property.path }}]({{ property.path }})</th>
             <td>
                 {%- if property.node['@id'] == "https://def.nde.nl/dataset#DateTimeShape" -%}
                     See [[#dataset-date]].

--- a/requirements/shacl.frame.jsonld
+++ b/requirements/shacl.frame.jsonld
@@ -4,6 +4,7 @@
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "schema": "https://schema.org/",
+    "dct": "http://purl.org/dc/terms/",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "nde": "https://def.nde.nl#",
     "nde-dataset": "https://def.nde.nl/dataset#",


### PR DESCRIPTION
## Summary

The attribute tables in the requirements spec rendered `dcterms` property paths as full URIs (e.g. `http://purl.org/dc/terms/accrualPeriodicity`) while all `schema.org` paths appeared in compact form. Register the `dct` prefix in the JSON-LD frame so framing compacts those IRIs during generation, matching the style used for `schema:` paths.

## Changes

- `requirements/shacl.frame.jsonld`: add `dct` → `http://purl.org/dc/terms/` to the context so dcterms property paths get compacted during JSON-LD framing.
- `requirements/attributes.liquid`: drop the `replace: 'https://schema.org/', 'schema:'` filter and the no-op `replace: 'https://schema.org/', 'https://schema.org/'` on the caption. Both were redundant — framing already emits compact IRIs.

Regenerate `requirements/index.bs` via `make spec` to pick up the change in the published spec.
