### PR TITLE
fix(shacl): drop incorrect sh:minCount 1 from distribution license v2.0 future change

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -520,9 +520,7 @@ nde-dataset:DistributionShape
             sh:maxCount 1 ;
             nde:futureChange [
                 nde:version "2.0" ;
-                sh:minCount 1 ;
                 sh:nodeKind sh:IRI ;
-                sh:severity sh:Violation ;
             ] ;
             sh:description """Licentie die van toepassing is op de distributie.
         Als de distributie geen eigen licentie heeft, wordt de licentie van de bovenliggende dataset overgenomen.


### PR DESCRIPTION
## Summary

The v2.0 future change on the distribution `schema:license` property added `sh:minCount 1`, which would have required a license on every distribution. That contradicts the property’s own description, which states a license must be available on *either* the distribution *or* its parent dataset.

The either/or rule is already enforced by the existing `DistributionLicenseRequiredShape` SPARQL constraint (a Violation today), so no SHACL `sh:minCount` is needed.

## Changes

- Remove `sh:minCount 1` and `sh:severity sh:Violation` from the v2.0 future change on the distribution license property shape.
- Keep `sh:nodeKind sh:IRI` in the future change so v2.0 still tightens the value format from `IRIOrLiteral` to `IRI`.
