### PR TITLE
fix(shacl): mark schema:contactPoint as v2.0 violation

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -646,6 +646,10 @@ nde-dataset:OrganizationContactPointRequiredShape
     a sh:NodeShape ;
     sh:targetObjectsOf schema:publisher, schema:creator ;
     sh:severity sh:Warning ;
+    nde:futureChange [
+        nde:version "2.0" ;
+        sh:severity sh:Violation ;
+    ] ;
     sh:message "Een organisatie moet een ContactPoint hebben"@nl, "An organization must have a ContactPoint"@en ;
     sh:sparql [
         sh:select """


### PR DESCRIPTION
Aligns the Schema.org-side `schema:contactPoint` requirement with the DCAT-side `dcat:contactPoint` requirement, both of which become violations in v2.0. Without this, Schema.org publishers could omit a contact point and the generated DCAT-AP-NL output would be incomplete.