### PR TITLE
fix(shacl): require dc:accrualPeriodicity from EU vocabulary

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -381,7 +381,6 @@ nde-dataset:DatasetShape
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:pattern "^http://publications\\.europa\\.eu/resource/authority/frequency/" ;
-            sh:severity sh:Warning ;
             sh:name "Updatefrequentie"@nl, "Accrual periodicity"@en ;
             sh:description """Hoe vaak de dataset wordt bijgewerkt.
                 Gebruik een waarde uit de EU-frequentielijst,
@@ -1138,7 +1137,6 @@ dcat:DatasetShape
         sh:maxCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:pattern "^http://publications\\.europa\\.eu/resource/authority/frequency/" ;
-        sh:severity sh:Warning ;
         sh:name "Updatefrequentie"@nl, "Accrual periodicity"@en ;
         sh:description """Hoe vaak de dataset wordt bijgewerkt.
             Gebruik een waarde uit de EU-frequentielijst,


### PR DESCRIPTION
Promotes the `dc:accrualPeriodicity` EU frequency vocabulary check from warning to violation immediately (no migration window). Applies to both the Schema.org Dataset shape and the DCAT Dataset shape. Default SHACL severity (`sh:Violation`) applies once `sh:severity sh:Warning` is removed.