### PR TITLE
fix(shacl): mark DataCatalog schema:publisher as v2.0 violation

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -47,6 +47,10 @@ nde-dataset:DatacatalogShape
             sh:minCount 1 ;
             sh:maxCount 1 ;
             sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
             sh:name "Persoon of organisatie die de datacatalogus heeft gepubliceerd"@nl, "Person or organization that published the data catalog"@en ;
             sh:description """
                 The publisher of the data catalog.


### PR DESCRIPTION
Aligns the Schema.org-side DataCatalog publisher requirement with the DCAT-side Catalog publisher requirement (already scheduled for v2.0). Without this, a Schema.org publisher could omit the catalog publisher and the generated DCAT-AP-NL Catalog would be incomplete.