### PR TITLE
fix(shacl): validate ISO-8601 dates on DCAT date properties

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -998,6 +998,16 @@ dcat:DatasetShape
         sh:message "Dataset zou een aanmaakdatum moeten hebben"@nl, "Dataset description  should have a creation date"@en ;
     ],
     [
+        sh:path dc:created ;
+        sh:node nde-dataset:DateTimeShape ;
+        sh:severity sh:Warning ;
+        nde:futureChange [
+            nde:version "2.0" ;
+            sh:severity sh:Violation ;
+        ] ;
+        sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
+    ],
+    [
         sh:path dc:issued ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
@@ -1006,12 +1016,32 @@ dcat:DatasetShape
         sh:message "Dataset zou een uitgavedatum moeten bevatten"@nl, "Dataset description  should contain an issued date"@en ;
     ],
     [
+        sh:path dc:issued ;
+        sh:node nde-dataset:DateTimeShape ;
+        sh:severity sh:Warning ;
+        nde:futureChange [
+            nde:version "2.0" ;
+            sh:severity sh:Violation ;
+        ] ;
+        sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
+    ],
+    [
         sh:path dc:modified ;
         sh:minCount 1 ;
         sh:maxCount 1 ;
         sh:severity sh:Info ;
         sh:description "De meest recente datum waarop de dataset is gewijzigd of aangepast."@nl, "The most recent date on which the dataset was changed or modified."@en ;
         sh:message "Datasetbeschrijving zou een laatste wijzigingsdatum moeten bevatten"@nl, "Dataset description  should contain a modification date"@en ;
+    ],
+    [
+        sh:path dc:modified ;
+        sh:node nde-dataset:DateTimeShape ;
+        sh:severity sh:Warning ;
+        nde:futureChange [
+            nde:version "2.0" ;
+            sh:severity sh:Violation ;
+        ] ;
+        sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
     ],
     [
         sh:path dcat:keyword ;


### PR DESCRIPTION
Adds the existing `DateTimeShape` regex check to `dc:created`, `dc:issued`, and `dc:modified` on the DCAT Dataset shape, mirroring the Schema.org side. Starts as warning, becomes violation in v2.0. The DCAT side previously had no ISO-8601 lexical-form validation at all (only minCount/maxCount as Info severity), so for example `"not-a-date"^^xsd:dateTime` would slip through. `sh:datatype` alone is engine-dependent on lexical-form validation, so the regex remains the portable defensive check.