### PR TITLE
fix(shacl): keep Catalog dc:publisher recommended, not required in v2.0

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -1288,10 +1288,6 @@ dcat:CatalogShape
         sh:path dc:publisher ;
         sh:minCount 1 ;
         sh:severity sh:Warning ;
-        nde:futureChange [
-            nde:version "2.0" ;
-            sh:severity sh:Violation ;
-        ] ;
         sh:description "De organisatie die verantwoordelijk is voor de publicatie van de catalogus."@nl,
             "The organization responsible for publishing the catalog."@en ;
         sh:message "Catalogus moet een uitgever hebben"@nl, "Catalog must have a publisher"@en ;


### PR DESCRIPTION
DCAT-AP-NL 3.0 marks `dct:publisher` on `dcat:Catalog` as *aanbevolen* (recommended, code "A"), not *verplicht* (required). Reverts the v2.0 violation promotion introduced earlier so we stay aligned with DCAT-AP-NL's cardinality rather than being stricter than the profile itself. Related: #1838 (closed, would have added the same stricter rule on the Schema.org side).