### PR TITLE
refactor(shacl): extract reusable AccrualPeriodicityProperty shape

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -387,21 +387,7 @@ nde-dataset:DatasetShape
             """@en ;
             sh:message "De datacatalogus moet een IRI zijn, geen tekst"@nl, "The data catalog must be an IRI, not a string literal"@en ;
         ] ,
-        [
-            a sh:PropertyShape ;
-            sh:path dc:accrualPeriodicity ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:pattern "^http://publications\\.europa\\.eu/resource/authority/frequency/" ;
-            sh:name "Updatefrequentie"@nl, "Accrual periodicity"@en ;
-            sh:description """Hoe vaak de dataset wordt bijgewerkt.
-                Gebruik een waarde uit de EU-frequentielijst,
-                bijvoorbeeld http://publications.europa.eu/resource/authority/frequency/WEEKLY ."""@nl,
-                """How often the dataset is updated.
-                Use a value from the EU frequency list,
-                for example http://publications.europa.eu/resource/authority/frequency/WEEKLY ."""@en ;
-            sh:message "Updatefrequentie moet een IRI zijn uit de EU-frequentielijst"@nl, "Accrual periodicity must be an IRI from the EU frequency list"@en ;
-        ] ,
+        nde-dataset:AccrualPeriodicityProperty ,
         nde-dataset:AccessRightsProperty
 .
 
@@ -925,6 +911,21 @@ nde-dataset:LicenseOpenDataCommonsShape a sh:NodeShape ;
         [ sh:pattern "^http://opendatacommons\\.org/licenses/[^/]+/[0-9]+\\.[0-9]+/$" ]
     ) .
 
+nde-dataset:AccrualPeriodicityProperty a sh:PropertyShape ;
+    sh:path dc:accrualPeriodicity ;
+    sh:maxCount 1 ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^http://publications\\.europa\\.eu/resource/authority/frequency/" ;
+    sh:name "Updatefrequentie"@nl, "Accrual periodicity"@en ;
+    sh:description """Hoe vaak de dataset wordt bijgewerkt.
+        Gebruik een waarde uit de EU-frequentielijst,
+        bijvoorbeeld http://publications.europa.eu/resource/authority/frequency/WEEKLY ."""@nl,
+        """How often the dataset is updated.
+        Use a value from the EU frequency list,
+        for example http://publications.europa.eu/resource/authority/frequency/WEEKLY ."""@en ;
+    sh:message "Updatefrequentie moet een IRI zijn uit de EU-frequentielijst"@nl, "Accrual periodicity must be an IRI from the EU frequency list"@en ;
+.
+
 nde-dataset:AccessRightsProperty a sh:PropertyShape ;
     sh:path dc:accessRights ;
     sh:minCount 0 ;
@@ -1181,21 +1182,7 @@ dcat:DatasetShape
         sh:description "Een beschikbare representatie van de dataset."@nl, "An available representation of the dataset."@en ;
         sh:message "Datasetbeschrijving zou minstens één distributie moeten bevatten"@nl, "Dataset description should contain at least one distribution"@en ;
     ] ,
-    [
-        a sh:PropertyShape ;
-        sh:path dc:accrualPeriodicity ;
-        sh:maxCount 1 ;
-        sh:nodeKind sh:IRI ;
-        sh:pattern "^http://publications\\.europa\\.eu/resource/authority/frequency/" ;
-        sh:name "Updatefrequentie"@nl, "Accrual periodicity"@en ;
-        sh:description """Hoe vaak de dataset wordt bijgewerkt.
-            Gebruik een waarde uit de EU-frequentielijst,
-            bijvoorbeeld http://publications.europa.eu/resource/authority/frequency/WEEKLY ."""@nl,
-            """How often the dataset is updated.
-            Use a value from the EU frequency list,
-            for example http://publications.europa.eu/resource/authority/frequency/WEEKLY ."""@en ;
-        sh:message "Updatefrequentie moet een IRI zijn uit de EU-frequentielijst"@nl, "Accrual periodicity must be an IRI from the EU frequency list"@en ;
-    ] ,
+    nde-dataset:AccrualPeriodicityProperty ,
     nde-dataset:AccessRightsProperty ,
     [
         a sh:PropertyShape ;


### PR DESCRIPTION
The `dc:accrualPeriodicity` constraint was defined inline on both the Schema.org `DatasetShape` and the DCAT `dcat:DatasetShape` with identical content (same path, maxCount, IRI pattern, name, description, message). Extracts it into `nde-dataset:AccrualPeriodicityProperty`, mirroring the existing `AccessRightsProperty` pattern. Semantic no-op.