### PR TITLE
fix(shacl): align publisher cardinality with DCAT-AP-NL 3.0

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -47,6 +47,10 @@ nde-dataset:DatacatalogShape
             sh:minCount 1 ;
             sh:maxCount 1 ;
             sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
             sh:name "Persoon of organisatie die de datacatalogus heeft gepubliceerd"@nl, "Person or organization that published the data catalog"@en ;
             sh:description """
                 The publisher of the data catalog.
@@ -1116,6 +1120,7 @@ dcat:DatasetShape
     [
         sh:path dc:publisher ;
         sh:minCount 1 ;
+        sh:maxCount 1 ;
         sh:severity sh:Warning ;
         nde:futureChange [
             nde:version "2.0" ;
@@ -1335,6 +1340,7 @@ dcat:CatalogShape
     [
         sh:path dc:publisher ;
         sh:minCount 1 ;
+        sh:maxCount 1 ;
         sh:severity sh:Warning ;
         nde:futureChange [
             nde:version "2.0" ;


### PR DESCRIPTION
DCAT-AP-NL 3.0 specifies `dct:publisher` as *Verplicht* (V), cardinality 1..1 on both Dataset (§4.2.13) and Catalog (§4.4.13). Aligns our SHACL:

- `schema:publisher` on DataCatalog: adds `nde:futureChange` to promote from Warning to Violation in v2.0, matching the DCAT Catalog side.
- `dc:publisher` on DCAT Dataset: adds `sh:maxCount 1` (previously only minCount 1 was enforced).
- `dc:publisher` on DCAT Catalog: adds `sh:maxCount 1` (same gap).

Supersedes #1838 (closed) and #1840 (closed, was based on a wrong reading of the spec's summary table; the per-property detail section is authoritative).