### PR TITLE
fix(spec): suppress contradictory ‘becomes required’ on already-required properties

### DIFF
--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -60,10 +60,12 @@
                 {% endif -%}
             </td>
             <td>
+                {% assign is_required = false -%}
                 {% if property.minCount > 0 -%}
                     {% assign severity = property.severity | default: "Violation" -%}
                     {% if severity == "Violation" or property.severity == "Warning" -%}
                         Required
+                        {% assign is_required = true -%}
                     {% else -%}
                         Recommended
                     {% endif -%}
@@ -72,21 +74,25 @@
                 {% endif -%}
                 {% if property['nde:futureChange'] -%}
                     {% assign change = property['nde:futureChange'] -%}
-                    <br><small>v{{ change['nde:version'] }}:
+                    {% assign future_text = "" -%}
                     {% if change.datatype -%}
-                        must be {{ change.datatype | replace: 'http://www.w3.org/2001/XMLSchema#', 'xsd:' }}
+                        {% assign future_text = change.datatype | replace: 'http://www.w3.org/2001/XMLSchema#', 'xsd:' | prepend: 'must be ' -%}
                     {% elsif change.pattern -%}
-                        must match <code>{{ change.pattern }}</code>
+                        {% capture future_text %}must match <code>{{ change.pattern }}</code>{% endcapture -%}
                     {% elsif change.nodeKind == "IRI" and change.severity != "Violation" -%}
-                        must be IRI
+                        {% assign future_text = "must be IRI" -%}
                     {% elsif change.maxCount -%}
-                        max {{ change.maxCount }}
+                        {% assign future_text = change.maxCount | prepend: "max " -%}
                     {% elsif change.severity == "Violation" and property.nodeKind == "IRI" -%}
-                        must be IRI
-                    {% elsif change.severity == "Violation" -%}
-                        becomes required
+                        {% assign future_text = "must be IRI" -%}
+                    {% elsif change.severity == "Violation" and property.datatype -%}
+                        {% assign future_text = property.datatype | replace: 'http://www.w3.org/2001/XMLSchema#', 'xsd:' | replace: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'rdf:' | prepend: 'must be ' -%}
+                    {% elsif change.severity == "Violation" and is_required == false -%}
+                        {% assign future_text = "becomes required" -%}
                     {% endif -%}
-                    </small>
+                    {% if future_text != "" -%}
+                        <br><small>v{{ change['nde:version'] }}: {{ future_text }}</small>
+                    {% endif -%}
                 {% endif -%}
             </td>
         </tr>


### PR DESCRIPTION
## Summary

The generated spec rendered contradictory cells like "Required / v2.0: becomes required" on properties that are already required today (e.g. `schema:name`, `schema:description`, `schema:creator`, `dc:title`, `dc:description`). The `becomes required` catch-all fired whenever a `nde:futureChange` upgraded severity from Warning to Violation, even when the merged property was already labeled Required.

## Changes

- Track an `is_required` flag in `requirements/attributes.liquid` and guard the `becomes required` branch so it only renders when the property is not currently Required.
- Add a branch that, when a futureChange upgrades severity to Violation and the property shape carries a `sh:datatype`, renders "must be `<datatype>`" (e.g. `rdf:langString`) — surfacing the actual v2.0 constraint that was hidden behind the generic fallback.
- Restructure the template so the `<small>v2.0: …</small>` wrapper is only emitted when there is meaningful text to show.

## Result

- `schema:name`, `schema:description`, `dc:title`, `dc:description`: "Required / v2.0: must be rdf:langString"
- `schema:creator`: "Required" (no contradictory suffix)
- Other properties with `change.datatype`, `change.pattern`, `change.nodeKind`, `change.maxCount` continue to render as before.
