### PR TITLE
docs(spec): populate attribute tables and normalize URI to IRI

### DIFF
--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -275,8 +275,8 @@ describe('Validator', () => {
     expect(formatReport(report)).toMatchInlineSnapshot(`
       "[Warning] https://schema.org/contactPoint on <https://www.goudatijdmachine.nl/omeka/api/items/232>: An organization must have a ContactPoint
       [Warning] https://schema.org/identifier on <https://www.goudatijdmachine.nl/omeka/api/items/232>: An organization must have one or more identifiers
-      [Warning] https://schema.org/license on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: Use one of the recommended canonical license URIs
-      [Warning] https://schema.org/license on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: Use the canonical Creative Commons license URI with https:// (e.g. https://creativecommons.org/publicdomain/zero/1.0/)"
+      [Warning] https://schema.org/license on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: Use one of the recommended canonical license IRIs
+      [Warning] https://schema.org/license on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: Use the canonical Creative Commons license IRI with https:// (e.g. https://creativecommons.org/publicdomain/zero/1.0/)"
     `);
   });
 

--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -19,6 +19,13 @@
             <td>1</td>
             <td>Required</td>
         </tr>
+        {% elsif nodeShape['nde:futureChange'].nodeKind == "IRI" %}
+        <tr>
+            <th scope="row">@id</th>
+            <td>The HTTP [[IRI]] of the {{ name }}.</td>
+            <td>1</td>
+            <td>Recommended<br><small>v{{ nodeShape['nde:futureChange']['nde:version'] }}: must be IRI</small></td>
+        </tr>
         {% endif %}
         {% assign merged_properties = nodeShape.property | mergePropertiesByPath -%}
         {% for property in merged_properties %}
@@ -26,22 +33,25 @@
         <tr>
             <th scope="row">[{{ property.path }}]({{ property.path }})</th>
             <td>
-                {%- if property.node['@id'] == "https://def.nde.nl/dataset#DateTimeShape" -%}
-                    See [[#dataset-date]].
-                {%- elsif property.path == "https://schema.org/publisher" or property.path == "https://schema.org/creator" -%}
+                {%- if property.node['@id'] == "nde-dataset:DateTimeShape" -%}
+                    {%- assign description = property.description | lang: "en" -%}
+                    {%- if description != "" -%}{{ description }} {% endif -%}See [[#dataset-date]].
+                {%- elsif property.path == "schema:publisher" or property.path == "schema:creator" -%}
                     {{ property.name | lang: "en" }}. See [[#creator-publisher-information]].
-                {%- elsif property.path == "https://schema.org/contactPoint" -%}
+                {%- elsif property.path == "schema:contactPoint" -%}
                     {{ property.description | lang: "en" }} See [[#contact]].
                 {%- elsif name == 'Dataset' -%}
-                    {%- if property.path == "https://schema.org/name" or property.path == "https://schema.org/description" -%}
+                    {%- if property.path == "schema:name" -%}
                         {{ property.name | lang: "en" }}. See [[#dataset-basic]].
-                    {%- elsif property.path == "https://schema.org/license" -%}
-                        See [[#dataset-license]].
-                    {%- elsif property.path == "https://schema.org/distribution" -%}
-                        See [[#dataset-distributions]].
-                    {%- elsif property.path == "https://schema.org/version" -%}
-                        See [[#dataset-versions]].
-                    {%- elsif property.node['@id'] == "https://def.nde.nl/dataset#DateTimeShape" -%}
+                    {%- elsif property.path == "schema:description" -%}
+                        {{ property.description | lang: "en" }} See [[#dataset-basic]].
+                    {%- elsif property.path == "schema:license" -%}
+                        {{ property.description | lang: "en" }} See [[#dataset-license]].
+                    {%- elsif property.path == "schema:distribution" -%}
+                        {{ property.description | lang: "en" }} See [[#dataset-distributions]].
+                    {%- elsif property.path == "schema:version" -%}
+                        {{ property.description | lang: "en" }} See [[#dataset-versions]].
+                    {%- elsif property.node['@id'] == "nde-dataset:DateTimeShape" -%}
                         See [[#dataset-date]].
                     {%- else -%}
                         {{ property.description | lang: "en" }}
@@ -87,6 +97,8 @@
                         {% assign future_text = "must be IRI" -%}
                     {% elsif change.severity == "Violation" and property.datatype -%}
                         {% assign future_text = property.datatype | replace: 'http://www.w3.org/2001/XMLSchema#', 'xsd:' | replace: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'rdf:' | prepend: 'must be ' -%}
+                    {% elsif change.severity == "Violation" and property.node['@id'] == "nde-dataset:DateTimeShape" -%}
+                        {% assign future_text = "must be valid ISO 8601" -%}
                     {% elsif change.severity == "Violation" and is_required == false -%}
                         {% assign future_text = "becomes required" -%}
                     {% endif -%}

--- a/requirements/index.bs.liquid
+++ b/requirements/index.bs.liquid
@@ -188,17 +188,17 @@ When the [=dataset description=] is embedded in an HTML page (see [[#rdf]]), `te
 
 See also [[DWBP-UCR#R-UniqueIdentifier]] and [[DWBP-UCR#R-PersistentIdentification]].
 
-### Resolvable dataset URIs ### {#resolvable-uris}
+### Resolvable dataset IRIs ### {#resolvable-iris}
 
-[=Consumers=] want to look up a [=dataset=] by its URI.
-When the dataset URI resolves, consumers can retrieve both the machine-readable [=dataset description=] (via [content negotiation](https://httpwg.org/specs/rfc9110.html#content.negotiation))
+[=Consumers=] want to look up a [=dataset=] by its IRI.
+When the dataset IRI resolves, consumers can retrieve both the machine-readable [=dataset description=] (via [content negotiation](https://httpwg.org/specs/rfc9110.html#content.negotiation))
 and a human-readable HTML page without needing a separate landing page URL.
 
-> Therefore, publishers *SHOULD* ensure that the dataset URI resolves
+> Therefore, publishers *SHOULD* ensure that the dataset IRI resolves
 > and serves both an RDF representation (the [=dataset description=]) and an HTML representation.
 > The HTML representation *MUST* be consistent with and include at least all details (such as distributions) from the RDF representation.
 
-When the dataset URI resolves to an HTML page, a separate `mainEntityOfPage` is not needed (see [[#more-information]]).
+When the dataset IRI resolves to an HTML page, a separate `mainEntityOfPage` is not needed (see [[#more-information]]).
 
 ### Information remains available ### {#available}
 
@@ -268,12 +268,12 @@ Publishers *MUST* include basic information about the dataset, at the very minim
 [DCAT-AP-NL 3.0](https://docs.geostandaarden.nl/dcat/dcat-ap-nl30/) requires the use of Creative Commons licences
 and defines a [value list](https://definities.geostandaarden.nl/dcat-ap-nl/id/waardelijst/licenties/) for licences.
 The default *SHOULD* be [CC0](https://creativecommons.org/publicdomain/zero/1.0/) (`https://creativecommons.org/publicdomain/zero/1.0/`).
-The following table lists the recommended canonical license URIs.
-Creative Commons URIs *MUST* use `https://` and end with a trailing slash.
+The following table lists the recommended canonical license IRIs.
+Creative Commons IRIs *MUST* use `https://` and end with a trailing slash.
 
 <table class="data">
     <thead>
-        <tr><th>Canonical URI</th></tr>
+        <tr><th>Canonical IRI</th></tr>
     </thead>
     <tbody>
         {% for uri in license.in -%}
@@ -283,7 +283,7 @@ Creative Commons URIs *MUST* use `https://` and end with a trailing slash.
 </table>
 
 <div class="advisement">
-    In v2.0 of this specification, the license *MUST* be one of the URIs listed above.
+    In v2.0 of this specification, the license *MUST* be one of the IRIs listed above.
 </div>
 
 See also [[DWBP-UCR#R-LicenseAvailable]].
@@ -588,22 +588,22 @@ but simple dates (`2019-04-14`) are also allowed.
 
 ### Usage information ### {#usage-information}
 
-Each distribution *SHOULD* include one or more [schema:usageInfo](https://schema.org/usageInfo) URIs
+Each distribution *SHOULD* include one or more [schema:usageInfo](https://schema.org/usageInfo) IRIs
 that describe what the distribution provides.
 
-For [=web APIs=], this *MUST* be the URI of the protocol specification (such as SPARQL or OAI-PMH).
-The Dataset Register uses this URI to identify the distribution as an API.
+For [=web APIs=], this *MUST* be the IRI of the protocol specification (such as SPARQL or OAI-PMH).
+The Dataset Register uses this IRI to identify the distribution as an API.
 
-For downloads as well as APIs, this *MUST* be the URI of the application profile(s) that the data conforms to.
+For downloads as well as APIs, this *MUST* be the IRI of the application profile(s) that the data conforms to.
 
 <table>
-    <caption>Recommended URIs for typing distributions</caption>
+    <caption>Recommended IRIs for typing distributions</caption>
     <thead>
         <tr>
             <th>Item</th>
             <th>Type</th>
             <th>Applies to</th>
-            <th>URI</th>
+            <th>IRI</th>
         </tr>
     </thead>
     <tbody>
@@ -841,7 +841,7 @@ Version 1.5.1 (2026-04-10) {#v1.5.1}
 
 - Correct v2.0 annotation for IRI-constrained properties in spec ([63e694a](https://github.com/netwerk-digitaal-erfgoed/dataset-register/commit/63e694a7256b3666dbe3e2d64cc3207c65ddb81c)).
 - Use single sh:message on SPARQL constraint for Jena compatibility ([5e67a50](https://github.com/netwerk-digitaal-erfgoed/dataset-register/commit/5e67a5004888e0d04690eb906f3bb543ca28425e)).
-- Add resolvable dataset URI requirement and update mainEntityOfPage ([59f995d](https://github.com/netwerk-digitaal-erfgoed/dataset-register/commit/59f995ded5d4ae48f4b60160fc0e5a75e7901a61)).
+- Add resolvable dataset IRI requirement and update mainEntityOfPage ([59f995d](https://github.com/netwerk-digitaal-erfgoed/dataset-register/commit/59f995ded5d4ae48f4b60160fc0e5a75e7901a61)).
 
 Version 1.5.0 (2026-04-02) {#v1.5.0}
 ----------

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -24,6 +24,10 @@ nde-dataset:DatacatalogShape
     sh:class schema:DataCatalog ;
     rdfs:label "Datacatalogus"@nl, "Data catalog"@en ;
     sh:description "Een datacatalogus bestaat uit een set van datasetbeschrijvingen"@nl, "A data catalog consists of a set of dataset descriptions"@en ;
+    nde:futureChange [
+        nde:version "2.0" ;
+        sh:nodeKind sh:IRI ;
+    ] ;
     sh:property
         [
             sh:path schema:name ;
@@ -38,10 +42,10 @@ nde-dataset:DatacatalogShape
         ] ,
         nde-dataset:SchemaNameUniqueLangProperty,
         nde-dataset:SchemaNameLangStringProperty,
+        nde-dataset:SchemaDescriptionPropertyShouldExist,
         nde-dataset:SchemaDescriptionProperty,
         nde-dataset:SchemaDescriptionUniqueLangProperty,
         nde-dataset:SchemaDescriptionLangStringProperty,
-        nde-dataset:SchemaDescriptionPropertyShouldExist,
         [
             sh:path schema:publisher ;
             sh:minCount 1 ;
@@ -89,7 +93,7 @@ nde-dataset:DatasetShape
                 [ sh:datatype xsd:string ]
                 [ sh:datatype rdf:langString ]
             ) ;
-            sh:name "Naam van de dataset"@nl, "Name of the dataset"@en ;
+            sh:name "Naam van de beschreven dataset"@nl, "Name of the described dataset"@en ;
             sh:message "Een datasetbeschrijving moet een naam hebben"@nl, "A dataset description must have a name"@en ;
         ] ,
         nde-dataset:SchemaNameUniqueLangProperty,
@@ -119,7 +123,9 @@ nde-dataset:DatasetShape
                 nde:version "2.0" ;
                 sh:nodeKind sh:IRI ;
             ] ;
+            sh:minCount 1 ;
             sh:maxCount 1 ;
+            sh:severity sh:Warning ;
             sh:name "Licentie"@nl, "License"@en ;
             sh:description """Licentie die van toepassing is op de dataset.
                 Als de dataset een licentie heeft, wordt deze overgenomen door alle distributies die geen eigen licentie hebben."""@nl, """
@@ -136,11 +142,11 @@ nde-dataset:DatasetShape
                 Adopting a non-open license will severely limit reuse and does not comply
                 with the DERA principles.
 
-                The value *MUST* be the canonical URI of a license.
+                The value *MUST* be the canonical IRI of a license.
                 For example, use https://creativecommons.org/publicdomain/zero/1.0/ instead
                 of https://creativecommons.org/publicdomain/zero/1.0/deed.nl.
                 """@en ;
-            sh:message "Een datasetbeschrijving moet één licentie bevatten (in de vorm van een URI)"@nl, "A dataset description must contain one license (in the form of a URI)"@en ;
+            sh:message "Een datasetbeschrijving moet één licentie bevatten (in de vorm van een URI)"@nl, "A dataset description must contain one license (in the form of an IRI)"@en ;
         ] ,
         [
             sh:path schema:license ;
@@ -159,39 +165,40 @@ nde-dataset:DatasetShape
                 <https://creativecommons.org/licenses/by-nd/4.0/>
                 <https://creativecommons.org/licenses/by-nc-nd/4.0/>
             ) ;
-            sh:message "Gebruik een van de aanbevolen canonieke licentie-URI's"@nl, "Use one of the recommended canonical license URIs"@en ;
+            sh:message "Gebruik een van de aanbevolen canonieke licentie-URI's"@nl, "Use one of the recommended canonical license IRIs"@en ;
         ] ,
         [
             sh:path schema:license ;
             sh:node nde-dataset:LicenseCreativeCommonsHttpsShape ;
             sh:severity sh:Warning ;
-            sh:message "Gebruik de canonieke Creative Commons licentie-URI met https:// (bijv. https://creativecommons.org/publicdomain/zero/1.0/)"@nl, "Use the canonical Creative Commons license URI with https:// (e.g. https://creativecommons.org/publicdomain/zero/1.0/)"@en ;
+            sh:message "Gebruik de canonieke Creative Commons licentie-URI met https:// (bijv. https://creativecommons.org/publicdomain/zero/1.0/)"@nl, "Use the canonical Creative Commons license IRI with https:// (e.g. https://creativecommons.org/publicdomain/zero/1.0/)"@en ;
         ] ,
         [
             sh:path schema:license ;
             sh:node nde-dataset:LicenseCreativeCommonsTrailingSlashShape ;
             sh:severity sh:Warning ;
-            sh:message "Gebruik de canonieke Creative Commons licentie-URI met een afsluitende slash (bijv. https://creativecommons.org/licenses/by/4.0/)"@nl, "Use the canonical Creative Commons license URI with a trailing slash (e.g. https://creativecommons.org/licenses/by/4.0/)"@en ;
+            sh:message "Gebruik de canonieke Creative Commons licentie-URI met een afsluitende slash (bijv. https://creativecommons.org/licenses/by/4.0/)"@nl, "Use the canonical Creative Commons license IRI with a trailing slash (e.g. https://creativecommons.org/licenses/by/4.0/)"@en ;
         ] ,
         [
             sh:path schema:license ;
             sh:node nde-dataset:LicenseNotOpenDefinitionShape ;
             sh:severity sh:Warning ;
-            sh:message "Gebruik de canonieke licentie-URI van de licentiegever zelf (bijv. https://creativecommons.org/licenses/by/4.0/), niet een opendefinition.org-alias"@nl, "Use the canonical license URI from the license issuer itself (e.g. https://creativecommons.org/licenses/by/4.0/), not an opendefinition.org alias"@en ;
+            sh:message "Gebruik de canonieke licentie-URI van de licentiegever zelf (bijv. https://creativecommons.org/licenses/by/4.0/), niet een opendefinition.org-alias"@nl, "Use the canonical license IRI from the license issuer itself (e.g. https://creativecommons.org/licenses/by/4.0/), not an opendefinition.org alias"@en ;
         ] ,
         [
             sh:path schema:license ;
             sh:node nde-dataset:LicenseOpenDataCommonsShape ;
             sh:severity sh:Warning ;
-            sh:message "Gebruik de canonieke OpenDataCommons licentie-URI met versienummer (bijv. http://opendatacommons.org/licenses/odbl/1.0/)"@nl, "Use the canonical OpenDataCommons license URI with version number (e.g. http://opendatacommons.org/licenses/odbl/1.0/)"@en ;
+            sh:message "Gebruik de canonieke OpenDataCommons licentie-URI met versienummer (bijv. http://opendatacommons.org/licenses/odbl/1.0/)"@nl, "Use the canonical OpenDataCommons license IRI with version number (e.g. http://opendatacommons.org/licenses/odbl/1.0/)"@en ;
         ] ,
         # Recommended properties
         [
+            sh:path schema:distribution ;
             sh:class schema:DataDownload ;
             sh:minCount 1 ;
             sh:severity sh:Info ;
-            sh:path schema:distribution ;
             sh:name "Dataset distributions"@en , "Distributies van een dataset"@nl ;
+            sh:description "Distributies waarmee de dataset kan worden opgehaald, bijvoorbeeld als download of via een API."@nl, "Distributions through which the dataset can be retrieved, for example as a download or via an API."@en ;
         ] ,
         [
             sh:path schema:creator ;
@@ -216,7 +223,8 @@ nde-dataset:DatasetShape
             sh:minCount 1 ;
             sh:maxCount 1 ;
             sh:severity sh:Info ;
-            sh:name "Publicatiedatum van de datasetbeschrijving"@nl, "Publication date of the dataset description"@en ;
+            sh:name "Publication date"@en, "Publicatiedatum"@nl ;
+            sh:description "Publicatiedatum van de datasetbeschrijving."@nl, "Publication date of the dataset description."@en ;
             sh:message "Een datasetbeschrijving zou één publicatiedatum moeten bevatten"@nl, "A dataset description should contain one publication date"@en ;
         ] ,
         [
@@ -234,7 +242,8 @@ nde-dataset:DatasetShape
             sh:minCount 1 ;
             sh:maxCount 1 ;
             sh:severity sh:Info ;
-            sh:name "Aanmaakdatum van de datasetbeschrijving"@nl, "Creation date of the dataset description"@en ;
+            sh:name "Creation date"@en, "Aanmaakdatum"@nl ;
+            sh:description "Aanmaakdatum van de datasetbeschrijving."@nl, "Creation date of the dataset description."@en ;
             sh:message "Een datasetbeschrijving zou één aanmaakdatum moeten bevatten"@nl, "A dataset description should contain one creation date"@en ;
         ] ,
         [
@@ -252,7 +261,8 @@ nde-dataset:DatasetShape
             sh:minCount 1 ;
             sh:maxCount 1 ;
             sh:severity sh:Info ;
-            sh:name "Datum waarop de datasetbeschrijving voor het laatst is gewijzigd"@nl, "Date on which the dataset description was last modified"@en ;
+            sh:name "Last modified date"@en, "Wijzigingsdatum"@nl ;
+            sh:description "Datum waarop de datasetbeschrijving voor het laatst is gewijzigd."@nl, "Date on which the dataset description was last modified."@en ;
             sh:message "Een datasetbeschrijving zou één wijzigingsdatum moeten bevatten"@nl, "A dataset description should contain one modification date"@en ;
         ] ,
         [
@@ -271,6 +281,7 @@ nde-dataset:DatasetShape
             sh:name "Version"@en ;
             sh:minCount 0 ;
             sh:maxCount 1 ;
+            sh:description "Versieaanduiding van de dataset, bijvoorbeeld een semantisch versienummer of een datum."@nl, "Version identifier of the dataset, for example a semantic version number or a date."@en ;
             sh:message "Een datasetbeschrijving mag een versie bevatten"@nl, "A dataset description may contain a version"@en ;
         ] ,
         [
@@ -282,9 +293,16 @@ nde-dataset:DatasetShape
             ] ;
             sh:minCount 0 ;
             sh:name "Language"@en ;
-            sh:description """
-                Language or languages in which the dataset is available. Use one of the language codes from the [[BCP47]], such as `nl-NL`.
-            """@en ;
+            sh:description """De natuurlijke taal van de tekstuele waardes in de dataset – dus van de beschrijvingen van de erfgoedobjecten zelf (titels, omschrijvingen, onderwerpen, enzovoort). Niet alle data heeft de eigenschap taal, bijvoorbeeld afbeeldingen.
+
+                Gebruik van de waardelijst EU Vocabularies Languages Named Authority List is vereist.
+
+                De waarde heeft alleen betrekking op de tekstuele waardes in de dataset zelf en niet op de taal van de metadata van de dataset. De taal van de datasetbeschrijving wordt opgenomen in de eigenschap language van de klasse CatalogRecord."""@nl,
+                """The natural language of the textual values within the dataset – that is, of the heritage object records themselves (titles, descriptions, subjects, and so on). Not all data has a language property, for example images.
+
+                Use of the EU Vocabularies Languages Named Authority List is required.
+
+                The value applies only to the textual values in the dataset itself and not to the language of the dataset description. The language of the dataset description is captured in the language property of the CatalogRecord class."""@en ;
         ] ,
         [
             a sh:PropertyShape ;
@@ -295,7 +313,7 @@ nde-dataset:DatasetShape
             sh:name "Main entity of page"@en ;
             sh:description """
                 URL of a landing page where the dataset is described for human users.
-                Not needed when the dataset URI itself resolves to an HTML page (see [[#resolvable-uris]]).
+                Not needed when the dataset IRI itself resolves to an HTML page (see [[#resolvable-iris]]).
                 The human-readable description *MUST* be consistent with and include at least all details (such as distributions) from the RDF dataset description.
             """@en ;
         ] ,
@@ -311,6 +329,7 @@ nde-dataset:DatasetShape
         [
             a sh:PropertyShape ;
             sh:path schema:citation ;
+            sh:minCount 0 ;
             sh:name "Citation"@en ;
             sh:description """
                 A citation or reference for the dataset.
@@ -480,7 +499,7 @@ nde-dataset:DistributionShape
             sh:path schema:datePublished ;
             sh:minCount 0 ;
             sh:maxCount 1 ;
-            sh:description "Date (or datetime) the distribution was published"@en ;
+            sh:description "Date (or datetime) the distribution was published."@en ;
         ] ,
         [
             sh:path schema:datePublished ;
@@ -497,7 +516,7 @@ nde-dataset:DistributionShape
             sh:path schema:dateModified ;
             sh:minCount 0 ;
             sh:maxCount 1 ;
-            sh:description "Date (or datetime) the distribution was last modified"@en ;
+            sh:description "Date (or datetime) the distribution was last modified."@en ;
         ] ,
         [
             sh:path schema:dateModified ;
@@ -621,6 +640,7 @@ nde-dataset:OrganizationShape
         ] ,
         [
             sh:path schema:identifier ;
+            sh:minCount 0 ;
             sh:or (
                 [ sh:datatype xsd:string ]
                 [ sh:class schema:PropertyValue ]
@@ -801,7 +821,16 @@ nde-dataset:SchemaDescriptionProperty a sh:PropertyShape ;
         [ sh:datatype rdf:langString ]
     );
     sh:name "Description"@en ;
-    sh:description "Description."@en ;
+    sh:description """Een beschrijving van de inhoud.
+        Deze is bij voorkeur minimaal drie zinnen en maximaal één alinea lang (2000 karakters).
+        De vindbaarheid wordt onder andere bepaald door de kwaliteit van de beschrijving.
+        Denk hierbij aan verschillende gebruikers, vakgenoten maar ook anderen,
+        waarvoor de tekst begrijpelijk moet zijn."""@nl,
+        """A description of the contents.
+        Preferably at least three sentences and at most one paragraph (2,000 characters).
+        Discoverability depends in part on the quality of the description.
+        Consider different audiences – both domain experts and others –
+        for whom the text should be understandable."""@en ;
     sh:message "Een beschrijving moet van type string of langString zijn"@nl, "A description must be of type string or langString"@en ;
 .
 
@@ -880,22 +909,12 @@ nde-dataset:SchemaDescriptionPropertyShouldExist a sh:PropertyShape ;
         nde:version "2.0" ;
         sh:severity sh:Violation ;
     ] ;
-    sh:description """Een beschrijving van de inhoud van de dataset.
-        Deze is bij voorkeur minimaal drie zinnen en maximaal één alinea lang (2000 karakters).
-        De vindbaarheid van de dataset wordt onder andere bepaald door de kwaliteit van de beschrijving.
-        Denk hierbij aan verschillende gebruikers, vakgenoten maar ook anderen,
-        waarvoor de tekst begrijpelijk moet zijn."""@nl,
-        """A free-text account of the dataset.
-        Preferably at least three sentences and at most one paragraph (2,000 characters).
-        The discoverability of the dataset depends in part on the quality of the description.
-        Consider different audiences — both domain experts and others —
-        for whom the text should be understandable."""@en ;
     sh:message "Moet een beschrijving hebben"@nl, "Must have a description"@en ;
 .
 
 # Reusable constraint shapes for license canonicality, referenced via sh:node
 # from every license property path. Even the DCAT-AP-NL 3.0 examples incorrectly
-# use http://creativecommons.org/publicdomain/zero/1.0/deed.nl as a license URI
+# use http://creativecommons.org/publicdomain/zero/1.0/deed.nl as a license IRI
 # (see https://docs.geostandaarden.nl/dcat/dcat-ap-nl30/#distribution-licence).
 nde-dataset:LicenseCreativeCommonsHttpsShape a sh:NodeShape ;
     sh:not [ sh:pattern "^http://creativecommons\\.org/" ] .
@@ -917,6 +936,7 @@ nde-dataset:LicenseOpenDataCommonsShape a sh:NodeShape ;
 
 nde-dataset:AccrualPeriodicityProperty a sh:PropertyShape ;
     sh:path dc:accrualPeriodicity ;
+    sh:minCount 0 ;
     sh:maxCount 1 ;
     sh:nodeKind sh:IRI ;
     sh:pattern "^http://publications\\.europa\\.eu/resource/authority/frequency/" ;
@@ -991,10 +1011,10 @@ dcat:DatasetShape
         De vindbaarheid van de dataset wordt onder andere bepaald door de kwaliteit van de beschrijving.
         Denk hierbij aan verschillende gebruikers, vakgenoten maar ook anderen,
         waarvoor de tekst begrijpelijk moet zijn."""@nl,
-            """A free-text account of the dataset.
+            """A description of the contents of the dataset.
         Preferably at least three sentences and at most one paragraph (2,000 characters).
         The discoverability of the dataset depends in part on the quality of the description.
-        Consider different audiences — both domain experts and others —
+        Consider different audiences – both domain experts and others –
         for whom the text should be understandable."""@en ;
         sh:message "Dataset moet een beschrijving hebben"@nl, "Dataset must have a description"@en ;
     ],
@@ -1198,7 +1218,7 @@ dcat:DatasetShape
         sh:name "Landing page"@en ;
         sh:description """
             A web page where the dataset is described for human users.
-            Not needed when the dataset URI itself resolves to an HTML page (see [[#resolvable-uris]]).
+            Not needed when the dataset IRI itself resolves to an HTML page (see [[#resolvable-iris]]).
             The human-readable description *MUST* be consistent with and include at least all details (such as distributions) from the RDF dataset description.
         """@en ;
     ] ;
@@ -1258,25 +1278,25 @@ dcat:DistributionShape
         sh:path dc:license ;
         sh:node nde-dataset:LicenseCreativeCommonsHttpsShape ;
         sh:severity sh:Warning ;
-        sh:message "Gebruik de canonieke Creative Commons licentie-URI met https:// (bijv. https://creativecommons.org/publicdomain/zero/1.0/)"@nl, "Use the canonical Creative Commons license URI with https:// (e.g. https://creativecommons.org/publicdomain/zero/1.0/)"@en ;
+        sh:message "Gebruik de canonieke Creative Commons licentie-URI met https:// (bijv. https://creativecommons.org/publicdomain/zero/1.0/)"@nl, "Use the canonical Creative Commons license IRI with https:// (e.g. https://creativecommons.org/publicdomain/zero/1.0/)"@en ;
     ] ,
     [
         sh:path dc:license ;
         sh:node nde-dataset:LicenseCreativeCommonsTrailingSlashShape ;
         sh:severity sh:Warning ;
-        sh:message "Gebruik de canonieke Creative Commons licentie-URI met een afsluitende slash (bijv. https://creativecommons.org/licenses/by/4.0/)"@nl, "Use the canonical Creative Commons license URI with a trailing slash (e.g. https://creativecommons.org/licenses/by/4.0/)"@en ;
+        sh:message "Gebruik de canonieke Creative Commons licentie-URI met een afsluitende slash (bijv. https://creativecommons.org/licenses/by/4.0/)"@nl, "Use the canonical Creative Commons license IRI with a trailing slash (e.g. https://creativecommons.org/licenses/by/4.0/)"@en ;
     ] ,
     [
         sh:path dc:license ;
         sh:node nde-dataset:LicenseNotOpenDefinitionShape ;
         sh:severity sh:Warning ;
-        sh:message "Gebruik de canonieke licentie-URI van de licentiegever zelf (bijv. https://creativecommons.org/licenses/by/4.0/), niet een opendefinition.org-alias"@nl, "Use the canonical license URI from the license issuer itself (e.g. https://creativecommons.org/licenses/by/4.0/), not an opendefinition.org alias"@en ;
+        sh:message "Gebruik de canonieke licentie-URI van de licentiegever zelf (bijv. https://creativecommons.org/licenses/by/4.0/), niet een opendefinition.org-alias"@nl, "Use the canonical license IRI from the license issuer itself (e.g. https://creativecommons.org/licenses/by/4.0/), not an opendefinition.org alias"@en ;
     ] ,
     [
         sh:path dc:license ;
         sh:node nde-dataset:LicenseOpenDataCommonsShape ;
         sh:severity sh:Warning ;
-        sh:message "Gebruik de canonieke OpenDataCommons licentie-URI met versienummer (bijv. http://opendatacommons.org/licenses/odbl/1.0/)"@nl, "Use the canonical OpenDataCommons license URI with version number (e.g. http://opendatacommons.org/licenses/odbl/1.0/)"@en ;
+        sh:message "Gebruik de canonieke OpenDataCommons licentie-URI met versienummer (bijv. http://opendatacommons.org/licenses/odbl/1.0/)"@nl, "Use the canonical OpenDataCommons license IRI with version number (e.g. http://opendatacommons.org/licenses/odbl/1.0/)"@en ;
     ] .
 
 dcat:CatalogShape


### PR DESCRIPTION
## Summary

Follow-up to #1833 (dct prefix): the attribute tables in the requirements spec had several correctness gaps once JSON-LD framing started emitting compact IRIs. Branches that compared against full IRIs stopped firing, shared shapes rendered the wrong description text, and several properties had no description or cardinality at all. This PR fixes the template, consolidates shape metadata, and fills in the missing cardinalities from DCAT-AP-NL.

## Changes

### Template (`requirements/attributes.liquid`)
- Compare `property.path` and `property.node['@id']` in compact form (`schema:…`, `nde-dataset:DateTimeShape`) so the per-property branches actually match after JSON-LD framing.
- Flow `property.description` into the Dataset branches for `schema:description`, `schema:license`, `schema:distribution`, `schema:version`, and into the `DateTimeShape` branch so description prose appears alongside the section cross-reference.
- Render the `DateTimeShape` severity bump as `v2.0: must be valid ISO 8601` instead of falling through to the generic `becomes required` fallback (which was misleading — cardinality does not change).
- Render a Recommended `@id` row when the NodeShape carries an `nde:futureChange` with `sh:nodeKind sh:IRI`, so DataCatalog gets an `@id` row advertising the v2.0 IRI requirement without enforcing it today.

### SHACL (`requirements/shacl.ttl`)
- Move the long `sh:description` prose for `schema:description` onto the shape that also carries `sh:name`, so a single shape acts as the authoritative metadata source; generalize the wording so it fits both Dataset and DataCatalog ("A description of the contents…").
- Add descriptions for `schema:distribution`, `schema:version`, and the Dataset date shapes (`datePublished`, `dateCreated`, `dateModified`); rewrite `sh:name` on the date shapes into short labels and split the previous wording into `sh:description`.
- Expand the `schema:inLanguage` (Dataset) description with Dutch + English text from DCAT-AP-NL, clarifying that it applies to the textual values in the dataset (heritage object records) rather than the dataset description metadata.
- Add cardinalities that were missing but implied by DCAT-AP-NL: `schema:license` 1..1 (Warning severity, so remains Recommended today), `dct:accrualPeriodicity` 0..1, `schema:citation` 0..n, Organization `schema:identifier` 0..n.
- Add an `nde:futureChange` on `DatacatalogShape` declaring `sh:nodeKind sh:IRI` for v2.0.
- Normalize `URI` → `IRI` across English `sh:description` and `sh:message` text (Dutch messages untouched).

### Spec prose (`requirements/index.bs.liquid`)
- Normalize `URI` → `IRI` across English prose, including the "Resolvable dataset IRIs" heading (anchor renamed to `#resolvable-iris`), the usage-information section, and the license IRIs table. `xsd:anyURI` (the datatype name) and historical CHANGELOG entries are left as-is.
