### PR TITLE
refactor(shacl): split date and HTTP(S) IRI shapes by failure mode

### DIFF
--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -30,10 +30,13 @@
         {% assign merged_properties = nodeShape.property | mergePropertiesByPath -%}
         {% for property in merged_properties %}
         {% unless property.path %}{% continue %}{% endunless %}
+        {%- assign node_json = property.node | jsonify -%}
+        {%- assign is_date_shape = node_json contains "DateDatatypeShape" -%}
+        {%- assign is_iri_shape = node_json contains "IriNodeKindShape" -%}
         <tr>
             <th scope="row">[{{ property.path }}]({{ property.path }})</th>
             <td>
-                {%- if property.node['@id'] == "nde-dataset:DateTimeShape" -%}
+                {%- if is_date_shape -%}
                     {%- assign description = property.description | lang: "en" -%}
                     {%- if description != "" -%}{{ description }} {% endif -%}See [[#dataset-date]].
                 {%- elsif property.path == "schema:publisher" or property.path == "schema:creator" -%}
@@ -51,7 +54,7 @@
                         {{ property.description | lang: "en" }} See [[#dataset-distributions]].
                     {%- elsif property.path == "schema:version" -%}
                         {{ property.description | lang: "en" }} See [[#dataset-versions]].
-                    {%- elsif property.node['@id'] == "nde-dataset:DateTimeShape" -%}
+                    {%- elsif is_date_shape -%}
                         See [[#dataset-date]].
                     {%- else -%}
                         {{ property.description | lang: "en" }}
@@ -95,9 +98,11 @@
                         {% assign future_text = change.maxCount | prepend: "max " -%}
                     {% elsif change.severity == "Violation" and property.nodeKind == "IRI" -%}
                         {% assign future_text = "must be IRI" -%}
+                    {% elsif change.severity == "Violation" and is_iri_shape -%}
+                        {% assign future_text = "must be IRI" -%}
                     {% elsif change.severity == "Violation" and property.datatype -%}
                         {% assign future_text = property.datatype | replace: 'http://www.w3.org/2001/XMLSchema#', 'xsd:' | replace: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'rdf:' | prepend: 'must be ' -%}
-                    {% elsif change.severity == "Violation" and property.node['@id'] == "nde-dataset:DateTimeShape" -%}
+                    {% elsif change.severity == "Violation" and is_date_shape -%}
                         {% assign future_text = "must be valid ISO 8601" -%}
                     {% elsif change.severity == "Violation" and is_required == false -%}
                         {% assign future_text = "becomes required" -%}

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -229,13 +229,12 @@ nde-dataset:DatasetShape
         ] ,
         [
             sh:path schema:datePublished ;
-            sh:node nde-dataset:DateTimeShape ;
+            sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
-            sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
         ] ,
         [
             sh:path schema:dateCreated ;
@@ -248,13 +247,12 @@ nde-dataset:DatasetShape
         ] ,
         [
             sh:path schema:dateCreated ;
-            sh:node nde-dataset:DateTimeShape ;
+            sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
-            sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
         ] ,
         [
             sh:path schema:dateModified ;
@@ -267,13 +265,12 @@ nde-dataset:DatasetShape
         ] ,
         [
             sh:path schema:dateModified ;
-            sh:node nde-dataset:DateTimeShape ;
+            sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
-            sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
         ] ,
         [
             a sh:PropertyShape ;
@@ -308,8 +305,7 @@ nde-dataset:DatasetShape
             a sh:PropertyShape ;
             sh:path schema:mainEntityOfPage ;
             sh:minCount 0 ;
-            sh:nodeKind sh:IRI ;
-            sh:pattern "^https?://" ;
+            sh:node nde-dataset:IriNodeKindShape, nde-dataset:HttpsIriFormatShape ;
             sh:name "Main entity of page"@en ;
             sh:description """
                 URL of a landing page where the dataset is described for human users.
@@ -366,16 +362,13 @@ nde-dataset:DatasetShape
         ] ,
         [
             sh:path schema:spatialCoverage ;
-            sh:nodeKind sh:IRI ;
-            sh:pattern "^https?://" ;
+            sh:node nde-dataset:IriNodeKindShape, nde-dataset:HttpsIriFormatShape ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
             sh:description "Spatial coverage must be an HTTP(S) IRI, for example from [GeoNames](https://www.geonames.org/)."@en ;
-            sh:message "Gebiedsaanduiding moet een HTTP(S)-IRI zijn (bijv. https://sws.geonames.org/2750405/)"@nl,
-                "Spatial coverage must be an HTTP(S) IRI (e.g. https://sws.geonames.org/2750405/)"@en ;
         ] ,
         [
             sh:path schema:temporalCoverage ;
@@ -397,8 +390,7 @@ nde-dataset:DatasetShape
         [
             a sh:PropertyShape ;
             sh:path schema:includedInDataCatalog ;
-            sh:nodeKind sh:IRI ;
-            sh:pattern "^https?://" ;
+            sh:node nde-dataset:IriNodeKindShape, nde-dataset:HttpsIriFormatShape ;
             sh:minCount 0 ;
             sh:severity sh:Warning ;
             nde:futureChange [
@@ -408,7 +400,6 @@ nde-dataset:DatasetShape
             sh:description """
                 The HTTP [[IRI]] of the data catalog(s) that the dataset belongs to.
             """@en ;
-            sh:message "De datacatalogus moet een IRI zijn, geen tekst"@nl, "The data catalog must be an IRI, not a string literal"@en ;
         ] ,
         nde-dataset:AccrualPeriodicityProperty ,
         nde-dataset:AccessRightsProperty
@@ -503,13 +494,12 @@ nde-dataset:DistributionShape
         ] ,
         [
             sh:path schema:datePublished ;
-            sh:node nde-dataset:DateTimeShape ;
+            sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
-            sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
         ] ,
         [
             a sh:PropertyShape ;
@@ -520,13 +510,12 @@ nde-dataset:DistributionShape
         ] ,
         [
             sh:path schema:dateModified ;
-            sh:node nde-dataset:DateTimeShape ;
+            sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
-            sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
         ] ,
         [
             a sh:PropertyShape ;
@@ -568,8 +557,7 @@ nde-dataset:DistributionShape
         [
             a sh:PropertyShape ;
             sh:path schema:usageInfo ;
-            sh:nodeKind sh:IRI ;
-            sh:pattern "^https?://" ;
+            sh:node nde-dataset:IriNodeKindShape, nde-dataset:HttpsIriFormatShape ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
@@ -577,7 +565,6 @@ nde-dataset:DistributionShape
             ] ;
             sh:minCount 0 ;
             sh:description "A link to the documentation: for downloads, the application profile, vocabulary or ontology; for [=web APIs=], the protocol specification. See [[#usage-information]]."@en ;
-            sh:message "usageInfo zou een IRI moeten zijn"@nl, "usageInfo should be an IRI"@en ;
         ] ,
         nde-dataset:SchemaDescriptionPropertyShouldExist .
 
@@ -799,16 +786,30 @@ nde-dataset:PersonShape
     ] ,
     nde-dataset:SchemaNameLangStringProperty .
 
-# Reusable constraint shape for ISO-8601 dates. Referenced via sh:node from every
-# date property shape so the datatype + pattern rule lives in one place.
-nde-dataset:DateTimeShape a sh:NodeShape ;
+# Reusable constraint shapes for ISO-8601 dates. Split so each failure mode
+# (wrong datatype vs. malformed lexical form) carries its own sh:message.
+nde-dataset:DateDatatypeShape a sh:NodeShape ;
     sh:or (
         [ sh:datatype schema:Date ]
         [ sh:datatype schema:DateTime ]
         [ sh:datatype xsd:dateTime ]
         [ sh:datatype xsd:date ]
     ) ;
-    sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}.*)?$" .
+    sh:message "Datum moet van type xsd:date, xsd:dateTime, schema:Date of schema:DateTime zijn"@nl, "Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime"@en .
+
+nde-dataset:DateFormatShape a sh:NodeShape ;
+    sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}.*)?$" ;
+    sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en .
+
+# Reusable constraint shapes for HTTP(S) IRI values. Split so the node-kind and
+# URL-scheme failures carry their own sh:message.
+nde-dataset:IriNodeKindShape a sh:NodeShape ;
+    sh:nodeKind sh:IRI ;
+    sh:message "Waarde moet een IRI zijn (RDF-resource), geen tekstuele waarde die op een URL lijkt"@nl, "Value must be an IRI (RDF resource), not a string literal that looks like a URL"@en .
+
+nde-dataset:HttpsIriFormatShape a sh:NodeShape ;
+    sh:pattern "^https?://" ;
+    sh:message "IRI moet beginnen met http:// of https://"@nl, "IRI must start with http:// or https://"@en .
 
 #
 # Property shapes
@@ -1043,13 +1044,12 @@ dcat:DatasetShape
     ],
     [
         sh:path dc:created ;
-        sh:node nde-dataset:DateTimeShape ;
+        sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
         sh:severity sh:Warning ;
         nde:futureChange [
             nde:version "2.0" ;
             sh:severity sh:Violation ;
         ] ;
-        sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
     ],
     [
         sh:path dc:issued ;
@@ -1061,13 +1061,12 @@ dcat:DatasetShape
     ],
     [
         sh:path dc:issued ;
-        sh:node nde-dataset:DateTimeShape ;
+        sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
         sh:severity sh:Warning ;
         nde:futureChange [
             nde:version "2.0" ;
             sh:severity sh:Violation ;
         ] ;
-        sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
     ],
     [
         sh:path dc:modified ;
@@ -1079,13 +1078,12 @@ dcat:DatasetShape
     ],
     [
         sh:path dc:modified ;
-        sh:node nde-dataset:DateTimeShape ;
+        sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
         sh:severity sh:Warning ;
         nde:futureChange [
             nde:version "2.0" ;
             sh:severity sh:Violation ;
         ] ;
-        sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
     ],
     [
         sh:path dcat:keyword ;


### PR DESCRIPTION
## Summary

Split reusable SHACL shapes by failure mode so each violation carries a message that accurately describes what went wrong.

- `DateTimeShape` → `DateDatatypeShape` (wrong datatype) + `DateFormatShape` (malformed ISO-8601 lexical form).
- Introduce `IriNodeKindShape` and `HttpsIriFormatShape` for HTTP(S) IRI properties (`schema:mainEntityOfPage`, `schema:spatialCoverage`, `schema:includedInDataCatalog`, `schema:usageInfo`). `IriNodeKindShape`’s message emphasizes that the value must *be* an IRI (RDF resource) – not a string literal that happens to look like a URL.
- All affected property shapes now reference the split shapes via `sh:node` and drop their conflated `sh:message`, so the inner shape’s specific message surfaces.
