### PR TITLE
fix(shacl): inline date and IRI constraints so failure messages surface

### DIFF
--- a/packages/core/test/datasets/dataset-schema-org-invalid-date-and-iri.ttl
+++ b/packages/core/test/datasets/dataset-schema-org-invalid-date-and-iri.ttl
@@ -1,0 +1,16 @@
+@prefix schema: <https://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://data.example.com/dataset/invalid-date-iri> a schema:Dataset ;
+    schema:name "Dataset with invalid date and IRI values" ;
+    schema:description "Fixture for regression-testing specific SHACL messages on split date and IRI property shapes." ;
+    schema:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+    schema:publisher <https://example.com/publisher> ;
+    schema:datePublished "not-a-date" ;
+    schema:dateCreated "2024/01/15" ;
+    schema:dateModified "2024-01-15" ;
+    schema:spatialCoverage "Netherlands" ;
+    schema:includedInDataCatalog "ftp://example.com/catalog" .
+
+<https://example.com/publisher> a schema:Organization ;
+    schema:name "Example Publisher" .

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -358,6 +358,73 @@ describe('Validator', () => {
     expectViolations(report, ['https://schema.org/license'], 2);
   });
 
+  it('reports split date and IRI failures with specific messages, not generic sh:node fallback', async () => {
+    // Regression: a previous refactor moved the datatype/pattern checks into
+    // reusable NodeShapes referenced via sh:node, which caused shacl-engine to
+    // emit the generic "Value does not have shape …" message. The checks must
+    // be inlined as separate property shapes so each carries its own sh:message.
+    const report = (await validate(
+      'dataset-schema-org-invalid-date-and-iri.ttl',
+      new StreamParser(),
+    )) as Valid;
+
+    const messagesFor = (path: string) =>
+      [
+        ...report.errors.match(
+          null,
+          shacl('resultPath'),
+          rdf.namedNode(path),
+        ),
+      ]
+        .map((quad) => quad.subject)
+        .flatMap((resultNode) => [
+          ...report.errors.match(
+            resultNode as never,
+            shacl('resultMessage'),
+            null,
+          ),
+        ])
+        .filter(
+          (quad) =>
+            quad.object.termType === 'Literal' && quad.object.language === 'en',
+        )
+        .map((quad) => quad.object.value)
+        .sort();
+
+    // datePublished "not-a-date": wrong datatype AND wrong format
+    expect(messagesFor('https://schema.org/datePublished')).toEqual([
+      'Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime',
+      'Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)',
+    ]);
+
+    // dateModified "2024-01-15": plain string literal (wrong datatype) but
+    // lexical form matches the ISO pattern — exactly one message expected.
+    expect(messagesFor('https://schema.org/dateModified')).toEqual([
+      'Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime',
+    ]);
+
+    // spatialCoverage "Netherlands": not an IRI and does not start with http(s)
+    expect(messagesFor('https://schema.org/spatialCoverage')).toEqual([
+      'IRI must start with http:// or https://',
+      'Value must be an IRI (RDF resource), not a string literal that looks like a URL',
+    ]);
+
+    // includedInDataCatalog "ftp://…": literal with non-http(s) scheme
+    expect(messagesFor('https://schema.org/includedInDataCatalog')).toEqual([
+      'IRI must start with http:// or https://',
+      'Value must be an IRI (RDF resource), not a string literal that looks like a URL',
+    ]);
+
+    // No generic sh:node fallback leaked through.
+    const allMessages = [
+      ...report.errors.match(null, shacl('resultMessage'), null),
+    ].map((quad) => quad.object.value);
+    expect(allMessages).not.toContain('Value does not have shape');
+    expect(
+      allMessages.some((message) => message.startsWith('Value does not have shape')),
+    ).toBe(false);
+  });
+
   it('reports invalid encoding format', async () => {
     const report = await validate(
       'dataset-schema-org-invalid-encoding-format.jsonld',

--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -30,9 +30,8 @@
         {% assign merged_properties = nodeShape.property | mergePropertiesByPath -%}
         {% for property in merged_properties %}
         {% unless property.path %}{% continue %}{% endunless %}
-        {%- assign node_json = property.node | jsonify -%}
-        {%- assign is_date_shape = node_json contains "DateDatatypeShape" -%}
-        {%- assign is_iri_shape = node_json contains "IriNodeKindShape" -%}
+        {%- assign pattern_str = property.pattern | default: "" -%}
+        {%- assign is_date_shape = pattern_str contains "[0-9]{4}" -%}
         <tr>
             <th scope="row">[{{ property.path }}]({{ property.path }})</th>
             <td>
@@ -97,8 +96,6 @@
                     {% elsif change.maxCount -%}
                         {% assign future_text = change.maxCount | prepend: "max " -%}
                     {% elsif change.severity == "Violation" and property.nodeKind == "IRI" -%}
-                        {% assign future_text = "must be IRI" -%}
-                    {% elsif change.severity == "Violation" and is_iri_shape -%}
                         {% assign future_text = "must be IRI" -%}
                     {% elsif change.severity == "Violation" and property.datatype -%}
                         {% assign future_text = property.datatype | replace: 'http://www.w3.org/2001/XMLSchema#', 'xsd:' | replace: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'rdf:' | prepend: 'must be ' -%}

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -229,12 +229,28 @@ nde-dataset:DatasetShape
         ] ,
         [
             sh:path schema:datePublished ;
-            sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
+            sh:or (
+                [ sh:datatype schema:Date ]
+                [ sh:datatype schema:DateTime ]
+                [ sh:datatype xsd:dateTime ]
+                [ sh:datatype xsd:date ]
+            ) ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
+            sh:message "Datum moet van type xsd:date, xsd:dateTime, schema:Date of schema:DateTime zijn"@nl, "Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime"@en ;
+        ] ,
+        [
+            sh:path schema:datePublished ;
+            sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}.*)?$" ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
         ] ,
         [
             sh:path schema:dateCreated ;
@@ -247,12 +263,28 @@ nde-dataset:DatasetShape
         ] ,
         [
             sh:path schema:dateCreated ;
-            sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
+            sh:or (
+                [ sh:datatype schema:Date ]
+                [ sh:datatype schema:DateTime ]
+                [ sh:datatype xsd:dateTime ]
+                [ sh:datatype xsd:date ]
+            ) ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
+            sh:message "Datum moet van type xsd:date, xsd:dateTime, schema:Date of schema:DateTime zijn"@nl, "Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime"@en ;
+        ] ,
+        [
+            sh:path schema:dateCreated ;
+            sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}.*)?$" ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
         ] ,
         [
             sh:path schema:dateModified ;
@@ -265,12 +297,28 @@ nde-dataset:DatasetShape
         ] ,
         [
             sh:path schema:dateModified ;
-            sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
+            sh:or (
+                [ sh:datatype schema:Date ]
+                [ sh:datatype schema:DateTime ]
+                [ sh:datatype xsd:dateTime ]
+                [ sh:datatype xsd:date ]
+            ) ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
+            sh:message "Datum moet van type xsd:date, xsd:dateTime, schema:Date of schema:DateTime zijn"@nl, "Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime"@en ;
+        ] ,
+        [
+            sh:path schema:dateModified ;
+            sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}.*)?$" ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
         ] ,
         [
             a sh:PropertyShape ;
@@ -305,13 +353,19 @@ nde-dataset:DatasetShape
             a sh:PropertyShape ;
             sh:path schema:mainEntityOfPage ;
             sh:minCount 0 ;
-            sh:node nde-dataset:IriNodeKindShape, nde-dataset:HttpsIriFormatShape ;
+            sh:nodeKind sh:IRI ;
             sh:name "Main entity of page"@en ;
             sh:description """
                 URL of a landing page where the dataset is described for human users.
                 Not needed when the dataset IRI itself resolves to an HTML page (see [[#resolvable-iris]]).
                 The human-readable description *MUST* be consistent with and include at least all details (such as distributions) from the RDF dataset description.
             """@en ;
+            sh:message "Waarde moet een IRI zijn (RDF-resource), geen tekstuele waarde die op een URL lijkt"@nl, "Value must be an IRI (RDF resource), not a string literal that looks like a URL"@en ;
+        ] ,
+        [
+            sh:path schema:mainEntityOfPage ;
+            sh:pattern "^https?://" ;
+            sh:message "IRI moet beginnen met http:// of https://"@nl, "IRI must start with http:// or https://"@en ;
         ] ,
         [
             a sh:PropertyShape ;
@@ -362,13 +416,24 @@ nde-dataset:DatasetShape
         ] ,
         [
             sh:path schema:spatialCoverage ;
-            sh:node nde-dataset:IriNodeKindShape, nde-dataset:HttpsIriFormatShape ;
+            sh:nodeKind sh:IRI ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
             sh:description "Spatial coverage must be an HTTP(S) IRI, for example from [GeoNames](https://www.geonames.org/)."@en ;
+            sh:message "Waarde moet een IRI zijn (RDF-resource), geen tekstuele waarde die op een URL lijkt"@nl, "Value must be an IRI (RDF resource), not a string literal that looks like a URL"@en ;
+        ] ,
+        [
+            sh:path schema:spatialCoverage ;
+            sh:pattern "^https?://" ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "IRI moet beginnen met http:// of https://"@nl, "IRI must start with http:// or https://"@en ;
         ] ,
         [
             sh:path schema:temporalCoverage ;
@@ -390,7 +455,7 @@ nde-dataset:DatasetShape
         [
             a sh:PropertyShape ;
             sh:path schema:includedInDataCatalog ;
-            sh:node nde-dataset:IriNodeKindShape, nde-dataset:HttpsIriFormatShape ;
+            sh:nodeKind sh:IRI ;
             sh:minCount 0 ;
             sh:severity sh:Warning ;
             nde:futureChange [
@@ -400,6 +465,17 @@ nde-dataset:DatasetShape
             sh:description """
                 The HTTP [[IRI]] of the data catalog(s) that the dataset belongs to.
             """@en ;
+            sh:message "Waarde moet een IRI zijn (RDF-resource), geen tekstuele waarde die op een URL lijkt"@nl, "Value must be an IRI (RDF resource), not a string literal that looks like a URL"@en ;
+        ] ,
+        [
+            sh:path schema:includedInDataCatalog ;
+            sh:pattern "^https?://" ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "IRI moet beginnen met http:// of https://"@nl, "IRI must start with http:// or https://"@en ;
         ] ,
         nde-dataset:AccrualPeriodicityProperty ,
         nde-dataset:AccessRightsProperty
@@ -494,12 +570,28 @@ nde-dataset:DistributionShape
         ] ,
         [
             sh:path schema:datePublished ;
-            sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
+            sh:or (
+                [ sh:datatype schema:Date ]
+                [ sh:datatype schema:DateTime ]
+                [ sh:datatype xsd:dateTime ]
+                [ sh:datatype xsd:date ]
+            ) ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
+            sh:message "Datum moet van type xsd:date, xsd:dateTime, schema:Date of schema:DateTime zijn"@nl, "Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime"@en ;
+        ] ,
+        [
+            sh:path schema:datePublished ;
+            sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}.*)?$" ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
         ] ,
         [
             a sh:PropertyShape ;
@@ -510,12 +602,28 @@ nde-dataset:DistributionShape
         ] ,
         [
             sh:path schema:dateModified ;
-            sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
+            sh:or (
+                [ sh:datatype schema:Date ]
+                [ sh:datatype schema:DateTime ]
+                [ sh:datatype xsd:dateTime ]
+                [ sh:datatype xsd:date ]
+            ) ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
+            sh:message "Datum moet van type xsd:date, xsd:dateTime, schema:Date of schema:DateTime zijn"@nl, "Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime"@en ;
+        ] ,
+        [
+            sh:path schema:dateModified ;
+            sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}.*)?$" ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
         ] ,
         [
             a sh:PropertyShape ;
@@ -557,7 +665,7 @@ nde-dataset:DistributionShape
         [
             a sh:PropertyShape ;
             sh:path schema:usageInfo ;
-            sh:node nde-dataset:IriNodeKindShape, nde-dataset:HttpsIriFormatShape ;
+            sh:nodeKind sh:IRI ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
@@ -565,6 +673,17 @@ nde-dataset:DistributionShape
             ] ;
             sh:minCount 0 ;
             sh:description "A link to the documentation: for downloads, the application profile, vocabulary or ontology; for [=web APIs=], the protocol specification. See [[#usage-information]]."@en ;
+            sh:message "Waarde moet een IRI zijn (RDF-resource), geen tekstuele waarde die op een URL lijkt"@nl, "Value must be an IRI (RDF resource), not a string literal that looks like a URL"@en ;
+        ] ,
+        [
+            sh:path schema:usageInfo ;
+            sh:pattern "^https?://" ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "IRI moet beginnen met http:// of https://"@nl, "IRI must start with http:// or https://"@en ;
         ] ,
         nde-dataset:SchemaDescriptionPropertyShouldExist .
 
@@ -785,31 +904,6 @@ nde-dataset:PersonShape
         sh:message "Een persoon moet een naam hebben"@nl, "A person must have a name"@en ;
     ] ,
     nde-dataset:SchemaNameLangStringProperty .
-
-# Reusable constraint shapes for ISO-8601 dates. Split so each failure mode
-# (wrong datatype vs. malformed lexical form) carries its own sh:message.
-nde-dataset:DateDatatypeShape a sh:NodeShape ;
-    sh:or (
-        [ sh:datatype schema:Date ]
-        [ sh:datatype schema:DateTime ]
-        [ sh:datatype xsd:dateTime ]
-        [ sh:datatype xsd:date ]
-    ) ;
-    sh:message "Datum moet van type xsd:date, xsd:dateTime, schema:Date of schema:DateTime zijn"@nl, "Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime"@en .
-
-nde-dataset:DateFormatShape a sh:NodeShape ;
-    sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}.*)?$" ;
-    sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en .
-
-# Reusable constraint shapes for HTTP(S) IRI values. Split so the node-kind and
-# URL-scheme failures carry their own sh:message.
-nde-dataset:IriNodeKindShape a sh:NodeShape ;
-    sh:nodeKind sh:IRI ;
-    sh:message "Waarde moet een IRI zijn (RDF-resource), geen tekstuele waarde die op een URL lijkt"@nl, "Value must be an IRI (RDF resource), not a string literal that looks like a URL"@en .
-
-nde-dataset:HttpsIriFormatShape a sh:NodeShape ;
-    sh:pattern "^https?://" ;
-    sh:message "IRI moet beginnen met http:// of https://"@nl, "IRI must start with http:// or https://"@en .
 
 #
 # Property shapes
@@ -1044,12 +1138,28 @@ dcat:DatasetShape
     ],
     [
         sh:path dc:created ;
-        sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
+        sh:or (
+            [ sh:datatype schema:Date ]
+            [ sh:datatype schema:DateTime ]
+            [ sh:datatype xsd:dateTime ]
+            [ sh:datatype xsd:date ]
+        ) ;
         sh:severity sh:Warning ;
         nde:futureChange [
             nde:version "2.0" ;
             sh:severity sh:Violation ;
         ] ;
+        sh:message "Datum moet van type xsd:date, xsd:dateTime, schema:Date of schema:DateTime zijn"@nl, "Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime"@en ;
+    ] ,
+    [
+        sh:path dc:created ;
+        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}.*)?$" ;
+        sh:severity sh:Warning ;
+        nde:futureChange [
+            nde:version "2.0" ;
+            sh:severity sh:Violation ;
+        ] ;
+        sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
     ],
     [
         sh:path dc:issued ;
@@ -1061,12 +1171,28 @@ dcat:DatasetShape
     ],
     [
         sh:path dc:issued ;
-        sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
+        sh:or (
+            [ sh:datatype schema:Date ]
+            [ sh:datatype schema:DateTime ]
+            [ sh:datatype xsd:dateTime ]
+            [ sh:datatype xsd:date ]
+        ) ;
         sh:severity sh:Warning ;
         nde:futureChange [
             nde:version "2.0" ;
             sh:severity sh:Violation ;
         ] ;
+        sh:message "Datum moet van type xsd:date, xsd:dateTime, schema:Date of schema:DateTime zijn"@nl, "Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime"@en ;
+    ] ,
+    [
+        sh:path dc:issued ;
+        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}.*)?$" ;
+        sh:severity sh:Warning ;
+        nde:futureChange [
+            nde:version "2.0" ;
+            sh:severity sh:Violation ;
+        ] ;
+        sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
     ],
     [
         sh:path dc:modified ;
@@ -1078,12 +1204,28 @@ dcat:DatasetShape
     ],
     [
         sh:path dc:modified ;
-        sh:node nde-dataset:DateDatatypeShape, nde-dataset:DateFormatShape ;
+        sh:or (
+            [ sh:datatype schema:Date ]
+            [ sh:datatype schema:DateTime ]
+            [ sh:datatype xsd:dateTime ]
+            [ sh:datatype xsd:date ]
+        ) ;
         sh:severity sh:Warning ;
         nde:futureChange [
             nde:version "2.0" ;
             sh:severity sh:Violation ;
         ] ;
+        sh:message "Datum moet van type xsd:date, xsd:dateTime, schema:Date of schema:DateTime zijn"@nl, "Date must be of type xsd:date, xsd:dateTime, schema:Date or schema:DateTime"@en ;
+    ] ,
+    [
+        sh:path dc:modified ;
+        sh:pattern "^[0-9]{4}-[0-9]{2}-[0-9]{2}(T[0-9]{2}:[0-9]{2}:[0-9]{2}.*)?$" ;
+        sh:severity sh:Warning ;
+        nde:futureChange [
+            nde:version "2.0" ;
+            sh:severity sh:Violation ;
+        ] ;
+        sh:message "Datum moet geldig zijn overeenkomstig ISO-8601 (YYYY-MM-DD of YYYY-MM-DDTHH:MM:SS met optionele tijdzone)"@nl, "Date must be valid according to ISO-8601 (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS with optional timezone)"@en ;
     ],
     [
         sh:path dcat:keyword ;


### PR DESCRIPTION
## Summary

Follow-up to #1849. The previous refactor moved date and IRI constraints into reusable NodeShapes referenced via `sh:node`, but shacl-engine emits a generic "Value does not have shape …" for `sh:node` failures and does not propagate the referenced shape’s `sh:message`. Users saw unhelpful errors like _"Value does not have shape via https://schema.org/datePublished"_.

This PR inlines the constraints back into two property shapes per path so each violation carries the specific message that describes what went wrong:

- datatype / node-kind shape – _"Date must be of type …"_ or _"Value must be an IRI (RDF resource), not a string literal that looks like a URL"_
- format shape – _"Date must be valid according to ISO-8601 …"_ or _"IRI must start with http:// or https://"_

The reusable `DateDatatypeShape`, `DateFormatShape`, `IriNodeKindShape` and `HttpsIriFormatShape` are removed.

## Changes

- `requirements/shacl.ttl` – inline the datatype/pattern/nodeKind constraints across `schema:datePublished`, `schema:dateCreated`, `schema:dateModified` (Dataset + Distribution), `dc:created`, `dc:issued`, `dc:modified`, `schema:mainEntityOfPage`, `schema:spatialCoverage`, `schema:includedInDataCatalog`, `schema:usageInfo`.
- `requirements/attributes.liquid` – detect date rows via the ISO-8601 `sh:pattern` and rely on the existing `property.nodeKind == "IRI"` branch for the _"v2.0: must be IRI"_ note.
- Add a regression test that loads a Turtle fixture (to sidestep JSON-LD’s Schema.org context datatype coercion) and asserts the exact message set for every invalid date and IRI value.
