### PR TITLE
docs(requirements): add Linked Art profile to distribution IRI table

### DIFF
--- a/requirements/index.bs.liquid
+++ b/requirements/index.bs.liquid
@@ -614,6 +614,12 @@ For downloads as well as APIs, this *MUST* be the IRI of the application profile
             <td>https://spec.graphql.org/</td>
         </tr>
         <tr>
+            <th scope="row">Linked Art</th>
+            <td>Application profile</td>
+            <td>API, download</td>
+            <td>https://linked.art/model/</td>
+        </tr>
+        <tr>
             <th scope="row">OAI-PMH</th>
             <td>Protocol</td>
             <td>API</td>


### PR DESCRIPTION
Add Linked Art to the overview of recommended application-profile IRIs for typing distributions.

Uses `https://linked.art/model/` rather than the API IRI, since SPARQL endpoints and RDF dumps typically conform to the Linked Art data model but not the HTTP API conventions.
