### PR TITLE
fix(shacl): target sh:nodeKind sh:IRI for contentUrl in v2

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -496,14 +496,14 @@ nde-dataset:DistributionShape
         [
             sh:path schema:contentUrl ;
             sh:or (
-                [ sh:datatype xsd:anyURI ]      # literal preferred see https://github.com/netwerk-digitaal-erfgoed/dataset-register/issues/1366
-                [ sh:nodeKind sh:IRI ]          # IRI left for backward compatibility
+                [ sh:nodeKind sh:IRI ]          # schema.org’s JSON-LD context coerces contentUrl to @id, so values land as IRIs
+                [ sh:datatype xsd:anyURI ]      # xsd:anyURI literal accepted for Turtle / custom-context submissions
             ) ;
             sh:pattern "^https?://" ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
-                sh:datatype xsd:anyURI ;
+                sh:nodeKind sh:IRI ;
                 sh:severity sh:Violation ;
             ] ;
             sh:description "De URL waar de distributie rechtstreeks toegankelijk is."@nl, "The URL where the distribution may be directly accessed."@en ;


### PR DESCRIPTION
## Summary

Revert the v2 direction set in [#1366](https://github.com/netwerk-digitaal-erfgoed/dataset-register/issues/1366). That issue added `sh:datatype xsd:anyURI` as the v2 target for `schema:contentUrl`, on the assumption that the literal form is preferred over an IRI node. Two pieces of prior art show the opposite direction is correct:

**Schema.org JSON-LD context** declares:

```json
"contentUrl": { "@id": "schema:contentUrl", "@type": "@id" }
```

`"@type": "@id"` means any string value is coerced to an RDF **IRI node** by the JSON-LD processor. A `contentUrl` submitted via schema.org’s canonical context therefore arrives as `<https://…>`, not as a typed literal.

**DCAT-AP-NL 3.0** specifies `dcat:downloadURL` with range `rdfs:Resource` (and renders it as *URI* in its attribute tables). The normative example uses `dcat:downloadURL <https://…>` — an IRI node, not an `xsd:anyURI` literal.

Under the current v2 rule, every submission via the canonical schema.org context — and every submission aligned with DCAT-AP-NL — would fail validation. This PR flips the v2 target to `sh:nodeKind sh:IRI`, matching both specs. `xsd:anyURI` literals remain accepted via the existing `sh:or` branch for Turtle / custom-context submissions, so #1366’s original allowance is preserved – it just isn’t the sole v2 requirement.

## Changes

- `requirements/shacl.ttl` – swap `sh:datatype xsd:anyURI` for `sh:nodeKind sh:IRI` inside `nde:futureChange`, reorder the `sh:or` branches to lead with the IRI case, and update comments to explain why each branch exists.
