### PR TITLE
feat(core): support +zip alongside +gzip in mediaType

### DIFF
--- a/packages/core/src/literal.ts
+++ b/packages/core/src/literal.ts
@@ -39,19 +39,20 @@ export const normalizeLicense = (variable: string) =>
  * - Already-formed IANA URIs pass through unchanged
  * - Normalizes http:// to https:// for consistency
  * - Strips parameters (e.g., "text/html; charset=utf-8" becomes "text/html")
- * - Strips +gzip suffix (e.g., "application/n-triples+gzip" becomes "application/n-triples");
- *   the compression format is captured separately by compressFormatFromMediaType()
+ * - Strips +gzip or +zip suffix (e.g., "application/n-triples+gzip" becomes
+ *   "application/n-triples"); the compression format is captured separately by
+ *   compressFormatFromMediaType()
  */
 export const normalizeMediaType = (variable: string) =>
   `?${variable}Raw ;
         BIND(
           IF(
             isIRI(?${variable}Raw),
-            IRI(REPLACE(REPLACE(STR(?${variable}Raw), "\\\\+gzip$", ""), "^http://", "https://")),
+            IRI(REPLACE(REPLACE(STR(?${variable}Raw), "\\\\+g?zip$", ""), "^http://", "https://")),
             IRI(
               CONCAT(
                 "https://www.iana.org/assignments/media-types/",
-                REPLACE(REPLACE(STR(?${variable}Raw), ";.*$", ""), "\\\\+gzip$", "")
+                REPLACE(REPLACE(STR(?${variable}Raw), ";.*$", ""), "\\\\+g?zip$", "")
               )
             )
           )
@@ -59,11 +60,12 @@ export const normalizeMediaType = (variable: string) =>
         )`;
 
 /**
- * Detect +gzip in the raw media type and bind a compress format URI.
+ * Detect +gzip or +zip in the raw media type and bind a compress format URI.
  *
  * Returns a SPARQL BIND that sets the compress format variable to
- * <https://www.iana.org/assignments/media-types/application/gzip> when the raw
- * media type contains +gzip, or leaves it unbound otherwise.
+ * <https://www.iana.org/assignments/media-types/application/gzip> for +gzip,
+ * <https://www.iana.org/assignments/media-types/application/zip> for +zip,
+ * or leaves it unbound otherwise.
  */
 export const compressFormatFromMediaType = (
   mediaTypeVariable: string,
@@ -73,7 +75,11 @@ export const compressFormatFromMediaType = (
     IF(
       REGEX(STR(?${mediaTypeVariable}Raw), "\\\\+gzip$"),
       <https://www.iana.org/assignments/media-types/application/gzip>,
-      ?unbound
+      IF(
+        REGEX(STR(?${mediaTypeVariable}Raw), "\\\\+zip$"),
+        <https://www.iana.org/assignments/media-types/application/zip>,
+        ?unbound
+      )
     ) AS ?${compressFormatVariable}
   )`;
 

--- a/packages/core/test/datasets/dataset-dcat-valid-zip.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-valid-zip.jsonld
@@ -1,0 +1,33 @@
+{
+  "@context": {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "@type": "dcat:Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba-zip",
+  "dct:title": { "@value": "Zip-compressed dataset", "@language": "en" },
+  "dct:description": { "@value": "Dataset with a +zip distribution", "@language": "en" },
+  "dct:identifier": "http://data.bibliotheken.nl/id/dataset/rise-alba-zip",
+  "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" },
+  "dct:publisher": {
+    "@id": "https://example.com/publisher",
+    "@type": "foaf:Organization",
+    "foaf:name": { "@value": "Koninklijke Bibliotheek", "@language": "nl" }
+  },
+  "dcat:distribution": [
+    {
+      "@type": "dcat:Distribution",
+      "dcat:mediaType": {
+        "@id": "https://www.iana.org/assignments/media-types/application/n-triples+zip"
+      },
+      "dcat:accessURL": {
+        "@id": "https://data.bibliotheken.nl/id/dataset/rise-alba.nt.zip"
+      },
+      "dcat:downloadURL": {
+        "@id": "https://data.bibliotheken.nl/id/dataset/rise-alba.nt.zip"
+      },
+      "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" }
+    }
+  ]
+}

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -148,6 +148,53 @@ describe('Fetch', () => {
     ).toBe(true);
   });
 
+  it('strips +zip from mediaType and sets application/zip compressFormat', async () => {
+    const response = await file('dataset-dcat-valid-zip.jsonld');
+    nock('https://example.com')
+      .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
+      .get('/valid-dcat-dataset-zip')
+      .reply(200, response);
+
+    const datasets = await fetchDatasetsAsArray(
+      new URL('https://example.com/valid-dcat-dataset-zip'),
+    );
+
+    expect(datasets).toHaveLength(1);
+    const dataset = datasets[0];
+    const distributions = [
+      ...dataset.match(
+        factory.namedNode('http://data.bibliotheken.nl/id/dataset/rise-alba-zip'),
+        dcat('distribution'),
+        null,
+      ),
+    ];
+    expect(distributions).toHaveLength(1);
+    const zipDist = distributions[0].object as BlankNode;
+
+    expect(
+      dataset.has(
+        factory.quad(
+          zipDist,
+          dcat('mediaType'),
+          factory.namedNode(
+            'https://www.iana.org/assignments/media-types/application/n-triples',
+          ),
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      dataset.has(
+        factory.quad(
+          zipDist,
+          dcat('compressFormat'),
+          factory.namedNode(
+            'https://www.iana.org/assignments/media-types/application/zip',
+          ),
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it('preserves ODRL policy on DCAT distributions', async () => {
     const response = await file('dataset-dcat-valid-with-policy.jsonld');
     nock('https://example.com')


### PR DESCRIPTION
## Summary

Extend media type normalization and compress-format detection to recognize the `+zip` structured suffix in addition to the existing `+gzip` handling.

## Changes

- `normalizeMediaType` strips `+zip` as well as `+gzip` from `dcat:mediaType` values (both IRI and literal forms).
- `compressFormatFromMediaType` binds `https://www.iana.org/assignments/media-types/application/zip` when the raw media type ends in `+zip`, keeping the existing `application/gzip` mapping for `+gzip`.
- Added fixture `dataset-dcat-valid-zip.jsonld` and a test in `fetch.test.ts` asserting that `application/n-triples+zip` is split into `application/n-triples` plus an `application/zip` `dcat:compressFormat`.
