### PR TITLE
fix(browser): use literal IRI for dcat:theme

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -78,7 +78,7 @@ export const DatasetDetailSchema = {
     '@multilang': true,
   },
   theme: {
-    '@id': dcat.theme,
+    '@id': 'http://www.w3.org/ns/dcat#theme',
     '@optional': true,
     '@array': true,
   },


### PR DESCRIPTION
Every dataset detail page returned HTTP 500 because `DatasetDetailSchema.theme['@id']` resolved to `undefined`. The `dcat` namespace exported by `@lde/dataset-registry-client` does not include `theme` in its `terms`, so `dcat.theme` is `undefined`, and `createLens(DatasetDetailSchema)` threw `Invalid schema, "@id" key for property missing` before the page could render.

This change inlines the canonical IRI, matching the same workaround already used for `landingPage` in this schema.

Fix #1860
