### PR TITLE
ci(browser): run svelte-check in CI; fix 33 pre-existing errors

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: npx nx-cloud record -- echo Hello World
-      - run: npx nx affected -t lint test typecheck build
+      - run: npx nx affected -t lint test typecheck check build
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/apps/browser/e2e/accessibility.spec.ts
+++ b/apps/browser/e2e/accessibility.spec.ts
@@ -173,7 +173,14 @@ test.describe('Accessibility - Dataset Detail Page', () => {
   test('dataset detail page has no accessibility violations', async ({
     page,
   }) => {
-    await page.goto('/datasets/https%3A%2F%2Fexample.org%2Fdataset%2F1');
+    const response = await page.goto(
+      '/datasets/https%3A%2F%2Fexample.org%2Fdataset%2F1',
+    );
+    // SSR hits the live SPARQL endpoint (page.route only intercepts browser
+    // requests), so this URI returns a 404 "not found" page. Assert that the
+    // route does not crash (5xx) — see issue #1860 for the kind of regression
+    // this guards against.
+    expect(response?.status()).toBeLessThan(500);
     await page.waitForLoadState('load');
 
     const results = await new AxeBuilder({ page })
@@ -192,7 +199,14 @@ test.describe('Accessibility - Dataset Detail Page', () => {
   });
 
   test('dataset detail page has proper heading structure', async ({ page }) => {
-    await page.goto('/datasets/https%3A%2F%2Fexample.org%2Fdataset%2F1');
+    const response = await page.goto(
+      '/datasets/https%3A%2F%2Fexample.org%2Fdataset%2F1',
+    );
+    // SSR hits the live SPARQL endpoint (page.route only intercepts browser
+    // requests), so this URI returns a 404 "not found" page. Assert that the
+    // route does not crash (5xx) — see issue #1860 for the kind of regression
+    // this guards against.
+    expect(response?.status()).toBeLessThan(500);
     await page.waitForLoadState('load');
 
     // Check for main heading (h1 with dataset title)
@@ -210,7 +224,14 @@ test.describe('Accessibility - Dataset Detail Page', () => {
   });
 
   test('dataset detail page is keyboard accessible', async ({ page }) => {
-    await page.goto('/datasets/https%3A%2F%2Fexample.org%2Fdataset%2F1');
+    const response = await page.goto(
+      '/datasets/https%3A%2F%2Fexample.org%2Fdataset%2F1',
+    );
+    // SSR hits the live SPARQL endpoint (page.route only intercepts browser
+    // requests), so this URI returns a 404 "not found" page. Assert that the
+    // route does not crash (5xx) — see issue #1860 for the kind of regression
+    // this guards against.
+    expect(response?.status()).toBeLessThan(500);
     await page.waitForLoadState('load');
 
     // Find a link and verify it can receive focus
@@ -220,7 +241,14 @@ test.describe('Accessibility - Dataset Detail Page', () => {
   });
 
   test('dataset detail page meets WCAG AA color contrast', async ({ page }) => {
-    await page.goto('/datasets/https%3A%2F%2Fexample.org%2Fdataset%2F1');
+    const response = await page.goto(
+      '/datasets/https%3A%2F%2Fexample.org%2Fdataset%2F1',
+    );
+    // SSR hits the live SPARQL endpoint (page.route only intercepts browser
+    // requests), so this URI returns a 404 "not found" page. Assert that the
+    // route does not crash (5xx) — see issue #1860 for the kind of regression
+    // this guards against.
+    expect(response?.status()).toBeLessThan(500);
     await page.waitForLoadState('load');
 
     const results = await new AxeBuilder({ page })

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -74,6 +74,13 @@
           "build"
         ]
       },
+      "check": {
+        "cache": true,
+        "inputs": [
+          "default",
+          "^default"
+        ]
+      },
       "prune-lockfile": {
         "options": {
           "outputPath": "apps/browser/build"

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -78,7 +78,7 @@ export const DatasetDetailSchema = {
     '@multilang': true,
   },
   theme: {
-    '@id': dcat.theme,
+    '@id': 'http://www.w3.org/ns/dcat#theme',
     '@optional': true,
     '@array': true,
   },
@@ -360,9 +360,11 @@ async function fetchDistributionCount(query: string): Promise<number> {
     query,
   );
   for await (const bindings of bindingsStream) {
-    const count = bindings['count'];
-    if (count && 'value' in count) {
-      return parseInt(count.value as string, 10);
+    const typedBinding = bindings as unknown as {
+      count?: { value: string };
+    };
+    if (typedBinding.count?.value) {
+      return parseInt(typedBinding.count.value, 10);
     }
   }
   return 0;

--- a/apps/browser/src/lib/utils/i18n.ts
+++ b/apps/browser/src/lib/utils/i18n.ts
@@ -2,6 +2,7 @@ import {
   getLocale,
   localizeHref as localizeHrefDecorated,
   deLocalizeUrl as delocalizeUrlDecorated,
+  type Locale,
 } from '$lib/paraglide/runtime';
 import { encodeDatasetPath } from '$lib/utils/dataset-uri';
 
@@ -52,7 +53,7 @@ export function getLocalizedArray(
  */
 export function localizeHref(
   href: string,
-  options?: { locale?: string },
+  options?: { locale?: Locale },
 ): string {
   const encoded = encodeDatasetPath(href);
   const localized = localizeHrefDecorated(encoded, {

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -1191,7 +1191,7 @@
   {/if}
 
   <!-- VoID Summary Section -->
-  {#if hasVoidStats}
+  {#if summary && hasVoidStats}
     <div class="mb-8">
       <h2
         class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"


### PR DESCRIPTION
## Why

Issue #1860 (every dataset detail page returned HTTP 500) made it through CI because we do not run `svelte-check` on PRs. The Nx-generated `typecheck` target is disabled for this SvelteKit project (`noEmit: true` on project references), and our only real type-aware check — the `check` script (`svelte-kit sync && svelte-check --fail-on-warnings`) — was not wired into the pipeline.

Before this PR, `nx run @dataset-register/browser:check` reported **33 errors** on `main`, including the `dcat.theme` regression that shipped as #1860.

## Changes

- **CI**: `qa.yml` now runs `check` alongside `lint test typecheck build` under `nx affected`.
- **Nx config**: mark the `check` target as cacheable so affected detection + remote cache apply.
- **Pre-existing svelte-check fixes (33 errors → 0):**
  - `apps/browser/src/lib/utils/i18n.ts` — type `localizeHref`’s `locale` option as Paraglide’s `Locale` instead of `string`.
  - `apps/browser/src/lib/services/dataset-detail.ts` — inline the canonical IRI for `dcat:theme` (identical to #1861, merges cleanly), and give the SPARQL binding in `fetchDistributionCount` a proper shape.
  - `apps/browser/src/routes/datasets/[...uri]/+page.svelte` — narrow `summary` at the outer `{#if summary && hasVoidStats}` so every `{summary.*}` inside the VoID section is type-safe (fixes all 30 `summary is possibly null` errors at once).
- **E2E**: the detail-page accessibility tests now assert `response.status() < 500`. Because SSR hits the live SPARQL endpoint (the existing `page.route` mock only intercepts browser requests), this URI legitimately returns 404; asserting "not 5xx" is what would have caught #1860.

## Follow-ups (not in this PR)

- Properly mock the SPARQL endpoint for SSR so detail-page e2e tests can assert `status === 200` + real dataset content.
- Add a unit test that exercises `createLens(DatasetDetailSchema)` so namespace regressions are caught without needing the full SSR stack.
