### PR TITLE
refactor(browser): use dcat namespace terms from lde 0.7.5

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@dataset-register/core": "*",
-    "@lde/dataset-registry-client": "^0.7.4",
+    "@lde/dataset-registry-client": "^0.7.5",
     "@zazuko/prefixes": "^2.6.1",
     "feed": "^5.2.0",
     "fetch-sparql-endpoint": "^7.1.0",

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -78,7 +78,7 @@ export const DatasetDetailSchema = {
     '@multilang': true,
   },
   theme: {
-    '@id': 'http://www.w3.org/ns/dcat#theme',
+    '@id': dcat.theme,
     '@optional': true,
     '@array': true,
   },
@@ -108,7 +108,7 @@ export const DatasetDetailSchema = {
     '@optional': true,
   },
   landingPage: {
-    '@id': 'http://www.w3.org/ns/dcat#landingPage',
+    '@id': dcat.landingPage,
     '@optional': true,
   },
   publisher: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@dataset-register/core": "*",
-        "@lde/dataset-registry-client": "^0.7.4",
+        "@lde/dataset-registry-client": "^0.7.5",
         "@zazuko/prefixes": "^2.6.1",
         "feed": "^5.2.0",
         "fetch-sparql-endpoint": "^7.1.0",
@@ -2105,45 +2105,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
-    },
-    "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.2.0.tgz",
-      "integrity": "sha512-ssJFvn/UXhQQeICw3SR/fZPmYVj+JM2mP+Lx7bZ51cOeHaMWOKp3AUMuyM3QR82aFFXTfcAp67P5GpPjGmbZWQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/gast": "11.2.0",
-        "@chevrotain/types": "11.2.0",
-        "lodash-es": "4.17.23"
-      }
-    },
-    "node_modules/@chevrotain/gast": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.2.0.tgz",
-      "integrity": "sha512-c+KoD6eSI1xjAZZoNUW+V0l13UEn+a4ShmUrjIKs1BeEWCji0Kwhmqn5FSx1K4BhWL7IQKlV7wLR4r8lLArORQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/types": "11.2.0",
-        "lodash-es": "4.17.23"
-      }
-    },
-    "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.2.0.tgz",
-      "integrity": "sha512-lG73pBFqbXODTbXhdZwv0oyUaI+3Irm+uOv5/W79lI3g5hasYaJnVJOm3H2NkhA0Ef4XLBU4Scr7TJDJwgFkAw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/types": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.2.0.tgz",
-      "integrity": "sha512-vBMSj/lz/LqolbGQEHB0tlpW5BnljHVtp+kzjQfQU+5BtGMTuZCPVgaAjtKvQYXnHb/8i/02Kii00y0tsuwfsw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chevrotain/utils": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-+7whECg4yNWHottjvr2To2BRxL4XJVjIyyv5J4+bJ0iMOVU8j/8n1qPDLZS/90W/BObDR8VNL46lFbzY/Hosmw==",
-      "license": "Apache-2.0"
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -14267,14 +14228,15 @@
       }
     },
     "node_modules/@lde/dataset-registry-client": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@lde/dataset-registry-client/-/dataset-registry-client-0.7.4.tgz",
-      "integrity": "sha512-AkCPmzBo2hxm/tjp6J22Gy02O5A4DfJBI11niwzY16FDQlHlwmk+Kt26aFtdsj+lsw/him0U4CcXtzwcaEgBug==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@lde/dataset-registry-client/-/dataset-registry-client-0.7.5.tgz",
+      "integrity": "sha512-6pATW2XL59/7j09J13xQPiSp7Kc6tiyAEDDz1DzOhc6w4hgFCwDW4ma6u9DCjMhnIP8S0RFjBIsvIv1bl7RkxQ==",
+      "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.2",
-        "@traqula/generator-sparql-1-1": "^1.0.3",
-        "@traqula/parser-sparql-1-1": "^1.0.3",
-        "@traqula/rules-sparql-1-1": "^1.0.3",
+        "@traqula/generator-sparql-1-1": "^1.0.7",
+        "@traqula/parser-sparql-1-1": "^1.0.4",
+        "@traqula/rules-sparql-1-1": "^1.0.4",
         "ldkit": "^2.6.0",
         "tslib": "^2.3.0"
       }
@@ -17226,37 +17188,34 @@
       }
     },
     "node_modules/@traqula/chevrotain": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@traqula/chevrotain/-/chevrotain-1.0.0.tgz",
-      "integrity": "sha512-kyyT9aXpcJmJ3Bvq/MoeGA9e2vhrPdgOrswHaGC9WEQqXfsxJAye2Y+6aJdSGYZJMiH6CcAzgYLIJt1UDBvB0A==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@traqula/chevrotain/-/chevrotain-1.0.7.tgz",
+      "integrity": "sha512-SnyiSVuTqmniuysm2p298awhss6DeHeySGXaNI+amU1X+47Kl5DBjh0xInGHLJ/LIG2/wsxG16+8zx756MABDQ==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "chevrotain": "^11.0.3"
-      },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@traqula/core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@traqula/core/-/core-1.0.3.tgz",
-      "integrity": "sha512-jx37q7AbvredBoBrPAHjefu471/vwbjc7GP0R6DKoe0z/CanTy5B2rhiGuPKMc9f6OOQmQWiBBm+LsrDmLACAg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@traqula/core/-/core-1.0.7.tgz",
+      "integrity": "sha512-A6O+oKZ+XixfHk5nDDZoI9D0TMPDp9+AnkX8WSH332TozXKrcEsuxXhqBVcaJ2goQKe1F9id3lz3y897br5Rsw==",
       "license": "MIT",
       "dependencies": {
-        "@traqula/chevrotain": "^1.0.0"
+        "@traqula/chevrotain": "^1.0.7"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@traqula/generator-sparql-1-1": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@traqula/generator-sparql-1-1/-/generator-sparql-1-1-1.0.4.tgz",
-      "integrity": "sha512-kfR2HULbngz6pESz6kn6p4hZbRLjb70l92eAo+Ml2Gdqc5fOrmCZtGmcNlsNXjRXc+geYzvUZQWF45J2SAUlYw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@traqula/generator-sparql-1-1/-/generator-sparql-1-1-1.0.7.tgz",
+      "integrity": "sha512-hb0/9xpKzTDNwUA35hw8FK5qKnuYO3dPDdkYn0PP2mCrS+hffk1SeSDbgfXO85WPcFon6tVJaKCWfN6UrmG5bw==",
       "license": "MIT",
       "dependencies": {
-        "@traqula/core": "^1.0.3",
-        "@traqula/rules-sparql-1-1": "^1.0.4"
+        "@traqula/core": "^1.0.7",
+        "@traqula/rules-sparql-1-1": "^1.0.7"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -17307,13 +17266,13 @@
       }
     },
     "node_modules/@traqula/rules-sparql-1-1": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-1/-/rules-sparql-1-1-1.0.4.tgz",
-      "integrity": "sha512-L0rPcpYxCcsFggoMcwRvgQv9yqHup2cPyAJrgUMa0jyVLuxG5cVlQ2APJ8ulFBqOy3Tp5uBiqD8W8GbYf1P+PQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-1/-/rules-sparql-1-1-1.0.7.tgz",
+      "integrity": "sha512-OdE+2x5/bB7Q+ntLIzIsZurvmzivghYWuK49LUbyOgMQMbADNgRNEWcPpqVDt9KsNdj8pXMxBfbu5eFkQoj0Mw==",
       "license": "MIT",
       "dependencies": {
-        "@traqula/chevrotain": "^1.0.0",
-        "@traqula/core": "^1.0.3"
+        "@traqula/chevrotain": "^1.0.7",
+        "@traqula/core": "^1.0.7"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -20195,20 +20154,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/chevrotain": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.2.0.tgz",
-      "integrity": "sha512-mHCHTxM51nCklUw9RzRVc0DLjAh/SAUPM4k/zMInlTIo25ldWXOZoPt7XEIk/LwoT4lFVmJcu9g5MHtx371x3A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.2.0",
-        "@chevrotain/gast": "11.2.0",
-        "@chevrotain/regexp-to-ast": "11.2.0",
-        "@chevrotain/types": "11.2.0",
-        "@chevrotain/utils": "11.2.0",
-        "lodash-es": "4.17.23"
       }
     },
     "node_modules/chokidar": {
@@ -26071,12 +26016,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {


### PR DESCRIPTION
## Why

Now that `@lde/dataset-registry-client@0.7.5` exposes the full DCAT 3 vocabulary (ldelements/lde#356), the two literal-IRI workarounds in `dataset-detail.ts` can be replaced with proper strongly-typed namespace access.

## What

- Bump `@lde/dataset-registry-client` from `^0.7.4` to `^0.7.5`.
- `apps/browser/src/lib/services/dataset-detail.ts`
  - `'@id': 'http://www.w3.org/ns/dcat#theme'` → `'@id': dcat.theme` (added after the runtime regression in #1860)
  - `'@id': 'http://www.w3.org/ns/dcat#landingPage'` → `'@id': dcat.landingPage` (pre-existing workaround)

Both IRIs are now typed, so any future typo gets caught by `svelte-check` at PR time.

## Validation

- `nx check @dataset-register/browser` — 0 errors, 0 warnings.
- `nx build @dataset-register/browser` — clean.
