### PR TITLE
fix(shacl): accept ISO 8601 shortened-end intervals in temporalCoverage

### DIFF
--- a/packages/core/test/datasets/dataset-schema-org-temporal-shortened.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-temporal-shortened.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/temporal-shortened",
+  "name": "Temporal coverage in ISO 8601 shortened-end notation",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "temporalCoverage": "1889-06/07",
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://example.com/publisher",
+    "name": "Koninklijke Bibliotheek"
+  }
+}

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -289,6 +289,19 @@ describe('Validator', () => {
     `);
   });
 
+  it('accepts ISO 8601 shortened-end temporal coverage notation', async () => {
+    const report = (await validate(
+      'dataset-schema-org-temporal-shortened.jsonld',
+    )) as Valid;
+    expect(report.state).toEqual('valid');
+    const temporalResults = report.errors.match(
+      null,
+      shacl('resultPath'),
+      rdf.namedNode('https://schema.org/temporalCoverage'),
+    );
+    expect(temporalResults.size).toEqual(0);
+  });
+
   it('warns that schema:genre is deprecated', async () => {
     const report = (await validate(
       'dataset-schema-org-genre-deprecated.jsonld',

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -467,14 +467,14 @@ nde-dataset:DatasetShape
             sh:path schema:temporalCoverage ;
             sh:or (
                 [ sh:nodeKind sh:IRI ; sh:pattern "^https?://" ]
-                [ sh:pattern "^(-?\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}:\\d{2}(:\\d{2})?)?)?)?|\\.\\.)(/(-?\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}:\\d{2}(:\\d{2})?)?)?)?|\\.\\.))?$" ]
+                [ sh:pattern "^(-?\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}:\\d{2}(:\\d{2})?)?)?)?|\\.\\.)(/(-?\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}:\\d{2}(:\\d{2})?)?)?)?|\\d{2}(-\\d{2})?|\\.\\.))?$" ]
             ) ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
-            sh:description "De waarde moet een ISO 8601-datum of -tijdsinterval zijn (bijv. ‘2011’, ‘2011/2012’, ‘-0431/-0404’ voor v.Chr.-dateringen, of ‘1440/..’ voor een open einde), of een HTTP(S)-URI."@nl, "The value must be an ISO 8601 date or time interval (such as ‘2011’, ‘2011/2012’, ‘-0431/-0404’ for BCE dates, or ‘1440/..’ for an open-ended range), or an HTTP(S) URI."@en ;
+            sh:description "De waarde moet een ISO 8601-datum of -tijdsinterval zijn (bijv. ‘2011’, ‘2011/2012’, ‘1889-06/07’ voor een verkorte notatie, ‘-0431/-0404’ voor v.Chr.-dateringen, of ‘1440/..’ voor een open einde), of een HTTP(S)-URI."@nl, "The value must be an ISO 8601 date or time interval (such as ‘2011’, ‘2011/2012’, ‘1889-06/07’ for shortened notation, ‘-0431/-0404’ for BCE dates, or ‘1440/..’ for an open-ended range), or an HTTP(S) URI."@en ;
             sh:message "Gebruik een ISO 8601-datum of -tijdsinterval (bijv. ‘2011/2012’, ‘-0431/-0404’ voor v.Chr., of ‘1440/..’) of een web-URI"@nl, "Use an ISO 8601 date or time interval (such as ‘2011/2012’, ‘-0431/-0404’ for BCE, or ‘1440/..’) or a web URI"@en ;
         ] ,
         [


### PR DESCRIPTION
## Summary

- SHACL `schema:temporalCoverage` pattern now accepts ISO 8601 shortened-end notation (e.g. `1889-06/07` meaning June–July 1889), which the initial pattern in #1863 rejected.
- Regression test: new fixture + validator case asserting zero SHACL results on `schema:temporalCoverage` for `"1889-06/07"`.
- Description text gains the shortened form as an example; `sh:message` unchanged (Gouda snapshot stable).

Fix is identical in netwerk-digitaal-erfgoed/schema-profile#131 — the canonical example `examples/CreativeWork-temporalCoverage.jsonld` in that repo uses exactly this form.
