### PR TITLE
fix(core): align Distribution with DCAT-AP-NL 3.0 (title + description)

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -490,10 +490,6 @@ function schemaOrgQuery(prefix: string): string {
       }
       OPTIONAL { ?${distribution} ${prefix}:license ${normalizeLicense(distributionLicense + 'Provided')} }
       BIND(COALESCE(?${distributionLicense}Provided, ?${license}) AS ?${distributionLicense})
-      # ${prefix}:name → dct:title on Distribution (DCAT-AP-NL §4.2.24, Optional).
-      # When #698 lands and service-type distributions become dcat:DataService,
-      # the DataService shape requires dct:title as Mandatory (1..n) — route
-      # there instead of here for the DataService branch.
       OPTIONAL { ?${distribution} ${prefix}:name ?${distributionName} }
       OPTIONAL { ?${distribution} ${prefix}:contentSize ?${distributionSize} }
       OPTIONAL {

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -58,6 +58,7 @@ const distributionDateModified = 'distribution_dateModified';
 const distributionDescription = 'distribution_description';
 const distributionLanguage = 'distribution_language';
 const distributionLicense = 'distribution_license';
+const distributionName = 'distribution_name';
 const distributionSize = 'distribution_size';
 const distributionCompressFormat = 'distribution_compressFormat';
 const distributionDownloadUrl = 'distribution_downloadUrl';
@@ -299,6 +300,7 @@ export const constructQuery = `
       dct:description ?${distributionDescription} ;
       dct:language ?${distributionLanguage} ;
       dct:license ?${distributionLicense} ;
+      dct:title ?${distributionName} ;
       dcat:byteSize ?${distributionSize} ;
       odrl:hasPolicy ?policy .
 
@@ -371,6 +373,7 @@ export const constructQuery = `
             ${normalizeLanguage(`?${distributionLanguage}Raw`, distributionLanguage)}
           }
           OPTIONAL { ?${distribution} dct:license ${normalizeLicense(distributionLicense)} }
+          OPTIONAL { ?${distribution} dct:title ?${distributionName} }
           OPTIONAL { ?${distribution} dcat:byteSize ?${distributionSize} }
           OPTIONAL {
             ?${distribution} odrl:hasPolicy ?policy .
@@ -487,6 +490,11 @@ function schemaOrgQuery(prefix: string): string {
       }
       OPTIONAL { ?${distribution} ${prefix}:license ${normalizeLicense(distributionLicense + 'Provided')} }
       BIND(COALESCE(?${distributionLicense}Provided, ?${license}) AS ?${distributionLicense})
+      # ${prefix}:name → dct:title on Distribution (DCAT-AP-NL §4.2.24, Optional).
+      # When #698 lands and service-type distributions become dcat:DataService,
+      # the DataService shape requires dct:title as Mandatory (1..n) — route
+      # there instead of here for the DataService branch.
+      OPTIONAL { ?${distribution} ${prefix}:name ?${distributionName} }
       OPTIONAL { ?${distribution} ${prefix}:contentSize ?${distributionSize} }
       OPTIONAL {
         ?${distribution} ${prefix}:usageInfo ?${distributionConformsTo} .

--- a/packages/core/test/datasets/dataset-schema-org-distribution-name.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-distribution-name.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "@id": "https://example.com/dataset/distribution-name",
+  "name": "Dataset with named distribution",
+  "description": "Exercises schema:name → dct:title on DataDownload.",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://example.com/publisher",
+    "name": "Example Publisher"
+  },
+  "distribution": [
+    {
+      "@type": "DataDownload",
+      "name": "Turtle dump",
+      "description": "Full dataset serialised as Turtle.",
+      "encodingFormat": "text/turtle",
+      "contentUrl": "https://example.com/dataset.ttl"
+    }
+  ]
+}

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -757,6 +757,38 @@ describe('Fetch', () => {
     expect(accessUrls[0].object.termType).toBe('NamedNode');
   });
 
+  it('maps schema:name on DataDownload to dct:title on Distribution', async () => {
+    const response = await file('dataset-schema-org-distribution-name.jsonld');
+    nock('https://example.com')
+      .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
+      .get('/distribution-name')
+      .reply(200, response);
+
+    const datasets = await fetchDatasetsAsArray(
+      new URL('https://example.com/distribution-name'),
+    );
+    expect(datasets).toHaveLength(1);
+    const dataset = datasets[0];
+    const distributions = [
+      ...dataset.match(
+        factory.namedNode('https://example.com/dataset/distribution-name'),
+        dcat('distribution'),
+        null,
+      ),
+    ];
+    expect(distributions).toHaveLength(1);
+
+    const titleTriples = [
+      ...dataset.match(
+        distributions[0].object as BlankNode,
+        dct('title'),
+        null,
+      ),
+    ];
+    expect(titleTriples).toHaveLength(1);
+    expect((titleTriples[0].object as Literal).value).toBe('Turtle dump');
+  });
+
   it('accepts valid HTTP Schema.org dataset in JSON-LD', async () => {
     const response = await file('dataset-http-schema-org-valid.jsonld');
     nock('https://example.com')

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(() => ({
       thresholds: {
         autoUpdate: true,
         lines: 95.13,
-        functions: 94.64,
+        functions: 92.8,
         branches: 83.42,
         statements: 94.46,
       },

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(() => ({
       thresholds: {
         autoUpdate: true,
         lines: 95.13,
-        functions: 92.8,
+        functions: 94.64,
         branches: 83.42,
         statements: 94.46,
       },

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -709,10 +709,6 @@ nde-dataset:DistributionShape
             ] ;
             sh:message "Gebruik een web URI die begint met http:// of https://"@nl, "Use a web URI starting with http:// or https://"@en ;
         ] ,
-        # schema:description is Recommended (0..n) on Distribution per
-        # DCAT-AP-NL 3.0 \u00a74.2.8 \u2014 permanent sh:Info, no nde:futureChange,
-        # matching the house style for other Recommended properties
-        # (keywords, spatialCoverage, temporalCoverage).
         [
             sh:path schema:description ;
             sh:minCount 1 ;

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -709,7 +709,16 @@ nde-dataset:DistributionShape
             ] ;
             sh:message "Gebruik een web URI die begint met http:// of https://"@nl, "Use a web URI starting with http:// or https://"@en ;
         ] ,
-        nde-dataset:SchemaDescriptionPropertyShouldExist .
+        # schema:description is Recommended (0..n) on Distribution per
+        # DCAT-AP-NL 3.0 \u00a74.2.8 \u2014 permanent sh:Info, no nde:futureChange,
+        # matching the house style for other Recommended properties
+        # (keywords, spatialCoverage, temporalCoverage).
+        [
+            sh:path schema:description ;
+            sh:minCount 1 ;
+            sh:severity sh:Info ;
+            sh:message "Voeg een beschrijving toe"@nl, "Add a description"@en ;
+        ] .
 
 # Dedicated SPARQL constraint shape, structured the same way as the two
 # Organization-required shapes below: sh:targetObjectsOf for the entry, sh:message


### PR DESCRIPTION
## Summary

Aligns `dcat:Distribution` with DCAT-AP-NL 3.0 (§4.2). Two drifts corrected:

- **Restore `schema:name` → `dct:title` projection** that #1784 removed. DCAT-AP-NL 3.0 §4.2.24 lists `dct:title` on Distribution at **0..n, Optional (O)** — the premise of #1730 ("not part of DCAT-AP-NL 3.0") was factually wrong. Producer-supplied `schema:name` values on `DataDownload` now survive as `dct:title` on the Distribution.
- **Relax `schema:description` shape to `sh:Info`**. DCAT-AP-NL 3.0 §4.2.8 marks `dct:description` as **Recommended (A)**, not Mandatory. The inherited `sh:Warning` + `nde:futureChange` → `sh:Violation` from #1719 (shared-shape reuse oversight) overshoots to Mandatory. Replace with an inline `sh:Info` shape matching house style for other Recommended properties (`keywords`, `spatialCoverage`, `temporalCoverage`). Restores the original 2021 intent from PR #387. Closes #1868.

The two Dataset targets that still reference `nde-dataset:SchemaDescriptionPropertyShouldExist` are unchanged — for them DCAT-AP-NL makes description Mandatory, so the Warning → Violation bump is correct.

## Regression test

New fixture `dataset-schema-org-distribution-name.jsonld` + `fetch.test.ts` case assert that a DataDownload with `"name": "Turtle dump"` produces `<dist> dct:title "Turtle dump"` in the output graph.

## Out of scope

- **Data-quality policing of filename-ish titles** (#1730's empirical observation): producers often supply filenames as `schema:name`. A future SHACL `sh:pattern` negation can nudge them toward meaningful titles. Deferred to a dedicated issue — this PR restores the mapping, not the gate.
- **DataService support (#698)**: when service-type distributions become `dcat:DataService`, `schema:name` should route to `dct:title` on the DataService where it is Mandatory (1..n). A comment in `query.ts` flags the intent.

Closes #1868. Partially reverts #1784 based on a correction to #1730.
