### PR TITLE
feat(api): add Turtle example to API specs

### DIFF
--- a/apps/api/src/assets/api.yaml
+++ b/apps/api/src/assets/api.yaml
@@ -90,6 +90,23 @@ paths:
       operationId: validate-body
       requestBody:
         content:
+          text/turtle:
+            schema:
+              type: string
+            examples:
+              valid:
+                summary: A valid dataset in the request body
+                value: |-
+                  @prefix schema: <https://schema.org/> .
+                  <http://data.bibliotheken.nl/id/dataset/rise-alba>
+                    a schema:Dataset ;
+                    schema:name "Alba amicorum van de Koninklijke Bibliotheek" ;
+                    schema:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
+                    schema:publisher <https://example.com/publisher> .
+
+                  <https://example.com/publisher>
+                    a schema:Organization ;
+                    schema:name "Koninklijke Bibliotheek" .
           application/ld+json:
             schema:
               type: object


### PR DESCRIPTION
For most users Turtle is a much more readable RDF syntax than JSON+LD. Therefore I propose this change to include a Turtle example, with an extra benefit of being able to change the `Accept` header to `text/turtle` when quickly checking out the API.