### PR TITLE
feat(shacl): require SPARQL protocol URI in usageInfo for SPARQL mediaType

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -344,13 +344,19 @@ export const constructQuery = `
         OPTIONAL {
           ?${dataset} dcat:distribution ?${distribution} .
           ?${distribution} a dcat:Distribution .
-          ?${distribution} dcat:mediaType ${normalizeMediaType(distributionMediaType)} .
           ?${distribution} dcat:accessURL ${convertToIri(distributionUrl)} .
+          OPTIONAL {
+            ?${distribution} dcat:mediaType ${normalizeMediaType(distributionMediaType)} .
+          }
           OPTIONAL { ?${distribution} dct:conformsTo ?${distributionConformsTo} . }
           OPTIONAL {
             ?${distribution} dct:conformsTo ?${distributionConformsToProtocol} .
             VALUES ?${distributionConformsToProtocol} { ${apiProtocolValues} }
           }
+          # Infer the SPARQL protocol URI from a SPARQL-ish mediaType so distributions
+          # that haven't declared it explicitly via dct:conformsTo are still classified
+          # as APIs. Drop when DistributionSparqlMediaTypeRequiresProtocolShape escalates
+          # to Violation (nde:futureChange "2.0" in shacl.ttl).
           BIND(
             IF(
               CONTAINS(STR(?${distributionMediaType}), "sparql"),
@@ -462,9 +468,16 @@ function schemaOrgQuery(prefix: string): string {
     OPTIONAL {
       ?${dataset} ${prefix}:distribution ?${distribution} .
       ?${distribution} a ${prefix}:DataDownload .
-      ?${distribution} ${prefix}:encodingFormat ${normalizeMediaType(distributionMediaType)} .
       ?${distribution} ${prefix}:contentUrl ${convertToIri(distributionUrl)} .
 
+      OPTIONAL {
+        ?${distribution} ${prefix}:encodingFormat ${normalizeMediaType(distributionMediaType)} .
+      }
+
+      # Infer the SPARQL protocol URI from a SPARQL-ish encodingFormat so distributions
+      # that haven't declared it explicitly via schema:usageInfo are still classified
+      # as APIs. Drop when DistributionSparqlEncodingRequiresProtocolShape escalates
+      # to Violation (nde:futureChange "2.0" in shacl.ttl).
       BIND(
         IF(
           CONTAINS(STR(?${distributionMediaType}), "sparql"),

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -280,7 +280,9 @@ describe('Validator', () => {
     expect(report.state).toEqual('valid');
     expect(formatReport(report)).toMatchInlineSnapshot(`
       "[Info] https://schema.org/about on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: Add a URI describing the dataset’s subject matter or material type (for example from the Network of Terms)
+      [Warning]  on <https://www.goudatijdmachine.nl/omeka/api/items/3030722>: Add the SPARQL protocol URI (https://www.w3.org/TR/sparql11-protocol/) to schema:usageInfo for SPARQL endpoints
       [Warning] https://schema.org/contactPoint on <https://www.goudatijdmachine.nl/omeka/api/items/232>: Add a contact point with a name and email address, preferably of the department that manages the dataset or catalogue
+      [Warning] https://schema.org/encodingFormat on <https://www.goudatijdmachine.nl/omeka/api/items/3030722>: Remove the SPARQL MIME type from schema:encodingFormat; SPARQL endpoints are declared via schema:usageInfo
       [Warning] https://schema.org/genre on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: schema:genre is deprecated; use schema:about with a URI (for example from the Network of Terms)
       [Warning] https://schema.org/identifier on <https://www.goudatijdmachine.nl/omeka/api/items/232>: Add an identifier for the organisation, such as a Chamber of Commerce number or ISIL
       [Warning] https://schema.org/license on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: Use https:// (not http://) in the Creative Commons license URL

--- a/requirements/examples/dataset-schema-org-valid.jsonld
+++ b/requirements/examples/dataset-schema-org-valid.jsonld
@@ -81,7 +81,6 @@
         },
         {
           "@type": "DataDownload",
-          "encodingFormat": "application/sparql-query",
           "contentUrl": "https://data.bibliotheken.nl/id/dataset/sparql",
           "usageInfo": "https://www.w3.org/TR/sparql11-protocol/",
           "description": "SPARQL endpoint"

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -569,6 +569,16 @@ nde-dataset:DistributionShape
             When the distribution is compressed, the compression format (such as `zip`, `gzip`) must be included (such as `text/turtle+gzip`)."""@en ;
             sh:message "Vul een geldig MIME-type in, bijv. application/n-triples"@nl, "Enter a valid MIME type, such as application/n-triples"@en ;
         ] ,
+        [
+            sh:path schema:encodingFormat ;
+            sh:not [ sh:pattern "application/sparql-" ] ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "Verwijder het SPARQL MIME-type uit schema:encodingFormat; SPARQL-endpoints worden gedeclareerd via schema:usageInfo"@nl, "Remove the SPARQL MIME type from schema:encodingFormat; SPARQL endpoints are declared via schema:usageInfo"@en ;
+        ] ,
         # Recommended properties
         [
             sh:path schema:description ;
@@ -728,6 +738,59 @@ nde-dataset:DistributionLicenseRequiredShape
                 ?dataset schema:distribution $this .
                 FILTER NOT EXISTS { $this schema:license ?distLicense }
                 FILTER NOT EXISTS { ?dataset schema:license ?datasetLicense }
+            }
+        """ ;
+    ] .
+
+# SPARQL endpoints must declare the SPARQL protocol URI in schema:usageInfo so the
+# Dataset Register can identify them as APIs. A SPARQL MIME type in schema:encodingFormat
+# is not sufficient on its own. See [[#usage-information]].
+nde-dataset:DistributionSparqlEncodingRequiresProtocolShape
+    a sh:NodeShape ;
+    sh:targetObjectsOf schema:distribution ;
+    sh:severity sh:Warning ;
+    nde:futureChange [
+        nde:version "2.0" ;
+        sh:severity sh:Violation ;
+    ] ;
+    sh:message "Voeg de SPARQL protocol-URI (https://www.w3.org/TR/sparql11-protocol/) toe aan schema:usageInfo voor SPARQL-endpoints"@nl, "Add the SPARQL protocol URI (https://www.w3.org/TR/sparql11-protocol/) to schema:usageInfo for SPARQL endpoints"@en ;
+    sh:sparql [
+        sh:select """
+            PREFIX schema: <https://schema.org/>
+            SELECT $this
+            WHERE {
+                $this schema:encodingFormat ?format .
+                FILTER(CONTAINS(STR(?format), "application/sparql-"))
+                FILTER NOT EXISTS {
+                    $this schema:usageInfo <https://www.w3.org/TR/sparql11-protocol/> .
+                }
+            }
+        """ ;
+    ] .
+
+# DCAT mirror of the shape above: SPARQL endpoints must declare the SPARQL protocol URI
+# in dct:conformsTo. A SPARQL MIME type in dcat:mediaType is not sufficient on its own.
+# See [[#usage-information]].
+dcat:DistributionSparqlMediaTypeRequiresProtocolShape
+    a sh:NodeShape ;
+    sh:targetObjectsOf dcat:distribution ;
+    sh:severity sh:Warning ;
+    nde:futureChange [
+        nde:version "2.0" ;
+        sh:severity sh:Violation ;
+    ] ;
+    sh:message "Voeg de SPARQL protocol-URI (https://www.w3.org/TR/sparql11-protocol/) toe aan dct:conformsTo voor SPARQL-endpoints"@nl, "Add the SPARQL protocol URI (https://www.w3.org/TR/sparql11-protocol/) to dct:conformsTo for SPARQL endpoints"@en ;
+    sh:sparql [
+        sh:select """
+            PREFIX dcat: <http://www.w3.org/ns/dcat#>
+            PREFIX dct: <http://purl.org/dc/terms/>
+            SELECT $this
+            WHERE {
+                $this dcat:mediaType ?mediaType .
+                FILTER(CONTAINS(STR(?mediaType), "application/sparql-"))
+                FILTER NOT EXISTS {
+                    $this dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> .
+                }
             }
         """ ;
     ] .
@@ -1458,6 +1521,16 @@ dcat:DistributionShape
         ] ]
     ) ;
     sh:property [
+        sh:path dcat:mediaType ;
+        sh:not [ sh:pattern "application/sparql-" ] ;
+        sh:severity sh:Warning ;
+        nde:futureChange [
+            nde:version "2.0" ;
+            sh:severity sh:Violation ;
+        ] ;
+        sh:message "Verwijder het SPARQL MIME-type uit dcat:mediaType; SPARQL-endpoints worden gedeclareerd via dct:conformsTo"@nl, "Remove the SPARQL MIME type from dcat:mediaType; SPARQL endpoints are declared via dct:conformsTo"@en ;
+    ] ,
+    [
         sh:path dc:license ;
         sh:minCount 1 ;
         sh:maxCount 1 ;


### PR DESCRIPTION
## Summary

Distributions sometimes use SPARQL-flavoured MIME types (`application/sparql-query`, `application/sparql-results+json`, …) in `schema:encodingFormat` / `dcat:mediaType` to indicate that they’re a SPARQL endpoint. The protocol URI in `schema:usageInfo` / `dct:conformsTo` is the right place for that signal — the MIME type field is for the response body of a downloadable file. Until now the Dataset Register quietly papered over this by inferring `dct:conformsTo: sparql11-protocol` from any MIME type containing `sparql`, which lets authors get away with never declaring the protocol explicitly.

## Changes

- **SHACL** – two new shapes per vocabulary:
  - **Require the SPARQL protocol URI** (`DistributionSparqlEncodingRequiresProtocolShape`, `DistributionSparqlMediaTypeRequiresProtocolShape`): `sh:sparql` constraint that fires when `schema:encodingFormat` / `dcat:mediaType` matches `application/sparql-*` and `schema:usageInfo` / `dct:conformsTo` does not contain `https://www.w3.org/TR/sparql11-protocol/`.
  - **Discourage the SPARQL MIME type itself**: a property warning on `schema:encodingFormat` / `dcat:mediaType` that fires whenever the value matches `application/sparql-*`, asking authors to leave the field empty for SPARQL endpoints.

  Both warnings now, `nde:futureChange` to Violation in 2.0. Together they implement the "use `usageInfo` *instead of* MIME type" semantics:
  - Only sparql-ish MIME type, no `usageInfo` → 2 warnings (add `usageInfo`, remove MIME type)
  - Both present → 1 warning (remove the redundant MIME type)
  - Only `usageInfo: sparql11-protocol/` → no warnings (correct end state)
- **Fetch query** (`packages/core/src/query.ts`) – wrap `schema:encodingFormat` / `dcat:mediaType` in nested `OPTIONAL`s so distributions that follow the nudge (protocol URI only, no MIME type) still flow through. API distributions still emit `dcat:accessURL` only via `downloadOnlyProperties`, so DCAT-AP-NL compliance is preserved.
- **Backward compatibility** – the `BIND … CONTAINS "sparql" …` inference in `query.ts` is kept. Distributions that haven’t yet added an explicit `usageInfo` keep their API classification while the warnings nudge authors. The inference will be dropped together with the Violation upgrade in 2.0.
- **Canonical example** – drop the redundant `application/sparql-query` `encodingFormat` from the SPARQL distribution in `requirements/examples/dataset-schema-org-valid.jsonld` so it stays warning-free.
- **Snapshot** – update the Gouda Tijdmachine inline snapshot in `validator.test.ts` to include both new warnings. The fixture uses `application/sparql-results+json` without a matching `usageInfo` and demonstrates the new shapes firing on real-world data.
