### PR TITLE
fix(shacl): split publisher min/max-count constraints into separate shapes

### DIFF
--- a/packages/core/test/datasets/dataset-schema-org-multiple-publishers.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-multiple-publishers.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "name": "Alba amicorum van de Koninklijke Bibliotheek",
+  "description": "Alba amicorum uit de collectie van de Koninklijke Bibliotheek.",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "publisher": [
+    {
+      "@type": "Organization",
+      "@id": "https://example.com/publisher-one",
+      "name": "Koninklijke Bibliotheek"
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://example.com/publisher-two",
+      "name": "Nationaal Archief"
+    }
+  ]
+}

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -518,6 +518,42 @@ describe('Validator', () => {
     ).toBe(false);
   });
 
+  it('reports multiple publishers with a max-count message, not the min-count message', async () => {
+    // Regression: min-count and max-count on schema:publisher previously shared
+    // a single sh:message ("Add a publisher"), so a dataset with two publishers
+    // returned a misleading result message. Each failure mode must carry its
+    // own message.
+    const report = (await validate(
+      'dataset-schema-org-multiple-publishers.jsonld',
+    )) as InvalidDataset;
+
+    expect(report.state).toBe('invalid');
+
+    const publisherMessages = [
+      ...report.errors.match(
+        null,
+        shacl('resultPath'),
+        rdf.namedNode('https://schema.org/publisher'),
+      ),
+    ]
+      .map((quad) => quad.subject)
+      .flatMap((resultNode) => [
+        ...report.errors.match(
+          resultNode as never,
+          shacl('resultMessage'),
+          null,
+        ),
+      ])
+      .filter(
+        (quad) =>
+          quad.object.termType === 'Literal' && quad.object.language === 'en',
+      )
+      .map((quad) => quad.object.value);
+
+    expect(publisherMessages).toContain('Use at most one publisher');
+    expect(publisherMessages).not.toContain('Add a publisher');
+  });
+
   it('reports invalid encoding format', async () => {
     const report = await validate(
       'dataset-schema-org-invalid-encoding-format.jsonld',

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -49,7 +49,6 @@ nde-dataset:DatacatalogShape
         [
             sh:path schema:publisher ;
             sh:minCount 1 ;
-            sh:maxCount 1 ;
             sh:severity sh:Warning ;
             nde:futureChange [
                 nde:version "2.0" ;
@@ -64,6 +63,16 @@ nde-dataset:DatacatalogShape
                 [ sh:class schema:Organization ]
                 [ sh:class schema:Person ]
             ) ;
+        ] ,
+        [
+            sh:path schema:publisher ;
+            sh:maxCount 1 ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "Gebruik maximaal één uitgever"@nl, "Use at most one publisher"@en ;
         ] ,
         [
             sh:path schema:dataset ;
@@ -107,7 +116,6 @@ nde-dataset:DatasetShape
         [
             sh:path schema:publisher ;
             sh:minCount 1 ;
-            sh:maxCount 1 ;
             sh:name "Uitgever van de dataset"@nl, "Publisher of the dataset"@en ;
             sh:description "De organisatie of persoon die verantwoordelijk is voor de publicatie van de dataset."@nl, "An entity (organisation or person) responsible for making the Dataset available."@en ;
             sh:message "Voeg een uitgever toe"@nl, "Add a publisher"@en ;
@@ -115,6 +123,11 @@ nde-dataset:DatasetShape
                 [ sh:class schema:Organization ]
                 [ sh:class schema:Person ]
             ) ;
+        ] ,
+        [
+            sh:path schema:publisher ;
+            sh:maxCount 1 ;
+            sh:message "Gebruik maximaal één uitgever"@nl, "Use at most one publisher"@en ;
         ] ,
         [
             sh:path schema:license ;
@@ -1342,7 +1355,6 @@ dcat:DatasetShape
     [
         sh:path dc:publisher ;
         sh:minCount 1 ;
-        sh:maxCount 1 ;
         sh:severity sh:Warning ;
         nde:futureChange [
             nde:version "2.0" ;
@@ -1354,6 +1366,16 @@ dcat:DatasetShape
             [ sh:class foaf:Organization ]
             [ sh:class foaf:Person ]
         ) ;
+    ],
+    [
+        sh:path dc:publisher ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        nde:futureChange [
+            nde:version "2.0" ;
+            sh:severity sh:Violation ;
+        ] ;
+        sh:message "Gebruik maximaal één uitgever"@nl, "Use at most one publisher"@en ;
     ],
     [
         sh:path dc:creator ;
@@ -1570,7 +1592,6 @@ dcat:CatalogShape
     [
         sh:path dc:publisher ;
         sh:minCount 1 ;
-        sh:maxCount 1 ;
         sh:severity sh:Warning ;
         nde:futureChange [
             nde:version "2.0" ;
@@ -1579,6 +1600,16 @@ dcat:CatalogShape
         sh:description "De organisatie die verantwoordelijk is voor de publicatie van de catalogus."@nl,
             "The organization responsible for publishing the catalog."@en ;
         sh:message "Voeg een uitgever toe"@nl, "Add a publisher"@en ;
+    ],
+    [
+        sh:path dc:publisher ;
+        sh:maxCount 1 ;
+        sh:severity sh:Warning ;
+        nde:futureChange [
+            nde:version "2.0" ;
+            sh:severity sh:Violation ;
+        ] ;
+        sh:message "Gebruik maximaal één uitgever"@nl, "Use at most one publisher"@en ;
     ],
     [
         sh:path dcat:contactPoint ;


### PR DESCRIPTION
## Summary

SHACL validation of a dataset with two publishers currently returns the message “Voeg een uitgever toe” / “Add a publisher” – the min-count message surfacing on a max-count violation. The four publisher property shapes combined `sh:minCount 1` and `sh:maxCount 1` under one `sh:message`, so both failure modes shared a single (min-count-flavoured) message.

This PR splits each publisher property shape in two, per the project’s SHACL guideline (“Split constraints with different failure modes into separate property shapes”) and the existing `schema:license` precedent:

- `schema:publisher` on `nde-dataset:DatacatalogShape` and `nde-dataset:DatasetShape`
- `dc:publisher` on `dcat:DatasetShape` and `dcat:CatalogShape`

Each split preserves the original `sh:severity` and `nde:futureChange → sh:Violation @ v2.0` where present. The new max-count shape reports “Gebruik maximaal één uitgever” / “Use at most one publisher”.

DCAT-AP-NL 3.0 §4.1.22 and §4.4.13 mandate `dct:publisher` 1..1 on both `dcat:Dataset` and `dcat:Catalog`, so the underlying cardinality rule is unchanged – only the message differentiation is new.

## Repro

`PUT /datasets/validate` against `https://www.ldmax.nl/datasets/wo2net/collecties` (two declared publishers) returned a SHACL `MaxCountConstraintComponent` violation carrying the misleading min-count message. After this change, the same input produces “Use at most one publisher”.

## Changes

- `requirements/shacl.ttl` – split four publisher property shapes.
- `packages/core/test/validator.test.ts` – regression test asserting the max-count message appears and the min-count message does not.
- `packages/core/test/datasets/dataset-schema-org-multiple-publishers.jsonld` – fixture with two publishers.
