### PR TITLE
ci(dependabot): split typescript out of eslint group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
           - '@typescript-eslint/*'
           - 'eslint'
           - 'eslint-plugin-svelte'
-          - 'typescript'
       fastify:
         patterns:
           - '@fastify/*'


### PR DESCRIPTION
## Summary

Split `typescript` out of the `eslint` Dependabot group so TypeScript bumps arrive as standalone PRs.

## Why

The `eslint` group kept `@typescript-eslint/*`, `eslint`, `eslint-plugin-svelte`, and `typescript` together. Grouping them made sense for minor/patch alignment between the parser and the compiler — but it also meant TypeScript majors (e.g. 5.x → 6.x) rode along in the same PR, forcing an all-or-nothing merge even though the Svelte / SvelteKit / svelte-check compatibility question for a TS major is much more involved than the lint bumps.

With `typescript` ungrouped, Dependabot will open it as its own PR, which can be evaluated on its own schedule without blocking the lint group.

`@typescript-eslint/*` still declares `typescript: ">=4.8.4 <6.1.0"` as a peer, so any TS bump that exceeds the parser’s range will surface naturally when the TS PR is reviewed.
