### PR TITLE
fix(api): use example.com URIs in API doc examples

### DIFF
--- a/apps/api/src/assets/api.yaml
+++ b/apps/api/src/assets/api.yaml
@@ -36,13 +36,13 @@ paths:
                 summary: A valid dataset
                 value:
                   {
-                    '@id': 'https://demo.netwerkdigitaalerfgoed.nl/datasets/kb/2.html',
+                    '@id': 'https://example.com/dataset',
                   }
               invalid:
                 summary: An invalid dataset
                 value:
                   {
-                    '@id': 'https://demo.netwerkdigitaalerfgoed.nl/datasets/kb/2a.html',
+                    '@id': 'https://example.com/invalid-dataset',
                   }
       responses:
         202:
@@ -158,13 +158,13 @@ paths:
                 summary: A valid dataset
                 value:
                   {
-                    '@id': 'https://demo.netwerkdigitaalerfgoed.nl/datasets/kb/2.html',
+                    '@id': 'https://example.com/dataset',
                   }
               invalid:
                 summary: An invalid dataset
                 value:
                   {
-                    '@id': 'https://demo.netwerkdigitaalerfgoed.nl/datasets/kb/2a.html',
+                    '@id': 'https://example.com/invalid-dataset',
                   }
       responses:
         200:


### PR DESCRIPTION
Replace the default `@id` example values in the OpenAPI spec for `POST /datasets` and `PUT /datasets/validate` with `https://example.com/dataset` and `https://example.com/invalid-dataset`.

Fix #1871
