### PR TITLE
fix(shacl): consolidate publisher/creator shapes into AgentShape

### DIFF
--- a/packages/core/test/datasets/dataset-dcat-organization-person-duplicate-shapes.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-organization-person-duplicate-shapes.jsonld
@@ -1,0 +1,30 @@
+{
+  "@context": {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "@graph": [
+    {
+      "@id": "http://example.com/dataset/1",
+      "@type": "dcat:Dataset",
+      "dct:title": [
+        { "@value": "Dataset", "@language": "en" },
+        { "@value": "Dataset", "@language": "nl" }
+      ],
+      "dct:description": [
+        { "@value": "Description", "@language": "en" },
+        { "@value": "Beschrijving", "@language": "nl" }
+      ],
+      "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" },
+      "dct:publisher": { "@id": "http://example.com/org/1" }
+    },
+    {
+      "@id": "http://example.com/org/1",
+      "foaf:name": [
+        { "@value": "Name One", "@language": "en" },
+        { "@value": "Name Two", "@language": "en" }
+      ]
+    }
+  ]
+}

--- a/packages/core/test/datasets/dataset-dcat-publisher-equals-creator.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-publisher-equals-creator.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "@graph": [
+    {
+      "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+      "@type": "dcat:Dataset",
+      "dct:title": [
+        { "@value": "Alba amicorum", "@language": "en" },
+        { "@value": "Alba amicorum", "@language": "nl" }
+      ],
+      "dct:description": [
+        { "@value": "Description", "@language": "en" },
+        { "@value": "Beschrijving", "@language": "nl" }
+      ],
+      "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" },
+      "dct:publisher": { "@id": "http://data.bibliotheken.nl/id/thes/p075301482" },
+      "dct:creator": { "@id": "http://data.bibliotheken.nl/id/thes/p075301482" }
+    },
+    {
+      "@id": "http://data.bibliotheken.nl/id/thes/p075301482",
+      "foaf:name": [
+        { "@value": "KB, national library of the Netherlands", "@language": "en" },
+        { "@value": "KB, nationale bibliotheek", "@language": "nl" }
+      ]
+    }
+  ]
+}

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -583,6 +583,42 @@ describe('Validator', () => {
     const report = await validate('dataset-schema-org-valid-minimal.jsonld');
     expect(report.state).toEqual('valid');
   });
+
+  it('emits uniqueLang violation once per focus node, not once per shape', async () => {
+    // Regression: Organization and Person shapes both targeted objects of
+    // dct:publisher and dct:creator with identical foaf:name constraints, so
+    // every uniqueLang violation fired twice on the same focus node.
+    const report = await validate(
+      'dataset-dcat-organization-person-duplicate-shapes.jsonld',
+    );
+    const foafName = rdf.namedNode('http://xmlns.com/foaf/0.1/name');
+    const uniqueLangResults = [
+      ...report.errors.match(null, shacl('resultPath'), foafName),
+    ]
+      .map((quad) => quad.subject)
+      .filter(
+        (resultNode) =>
+          [
+            ...report.errors.match(
+              resultNode as never,
+              shacl('sourceConstraintComponent'),
+              shacl('UniqueLangConstraintComponent'),
+            ),
+          ].length > 0,
+      );
+    expect(uniqueLangResults).toHaveLength(1);
+  });
+
+  it('does not emit spurious foaf:name violations when publisher equals creator', async () => {
+    const report = (await validate(
+      'dataset-dcat-publisher-equals-creator.jsonld',
+    )) as Valid;
+    const foafName = rdf.namedNode('http://xmlns.com/foaf/0.1/name');
+    const foafNameResults = [
+      ...report.errors.match(null, shacl('resultPath'), foafName),
+    ];
+    expect(foafNameResults).toHaveLength(0);
+  });
 });
 
 export const validate = async (filename: string, parser?: Transform) =>

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -588,9 +588,9 @@ describe('Validator', () => {
     // Regression: Organization and Person shapes both targeted objects of
     // dct:publisher and dct:creator with identical foaf:name constraints, so
     // every uniqueLang violation fired twice on the same focus node.
-    const report = await validate(
+    const report = (await validate(
       'dataset-dcat-organization-person-duplicate-shapes.jsonld',
-    );
+    )) as Valid;
     const foafName = rdf.namedNode('http://xmlns.com/foaf/0.1/name');
     const uniqueLangResults = [
       ...report.errors.match(null, shacl('resultPath'), foafName),

--- a/requirements/index.bs.liquid
+++ b/requirements/index.bs.liquid
@@ -804,7 +804,7 @@ This is an overview of required and recommended attributes.
 {% render 'attributes', name: 'Dataset', nodeShape: datasetShape %}
 
 {% for shape in nodeShapes -%}
-{%- if shape['@id'] == 'nde-dataset:OrganizationShape' %}{% assign organizationShape = shape %}{% endif -%}
+{%- if shape['@id'] == 'nde-dataset:AgentShape' %}{% assign organizationShape = shape %}{% endif -%}
 {%- if shape['@id'] == 'nde-dataset:DistributionShape' %}{% assign distributionShape = shape %}{% endif -%}
 {%- endfor %}
 {% render 'attributes', name: 'Organization', nodeShape: organizationShape, targetClass: 'schema:Organization' %}

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -813,7 +813,7 @@ dcat:DistributionSparqlMediaTypeRequiresProtocolShape
         """ ;
     ] .
 
-nde-dataset:OrganizationShape
+nde-dataset:AgentShape
     a sh:NodeShape ;
     sh:targetObjectsOf schema:publisher, schema:creator ;
     sh:message "Gebruik een web-URI die begint met http:// of https://"@nl, "Use a web URI starting with http:// or https://"@en ;
@@ -827,8 +827,8 @@ nde-dataset:OrganizationShape
                 [ sh:datatype xsd:string ]
                 [ sh:datatype rdf:langString ]
             ) ;
-            sh:description "The organization’s full name."@en ;
-            sh:message "Vul een naam in voor de organisatie"@nl, "Enter a name for the organisation"@en ;
+            sh:description "The full name of the publisher or creator."@en ;
+            sh:message "Vul een naam in voor de uitgever of maker"@nl, "Enter a name for the publisher or creator"@en ;
         ] ,
         nde-dataset:SchemaNameUniqueLangProperty,
         nde-dataset:SchemaNameLangStringProperty,
@@ -1027,23 +1027,11 @@ nde-dataset:ContactPointShape
         sh:message "Vul een e-mailadres in voor het contactpunt"@nl, "Enter an email address for the contact point"@en ;
     ] .
 
-nde-dataset:PersonShape
-    a sh:NodeShape ;
-    sh:targetObjectsOf schema:publisher, schema:creator ;
-    sh:nodeKind sh:IRI ;
-    sh:pattern "^https?://" ;
-    sh:message "Gebruik een web URI die begint met http:// of https://"@nl, "Use a web URI starting with http:// or https://"@en ;
-    sh:property [
-        sh:path schema:name ;
-        sh:minCount 1 ;
-        sh:or (
-            [ sh:datatype xsd:string ]
-            [ sh:datatype rdf:langString ]
-        ) ;
-        sh:uniqueLang true ;
-        sh:message "Gebruik per taal maximaal één waarde"@nl, "Use at most one value per language"@en ;
-    ] ,
-    nde-dataset:SchemaNameLangStringProperty .
+# Publisher/creator validation is consolidated into nde-dataset:AgentShape above,
+# which covers both schema:Organization and schema:Person instances. Separate Organization
+# and Person shapes would duplicate every constraint (nodeKind, pattern, name) and fire
+# two identical violations on the same focus node. Organization-specific requirements are
+# gated by SPARQL with "$this a schema:Organization" so Persons aren’t caught by those.
 
 #
 # Property shapes
@@ -1729,7 +1717,7 @@ dcat:ContactPointShape
         sh:message "Vul een e-mailadres in voor het contactpunt, als mailto:-URL"@nl, "Enter an email address for the contact point, as a mailto: URL"@en ;
     ] .
 
-dcat:OrganizationShape
+dcat:AgentShape
     a sh:NodeShape ;
     sh:targetObjectsOf dc:publisher, dc:creator ;
     sh:nodeKind sh:IRI ;
@@ -1742,25 +1730,12 @@ dcat:OrganizationShape
             [ sh:datatype rdf:langString ]
         ) ;
         sh:uniqueLang true ;
-        sh:description "De naam van de organisatie."@nl, "The name of the organization."@en ;
+        sh:description "De naam van de uitgever of maker."@nl, "The name of the publisher or creator."@en ;
         sh:message "Gebruik per taal maximaal één waarde"@nl, "Use at most one value per language"@en ;
     ] ,
     nde-dataset:FoafNameLangStringProperty .
 
-dcat:PersonShape
-    a sh:NodeShape ;
-    sh:targetObjectsOf dc:publisher, dc:creator ;
-    sh:nodeKind sh:IRI ;
-    sh:pattern "^https?://" ;
-    sh:property [
-        sh:path foaf:name ;
-        sh:minCount 1 ;
-        sh:or (
-            [ sh:datatype xsd:string ]
-            [ sh:datatype rdf:langString ]
-        ) ;
-        sh:uniqueLang true ;
-        sh:description "De naam van de persoon."@nl, "The name of the person."@en ;
-        sh:message "Gebruik per taal maximaal één waarde"@nl, "Use at most one value per language"@en ;
-    ] ,
-    nde-dataset:FoafNameLangStringProperty .
+# Publisher/creator validation is consolidated into dcat:AgentShape above, which covers
+# both foaf:Organization and foaf:Person instances. Separate Organization and Person
+# shapes would duplicate every constraint (nodeKind, pattern, foaf:name) and fire two
+# identical violations on the same focus node.


### PR DESCRIPTION
Fix #1886.

## Summary

`OrganizationShape` and `PersonShape` both targeted the objects of `dct:publisher` and `dct:creator` (and the `schema:` equivalents) without any class-based discrimination, and their constraint sets were identical. As a result every violation on the agent – `sh:uniqueLang` on `foaf:name` in particular – fired twice on the same focus node.

## Changes

- Consolidate `OrganizationShape` and `PersonShape` into a single `AgentShape` (both the `nde-dataset:` and `dcat:` variants).
- Rename the missing-name message and property description to neutral wording (“publisher or creator”) since the shape now applies to both.
- Keep `OrganizationContactPointRequiredShape` and `OrganizationIdentifierRequiredShape` as-is – they are genuinely Organization-specific (gated by SPARQL `$this a schema:Organization`), so Persons are still correctly skipped.
- Add regression tests: one that asserts a single `uniqueLang` result for an agent with duplicate languages, and one that asserts no `foaf:name` violations when publisher and creator resolve to the same IRI with one value per language.
