### PR TITLE
fix(browser): jump to focus node's subject-position line

### DIFF
--- a/apps/browser/src/lib/components/validation/ResultRow.svelte
+++ b/apps/browser/src/lib/components/validation/ResultRow.svelte
@@ -56,10 +56,26 @@
     if (!sourceText) return null;
     const needle = result.value ?? result.focusNode;
     if (!needle) return null;
+    // Prefer the line where the focus node appears as a *subject* — it usually
+    // shows up earlier as an object reference (e.g. <catalog> schema:dataset
+    // <dataset>), and indexOf would jump to that wrong place.
+    if (!result.value && result.focusNode) {
+      const subjectMatch = new RegExp(
+        `^[ \\t]*<${escapeRegex(result.focusNode)}>`,
+        'm',
+      ).exec(sourceText);
+      if (subjectMatch) {
+        return sourceText.slice(0, subjectMatch.index).split(/\r?\n/).length;
+      }
+    }
     const index = sourceText.indexOf(needle);
     if (index === -1) return null;
     return sourceText.slice(0, index).split(/\r?\n/).length;
   });
+
+  function escapeRegex(input: string): string {
+    return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
 
   let currentValues = $state<DataValue[]>([]);
   $effect(() => {


### PR DESCRIPTION
## Summary

- Jump-to-line for a focus-node result (`Voeg een maker toe`, `Add a contact point`, …) used `sourceText.indexOf(focusNode)`, which finds the first occurrence of that IRI — often the *object* position inside a catalog (`<catalog> schema:dataset <dataset>`) rather than where the dataset is defined.
- Now we first look for a line starting with `<focusNode>` (subject position) and fall back to `indexOf` only if none exists. Literals and `sh:value` IRIs keep the old behavior.

## Test plan

- [ ] `/validate?url=https://www.goudatijdmachine.nl/.well-known/datacatalog` — click "Jump to line" on `Voeg een maker toe` → lands on the Dataset's own `<…> a schema:Dataset` line, not the `<catalog> schema:dataset <dataset>` row that appears earlier.
- [ ] Results whose `sh:value` is a literal still jump to the literal's line.
