### PR TITLE
fix(browser): avoid Cartesian product in dataset detail CONSTRUCT

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -458,6 +458,49 @@ export async function fetchDatasetDetail(
     sources: [PUBLIC_SPARQL_ENDPOINT],
   });
 
+  // Custom CONSTRUCT that sidesteps ldkit's auto-generated findByIri query.
+  // ldkit's default places every property under OPTIONAL in a single BGP, which
+  // Cartesian-products multi-valued properties (keyword, theme, spatial, etc.).
+  // On a dataset with 20 keywords × 13 spatial × 9 themes, that produced
+  // ~674k wire triples and a ~22s page load. Isolating each linked resource
+  // (dataset, publisher, creator, subjectOf, contentRating) into its own UNION
+  // branch keeps results proportional to the data (~200 triples, <1s).
+  const datasetQuery = `
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX dcat: <http://www.w3.org/ns/dcat#>
+    PREFIX schema: <https://schema.org/>
+    PREFIX ldkit: <https://ldkit.io/ontology/>
+
+    CONSTRUCT {
+      ?s ?p ?o .
+      <${datasetUri}> a ldkit:Resource .
+    }
+    WHERE {
+      GRAPH ?g {
+        {
+          <${datasetUri}> ?p ?o .
+          BIND(<${datasetUri}> AS ?s)
+        } UNION {
+          <${datasetUri}> dct:publisher ?publisher .
+          ?publisher ?p ?o .
+          BIND(?publisher AS ?s)
+        } UNION {
+          <${datasetUri}> dct:creator ?creator .
+          ?creator ?p ?o .
+          BIND(?creator AS ?s)
+        } UNION {
+          <${datasetUri}> schema:subjectOf ?subjectOf .
+          ?subjectOf ?p ?o .
+          BIND(?subjectOf AS ?s)
+        } UNION {
+          <${datasetUri}> schema:contentRating ?contentRating .
+          ?contentRating ?p ?o .
+          BIND(?contentRating AS ?s)
+        }
+      }
+    }
+  `;
+
   const distributionQuery = `
     PREFIX dcat: <http://www.w3.org/ns/dcat#>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -502,7 +545,7 @@ export async function fetchDatasetDetail(
   `;
 
   const [
-    dataset,
+    datasets,
     distributions,
     totalDistributions,
     summary,
@@ -510,7 +553,7 @@ export async function fetchDatasetDetail(
     classPartitionResult,
     temporalCoverages,
   ] = await Promise.all([
-    detailLens.findByIri(datasetUri),
+    detailLens.query(datasetQuery),
     distributionLens.query(distributionQuery),
     fetchDistributionCount(distributionCountQuery),
     summaryLens.findByIri(datasetUri).catch((e: unknown) => {
@@ -525,6 +568,7 @@ export async function fetchDatasetDetail(
     fetchTemporalCoverage(datasetUri),
   ]);
 
+  const dataset = datasets.find((d) => d.$id === datasetUri) ?? datasets[0];
   if (!dataset) {
     error(404, 'Dataset not found');
   }


### PR DESCRIPTION
## Summary

Some dataset detail pages took 22–32 s to load — notably `dataset_elo`, which has 20 keywords × 13 spatial × 9 themes. The cause was `detailLens.findByIri()` in `dataset-detail.ts`: ldkit’s generated CONSTRUCT places every property under `OPTIONAL` in one BGP, so multi-valued properties Cartesian-multiply. For `dataset_elo` that produced **~674,000 wire triples** (~5 s server + ~17 s client parse).

This PR replaces `findByIri` with a custom CONSTRUCT via `detailLens.query()` that isolates each linked resource (dataset, publisher, creator, subjectOf, contentRating) into its own `UNION` branch. Each branch binds `?s` independently, so multi-valued properties can’t cross-product — the same pattern already in use for `classPartition`.

## Measurements

Tested end-to-end against the production SPARQL endpoints on `dataset_elo`:

| | TTFB | Triples on wire |
| --- | ---: | ---: |
| Before (`findByIri`) | 21.83 s | ~674,000 |
| After (UNION CONSTRUCT) | 0.11 s (warm) | ~200 |

Page content verified byte-for-byte equivalent: same title, keyword counts, theme/spatial terms, distribution list.

Fix #1900
