### PR TITLE
feat(browser): look up labels for schema:about on dataset detail page

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -545,7 +545,11 @@ export async function fetchDatasetDetail(
       ? [(coverage as { iri: string }).iri].filter(isUri)
       : [],
   );
-  const termUris = [...(dataset.spatial?.filter(isUri) ?? []), ...temporalIris];
+  const termUris = [
+    ...(dataset.spatial?.filter(isUri) ?? []),
+    ...temporalIris,
+    ...(dataset.theme?.filter(isUri) ?? []),
+  ];
   const resolvedTerms =
     termUris.length > 0
       ? lookupTermLabels(termUris, getLocale())

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -944,8 +944,30 @@
                 </svg>
                 {m.detail_genres()}
               </dt>
-              <dd class="text-sm text-gray-700 dark:text-gray-300">
-                {localizedGenres.join(', ')}
+              <dd class="text-sm text-gray-700 dark:text-gray-300 break-all">
+                {#await data.resolvedTerms}
+                  {localizedGenres.join(', ')}
+                {:then resolvedTerms}
+                  {#each localizedGenres as genreValue, index (genreValue)}
+                    {#if index > 0},
+                    {/if}
+                    {#if resolvedTerms[genreValue]}
+                      <a
+                        href={genreValue}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-blue-600 hover:underline dark:text-blue-400"
+                      >
+                        {resolvedTerms[genreValue]}
+                        <span class="sr-only">
+                          ({m.opens_in_new_tab()})
+                        </span>
+                      </a>
+                    {:else}
+                      {genreValue}
+                    {/if}
+                  {/each}
+                {/await}
               </dd>
             </div>
           {/if}


### PR DESCRIPTION
## Summary

Datasets can describe what they’re about via `schema:about`, which the SPARQL CONSTRUCT layer (`packages/core/src/query.ts:270`) already rolls up into `dcat:theme`. On the dataset detail page those IRIs were rendered as raw URLs in the Genres row — e.g. `http://www.wikidata.org/entity/Q17319132` — instead of the Wikidata label a user can actually read.

This PR extends the existing Network of Terms lookup (already in use for `dct:spatial` and `dct:temporal` IRIs) to cover theme IRIs too, and mirrors the spatial-coverage rendering so resolved URIs become clickable links to the source with the human-readable label as the anchor text. Literals and unresolved URIs fall back to the raw value.

### Before

> **Genres** http://www.wikidata.org/entity/Q17319132

### After

> **Genres** [Pan Poeticon Batavum](http://www.wikidata.org/entity/Q17319132)

Fix #1897
