### PR TITLE
feat(shacl): redirect URIs in schema:keywords to schema:about

### DIFF
--- a/packages/core/test/datasets/dataset-schema-org-keyword-uri.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-keyword-uri.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/keyword-uri",
+  "name": "Dataset with an http(s) URI as a keyword",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "keywords": ["photographs", "http://vocab.getty.edu/aat/300046300"],
+  "about": { "@id": "http://vocab.getty.edu/aat/300046300" },
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://example.com/publisher",
+    "name": "Koninklijke Bibliotheek"
+  }
+}

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -379,6 +379,37 @@ describe('Validator', () => {
     }
   });
 
+  it('warns when schema:keywords contains an http(s) URI', async () => {
+    const report = (await validate(
+      'dataset-schema-org-keyword-uri.jsonld',
+    )) as Valid;
+    expect(report.state).toEqual('valid');
+    const keywordResults = [
+      ...report.errors.match(
+        null,
+        shacl('resultPath'),
+        rdf.namedNode('https://schema.org/keywords'),
+      ),
+    ].map((quad) => quad.subject);
+    expect(keywordResults).toHaveLength(1);
+    const [keywordResult] = keywordResults;
+    expect(
+      [...report.errors.match(keywordResult, shacl('resultSeverity'), null)][0]
+        ?.object.value,
+    ).toEqual('http://www.w3.org/ns/shacl#Warning');
+    const messages = [
+      ...report.errors.match(keywordResult, shacl('resultMessage'), null),
+    ]
+      .filter(
+        (quad) =>
+          quad.object.termType === 'Literal' && quad.object.language === 'en',
+      )
+      .map((quad) => quad.object.value);
+    expect(messages).toContain(
+      'Use schema:about for URIs describing the subject matter',
+    );
+  });
+
   it('validates PropertyValue identifier sub-constraints (propertyID, value, name)', async () => {
     // PropertyValue identifiers carry their own internal structure: propertyID
     // (must be IRI), value (must be xsd:string), name (must be string/langString

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -435,8 +435,19 @@ nde-dataset:DatasetShape
             sh:path schema:keywords ;
             sh:minCount 1 ;
             sh:severity sh:Info ;
-            sh:description "Woorden of geformaliseerde zinnen om een dataset te beschrijven."@nl, "Words or formalized phrases to describe the dataset."@en ;
+            sh:description """Woorden of geformaliseerde zinnen om een dataset te beschrijven. Trefwoorden zijn vrije tekst; gebruik `schema:about` voor URI’s die het onderwerp beschrijven."""@nl,
+                """Words or formalized phrases to describe the dataset. Keywords are free text; use `schema:about` for URIs describing the subject matter."""@en ;
             sh:message "Voeg trefwoorden toe"@nl, "Add keywords"@en ;
+        ] ,
+        [
+            sh:path schema:keywords ;
+            sh:not [ sh:pattern "^https?://" ] ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "Gebruik schema:about voor URI’s die het onderwerp beschrijven"@nl, "Use schema:about for URIs describing the subject matter"@en ;
         ] ,
         [
             sh:path schema:spatialCoverage ;


### PR DESCRIPTION
## Summary

Cross-references `schema:about` from `schema:keywords` for URI-valued subject terms, both in the existing keyword description and via a new SHACL warning that fires when a keyword value is an `http(s)` URI. The warning is scheduled to become a violation in v2.0 via `nde:futureChange`.

## Changes

- `requirements/shacl.ttl`: extend the default `schema:keywords` description to mention that URIs belong on `schema:about`; add a Warning-level property shape on `nde-dataset:DatasetShape` with `sh:not [ sh:pattern "^https?://" ]` and a `nde:futureChange` block promoting it to `sh:Violation` in v2.0.
- `packages/core/test/datasets/dataset-schema-org-keyword-uri.jsonld`: new fixture mixing a plain-text keyword with a URI keyword.
- `packages/core/test/validator.test.ts`: new test asserting one warning-level result on `schema:keywords` with the expected English message.
