### PR TITLE
feat(browser): make dataset detail link presentation consistent

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -197,6 +197,7 @@
   "lang_badge_unspecified": "Unspecified",
   "detail_is_part_of": "Part of",
   "detail_is_part_of_description": "The data catalog this dataset belongs to.",
+  "detail_browse_catalog": "Browse catalog",
   "license_cc0_1_0": "CC0 1.0 Universal",
   "license_cc_by_4_0": "CC BY 4.0 International",
   "license_cc_by_3_0": "CC BY 3.0 Unported",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -197,6 +197,7 @@
   "lang_badge_unspecified": "Niet gespecificeerd",
   "detail_is_part_of": "Onderdeel van",
   "detail_is_part_of_description": "De datacatalogus waar deze dataset bij hoort.",
+  "detail_browse_catalog": "Doorzoek catalogus",
   "license_cc0_1_0": "CC0 1.0 Universeel",
   "license_cc_by_4_0": "CC BY 4.0 Internationaal",
   "license_cc_by_3_0": "CC BY 3.0 Unported",

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -467,9 +467,10 @@
                 href={dataset.$id}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="break-all text-blue-600 hover:underline dark:text-blue-400"
+                class="inline-flex items-center gap-1 break-all text-blue-600 hover:underline dark:text-blue-400"
               >
                 {dataset.$id}
+                <ArrowUpRightFromSquareOutline class="h-3 w-3 shrink-0" />
                 <span class="sr-only"> ({m.opens_in_new_tab()})</span>
               </a>
               <Clipboard value={dataset.$id} class="p-0">
@@ -626,9 +627,10 @@
                       href={creator.$id}
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="text-blue-600 hover:underline dark:text-blue-400"
+                      class="inline-flex items-center gap-1 text-blue-600 hover:underline dark:text-blue-400"
                     >
                       {getLocalizedValue(creator.name)}
+                      <ArrowUpRightFromSquareOutline class="h-3 w-3 shrink-0" />
                       <span class="sr-only"> ({m.opens_in_new_tab()})</span>
                     </a>
                     <LanguageBadge values={creator.name} />
@@ -669,15 +671,27 @@
                   >{m.detail_is_part_of_description()}</Tooltip
                 >
               </dt>
-              <dd class="text-sm text-gray-700 dark:text-gray-300">
+              <dd
+                class="text-sm text-gray-700 dark:text-gray-300 flex flex-wrap items-center gap-2"
+              >
                 {#if dataset.isPartOf.startsWith('http://') || dataset.isPartOf.startsWith('https://')}
+                  <a
+                    href={dataset.isPartOf}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center gap-1 break-all text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {dataset.isPartOf}
+                    <ArrowUpRightFromSquareOutline class="h-3 w-3 shrink-0" />
+                    <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                  </a>
                   <a
                     href={`https://datasetregister.netwerkdigitaalerfgoed.nl/catalog.php?lang=${getLocale()}&uri=${encodeURIComponent(dataset.isPartOf)}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="text-blue-600 hover:underline dark:text-blue-400"
+                    class="inline-flex items-center gap-1 rounded-full border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
                   >
-                    {dataset.isPartOf}
+                    {m.detail_browse_catalog()}
                     <span class="sr-only"> ({m.opens_in_new_tab()})</span>
                   </a>
                 {:else}
@@ -744,10 +758,11 @@
                   href={dataset.license}
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="text-blue-600 hover:underline dark:text-blue-400"
+                  class="inline-flex items-center gap-1 text-blue-600 hover:underline dark:text-blue-400"
                   title={dataset.license}
                 >
                   {getLicenseName(dataset.license)}
+                  <ArrowUpRightFromSquareOutline class="h-3 w-3 shrink-0" />
                   <span class="sr-only"> ({m.opens_in_new_tab()})</span>
                 </a>
               </dd>
@@ -797,9 +812,12 @@
                         href={spatialValue}
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="text-blue-600 hover:underline dark:text-blue-400"
+                        class="inline-flex items-center gap-1 text-blue-600 hover:underline dark:text-blue-400"
                       >
                         {resolvedTerms[spatialValue]}
+                        <ArrowUpRightFromSquareOutline
+                          class="h-3 w-3 shrink-0"
+                        />
                         <span class="sr-only">
                           ({m.opens_in_new_tab()})
                         </span>
@@ -862,9 +880,12 @@
                             href={coverage.iri}
                             target="_blank"
                             rel="noopener noreferrer"
-                            class="text-blue-600 hover:underline dark:text-blue-400"
+                            class="inline-flex items-center gap-1 text-blue-600 hover:underline dark:text-blue-400"
                           >
                             {resolvedTerms[coverage.iri]}
+                            <ArrowUpRightFromSquareOutline
+                              class="h-3 w-3 shrink-0"
+                            />
                             <span class="sr-only">
                               ({m.opens_in_new_tab()})
                             </span>
@@ -956,9 +977,12 @@
                         href={genreValue}
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="text-blue-600 hover:underline dark:text-blue-400"
+                        class="inline-flex items-center gap-1 text-blue-600 hover:underline dark:text-blue-400"
                       >
                         {resolvedTerms[genreValue]}
+                        <ArrowUpRightFromSquareOutline
+                          class="h-3 w-3 shrink-0"
+                        />
                         <span class="sr-only">
                           ({m.opens_in_new_tab()})
                         </span>


### PR DESCRIPTION
## Summary

Per #1904, link presentation on the dataset detail page was inconsistent: the landing-page row had the external-arrow icon but identical external links elsewhere (URI, creator, license, spatial coverage, genres) did not, while ‘Part of’ was a single link that visibly pointed to the source catalog’s URI but actually redirected to an internal catalog listing.

This PR makes the rendering uniform:

- **External icon everywhere an external link appears.** The same `ArrowUpRightFromSquareOutline` used for the landing page is now appended inline to the URI, creator, license, spatial coverage, temporal coverage, and genres links. Internal filter links (publisher, keywords) stay unadorned so the two affordances are visually distinct.
- **‘Part of’ row split.** The row now shows the actual `dct:isPartOf` source URI as an external link (with icon), and a separate ‘Browse catalog’ / ‘Doorzoek catalogus’ pill button that opens the catalog listing (still the legacy PHP catalog page, per the issue’s note that it will be transferred to the dataset browser later). Previously the single link was a ‘disguised’ internal redirect that hid the source URI behind it.

Fix #1904

### Before

Landing page had the external-arrow icon; URI / creator / license / spatial / genres did not. ‘Part of’ showed the source URI but linked to `catalog.php`.

### After

All external links end with the same arrow icon. ‘Part of’ has an external link to the source plus a separate ‘Browse catalog’ button.
