### PR TITLE
refactor(browser): rename Genres label to About on dataset detail page

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -176,7 +176,7 @@
   "detail_terminology_sources_description": "Terminology sources used by objects in the dataset.",
   "detail_object_types_help": "Information about object types",
   "detail_object_types_description": "Shows the distribution between literal values and URI references in the dataset's object positions.",
-  "detail_genres": "Genres",
+  "detail_about": "About",
   "detail_linked_data_summary_description": "Statistical information about this dataset retrieved from the Knowledge Graph, including the number of triples, entities, properties, and class distribution.",
   "detail_registered_url": "Registered URL",
   "detail_registered_url_description": "URL where the dataset is described.",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -176,7 +176,7 @@
   "detail_terminology_sources_description": "Terminologiebronnen die door objecten in de dataset worden gebruikt.",
   "detail_object_types_help": "Informatie over objecttypen",
   "detail_object_types_description": "Toont de verdeling tussen literale waarden en URI-verwijzingen in de objectposities van de dataset.",
-  "detail_genres": "Genres",
+  "detail_about": "Onderwerp",
   "detail_linked_data_summary_description": "Statistische informatie over deze dataset opgehaald uit de Dataset Knowledge Graph, inclusief het aantal feiten, entiteiten, eigenschappen en typeverdeling.",
   "detail_registered_url": "Geregistreerde URL",
   "detail_registered_url_description": "URL waar de dataset wordt beschreven.",

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -167,13 +167,13 @@
     return downloadDistributions[0];
   });
 
-  // Extract keywords and genres for current locale. dcat:theme is the canonical
-  // target for subject/material classification; dct:type is kept for datasets
-  // registered before the schema:about → dcat:theme transition.
+  // Extract keywords and subject matter for current locale. dcat:theme is the
+  // canonical target for subject/material classification; dct:type is kept for
+  // datasets registered before the schema:about → dcat:theme transition.
   const EDUC_DEFAULT_THEME =
     'http://publications.europa.eu/resource/authority/data-theme/EDUC';
   const localizedKeywords = $derived(getLocalizedArray(dataset.keyword));
-  const localizedGenres = $derived([
+  const localizedAbout = $derived([
     ...(dataset.theme?.filter((value) => value !== EDUC_DEFAULT_THEME) ?? []),
     ...getLocalizedArray(dataset.type),
   ]);
@@ -426,7 +426,7 @@
   </div>
 
   <!-- Dataset Details Section (compact) -->
-  {#if localizedKeywords.length > 0 || dataset.publisher?.name || dataset.license || (dataset.spatial && dataset.spatial.length > 0) || temporalCoverages.length > 0 || localizedGenres.length > 0 || (dataset.language && dataset.language.length > 0)}
+  {#if localizedKeywords.length > 0 || dataset.publisher?.name || dataset.license || (dataset.spatial && dataset.spatial.length > 0) || temporalCoverages.length > 0 || localizedAbout.length > 0 || (dataset.language && dataset.language.length > 0)}
     <div class="mb-8">
       <div
         class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
@@ -921,8 +921,8 @@
             </div>
           {/if}
 
-          <!-- Genre -->
-          {#if localizedGenres.length > 0}
+          <!-- About -->
+          {#if localizedAbout.length > 0}
             <div
               class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
             >
@@ -942,29 +942,29 @@
                     d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"
                   />
                 </svg>
-                {m.detail_genres()}
+                {m.detail_about()}
               </dt>
               <dd class="text-sm text-gray-700 dark:text-gray-300 break-all">
                 {#await data.resolvedTerms}
-                  {localizedGenres.join(', ')}
+                  {localizedAbout.join(', ')}
                 {:then resolvedTerms}
-                  {#each localizedGenres as genreValue, index (genreValue)}
+                  {#each localizedAbout as aboutValue, index (aboutValue)}
                     {#if index > 0},
                     {/if}
-                    {#if resolvedTerms[genreValue]}
+                    {#if resolvedTerms[aboutValue]}
                       <a
-                        href={genreValue}
+                        href={aboutValue}
                         target="_blank"
                         rel="noopener noreferrer"
                         class="text-blue-600 hover:underline dark:text-blue-400"
                       >
-                        {resolvedTerms[genreValue]}
+                        {resolvedTerms[aboutValue]}
                         <span class="sr-only">
                           ({m.opens_in_new_tab()})
                         </span>
                       </a>
                     {:else}
-                      {genreValue}
+                      {aboutValue}
                     {/if}
                   {/each}
                 {/await}


### PR DESCRIPTION
Renames the UI label on the dataset detail page from “Genres” to “About”, following the shift from `schema:genre` to `schema:about` as the canonical source for `dcat:theme` (see #1858).

## Changes

- `apps/browser/messages/en.json`, `nl.json`: rename message key `detail_genres` → `detail_about`. EN reads “About”; NL reads “Onderwerp”.
- `apps/browser/src/routes/datasets/[...uri]/+page.svelte`: rename `localizedGenres` → `localizedAbout` and `genreValue` → `aboutValue`; swap `m.detail_genres()` for `m.detail_about()`; update section comment.

## Backwards compatibility

The derivation still reads both `dcat:theme` (canonical, projected from `schema:about`) and `dct:type` (the previous projection target for `schema:genre`), so datasets registered before the `schema:about` → `dcat:theme` transition keep rendering in this section.
