### PR TITLE
fix(browser): render backticks in SHACL descriptions as inline code

### DIFF
--- a/apps/browser/src/lib/components/validation/ResultRow.svelte
+++ b/apps/browser/src/lib/components/validation/ResultRow.svelte
@@ -37,6 +37,12 @@
       ? selectShape(shapes, result.path, focusType, result.sourceShape)
       : undefined,
   );
+  const descriptionHtml = $derived(
+    shapeMeta?.description?.replace(
+      /`([^`]+)`/g,
+      '<code class="font-mono">$1</code>',
+    ),
+  );
   const tone = $derived(
     result.severity === 'Violation'
       ? 'red'
@@ -126,10 +132,10 @@
           {#if result.path}
             <code class="font-mono text-xs">{shortenUri(result.path)}</code>
           {/if}
-          {#if shapeMeta?.description}
+          {#if descriptionHtml}
             {#if result.path}<span class="mx-1">·</span>{/if}
             <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-            {@html shapeMeta.description}
+            {@html descriptionHtml}
           {/if}
         </p>
       {/if}


### PR DESCRIPTION
## Summary

SHACL shape descriptions use backticks to mark inline code, e.g. `` `schema:about` ``. The browser renders them as plain text, so the backticks leak into the UI. Convert the backtick-delimited spans to `<code>` elements before passing the description to `{@html}`.

## Changes

- `apps/browser/src/lib/components/validation/ResultRow.svelte`: derive a `descriptionHtml` that wraps `` `…` `` with `<code class="font-mono">…</code>` and render that instead of the raw description.
