### PR TITLE
feat(shacl): downgrade missing organisation identifier to sh:Info

### DIFF
--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -230,22 +230,22 @@ describe('Validator', () => {
     expect(contactPointResult).toBeDefined();
     expect(identifierResult).toBeDefined();
 
-    for (const [result, expectedMessage] of [
+    for (const [result, expectedSeverity, expectedMessage] of [
       [
         contactPointResult,
+        'http://www.w3.org/ns/shacl#Warning',
         'Add a contact point with a name and email address, preferably of the department that manages the dataset or catalogue',
       ],
       [
         identifierResult,
+        'http://www.w3.org/ns/shacl#Info',
         'Add an identifier for the organisation, such as a Chamber of Commerce number or ISIL',
       ],
     ] as const) {
       expect(literal(result, shacl('focusNode'))).toEqual(
         'https://www.goudatijdmachine.nl/omeka/api/items/232',
       );
-      expect(literal(result, shacl('resultSeverity'))).toEqual(
-        'http://www.w3.org/ns/shacl#Warning',
-      );
+      expect(literal(result, shacl('resultSeverity'))).toEqual(expectedSeverity);
       expect(literal(result, shacl('sourceConstraintComponent'))).toEqual(
         'http://www.w3.org/ns/shacl#SPARQLConstraintComponent',
       );
@@ -261,8 +261,9 @@ describe('Validator', () => {
   });
 
   it('SPARQL-constrained Organization checks skip Person publishers/creators', async () => {
-    // Persons must pass v2.0 validation: contactPoint and identifier are promoted
-    // from Warning to Violation, and Person instances legitimately lack both.
+    // Person instances legitimately lack contactPoint and identifier, so the
+    // Organization-targeted SPARQL shapes must not fire against them — including
+    // when contactPoint is promoted to Violation at v2.0.
     const report = (await validate(
       'dataset-dcat-valid-minimal.jsonld',
     )) as Valid;
@@ -280,10 +281,10 @@ describe('Validator', () => {
     expect(report.state).toEqual('valid');
     expect(formatReport(report)).toMatchInlineSnapshot(`
       "[Info] https://schema.org/about on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: Add a URI describing the dataset’s subject matter or material type (for example from the Network of Terms)
+      [Info] https://schema.org/identifier on <https://www.goudatijdmachine.nl/omeka/api/items/232>: Add an identifier for the organisation, such as a Chamber of Commerce number or ISIL
       [Warning] https://schema.org/contactPoint on <https://www.goudatijdmachine.nl/omeka/api/items/232>: Add a contact point with a name and email address, preferably of the department that manages the dataset or catalogue
       [Warning] https://schema.org/encodingFormat on <https://www.goudatijdmachine.nl/omeka/api/items/3030722>: Remove the SPARQL MIME type from schema:encodingFormat; SPARQL endpoints are declared via schema:usageInfo
       [Warning] https://schema.org/genre on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: schema:genre is deprecated; use schema:about with a URI (for example from the Network of Terms)
-      [Warning] https://schema.org/identifier on <https://www.goudatijdmachine.nl/omeka/api/items/232>: Add an identifier for the organisation, such as a Chamber of Commerce number or ISIL
       [Warning] https://schema.org/license on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: Use https:// (not http://) in the Creative Commons license URL
       [Warning] https://schema.org/license on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: Use one of the Creative Commons licenses, such as https://creativecommons.org/publicdomain/zero/1.0/ (CC0) or https://creativecommons.org/licenses/by/4.0/ (CC BY 4.0)
       [Warning] https://schema.org/temporalCoverage on <https://www.goudatijdmachine.nl/omeka/api/items/3030723>: Use an ISO 8601 date or time interval (such as ‘2011/2012’, ‘-0431/-0404’ for BCE, or ‘1440/..’) or a web URI

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -245,7 +245,9 @@ describe('Validator', () => {
       expect(literal(result, shacl('focusNode'))).toEqual(
         'https://www.goudatijdmachine.nl/omeka/api/items/232',
       );
-      expect(literal(result, shacl('resultSeverity'))).toEqual(expectedSeverity);
+      expect(literal(result, shacl('resultSeverity'))).toEqual(
+        expectedSeverity,
+      );
       expect(literal(result, shacl('sourceConstraintComponent'))).toEqual(
         'http://www.w3.org/ns/shacl#SPARQLConstraintComponent',
       );

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -934,7 +934,7 @@ nde-dataset:OrganizationContactPointRequiredShape
 nde-dataset:OrganizationIdentifierRequiredShape
     a sh:NodeShape ;
     sh:targetObjectsOf schema:publisher, schema:creator ;
-    sh:severity sh:Warning ;
+    sh:severity sh:Info ;
     sh:message "Voeg een identificatie toe voor de organisatie, zoals een KvK-nummer of ISIL"@nl, "Add an identifier for the organisation, such as a Chamber of Commerce number or ISIL"@en ;
     sh:sparql [
         sh:select """


### PR DESCRIPTION
Downgrades the “missing organisation `schema:identifier`” check on `nde-dataset:OrganizationIdentifierRequiredShape` from `sh:Warning` to `sh:Info`, making it a suggestion rather than a warning in validation reports.

## Why

This aligns the SHACL with the prose in `requirements/index.bs.liquid`:

> Publishers *SHOULD* include the organization's [ISIL code](https://www.nationaalarchief.nl/archiveren/kennisbank/isil-codes).

Per the severity table in `requirements/README.md`, `SHOULD` → `sh:Info`. The previous `sh:Warning` was stricter than the written requirement.

## Changes

- `requirements/shacl.ttl`: `OrganizationIdentifierRequiredShape` now uses `sh:Info`.
- `packages/core/test/validator.test.ts`:
  - Split the severity assertion in the “SPARQL-constrained Organization checks produce fully structured results” test so `contactPoint` stays `sh:Warning` and `identifier` is `sh:Info`.
  - Refresh the Gouda Tijdmachine inline snapshot: the `schema:identifier` line is now `[Info]` and sorts with the other Info results.
  - Correct the stale comment on the Person-skip test — only `contactPoint` is promoted to `sh:Violation` at v2.0, `identifier` is not.
