### PR TITLE
fix(shacl): use HTML anchors for links in sh:description

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -467,7 +467,7 @@ nde-dataset:DatasetShape
                 nde:version "2.0" ;
                 sh:severity sh:Violation ;
             ] ;
-            sh:description "Spatial coverage must be an HTTP(S) URI, such as from [GeoNames](https://www.geonames.org/)."@en ;
+            sh:description "Spatial coverage must be an HTTP(S) URI, such as from <a href=\"https://www.geonames.org/\">GeoNames</a>."@en ;
             sh:message "Gebruik een waarde van type URI (RDF-resource), geen tekst"@nl, "Use a value of type URI (RDF resource), not text"@en ;
         ] ,
         [
@@ -1414,7 +1414,7 @@ dcat:DatasetShape
             sh:nodeKind sh:IRI ;
             sh:pattern "^http://publications\\.europa\\.eu/resource/authority/language/" ;
         ] ;
-        sh:description "De natuurlijke taal van de tekstuele waarden in de dataset. Gebruik een waarde uit de [EU Vocabularies Languages Named Authority List](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/language)."@nl, "The natural language of the textual values in the dataset. Use a value from the [EU Vocabularies Languages Named Authority List](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/language)."@en ;
+        sh:description "De natuurlijke taal van de tekstuele waarden in de dataset. Gebruik een waarde uit de <a href=\"https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/language\">EU Vocabularies Languages Named Authority List</a>."@nl, "The natural language of the textual values in the dataset. Use a value from the <a href=\"https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/language\">EU Vocabularies Languages Named Authority List</a>."@en ;
         sh:message "Vul de taal of talen in"@nl, "Enter the language or languages of the dataset"@en ;
     ],
     [
@@ -1615,7 +1615,7 @@ dcat:DistributionShape
             sh:nodeKind sh:IRI ;
             sh:pattern "^http://publications\\.europa\\.eu/resource/authority/language/" ;
         ] ;
-        sh:description "De natuurlijke taal van de tekstuele waarden in de distributie. Gebruik een waarde uit de [EU Vocabularies Languages Named Authority List](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/language)."@nl, "The natural language of the textual values in the distribution. Use a value from the [EU Vocabularies Languages Named Authority List](https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/language)."@en ;
+        sh:description "De natuurlijke taal van de tekstuele waarden in de distributie. Gebruik een waarde uit de <a href=\"https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/language\">EU Vocabularies Languages Named Authority List</a>."@nl, "The natural language of the textual values in the distribution. Use a value from the <a href=\"https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/language\">EU Vocabularies Languages Named Authority List</a>."@en ;
         sh:message "Vul de taal of talen in waarin de distributie beschikbaar is"@nl, "Enter the language or languages of the distribution"@en ;
     ] .
 


### PR DESCRIPTION
Converts the three `sh:description` values that used Markdown `[text](url)` links to HTML `<a href="url">text</a>`, aligning them with the existing HTML `<a>` link in `OrganizationIdentifierRequiredShape`.

## Why

`sh:description` is consumed by two surfaces:

- the browser UI, which renders via `{@html}` in `ResultRow.svelte` — this pipeline passes HTML through unchanged but shows Markdown as literal text (screenshot context: `[GeoNames](…)` visible as raw brackets);
- the Bikeshed spec, which is generated from `shacl.ttl` via `@lde/docgen from-shacl` — `Markdown yes` is enabled but inline HTML is also permitted.

HTML is the only form that renders correctly in both, and it matches what the identifier description already does.

## Changes

- `schema:spatialCoverage` description: `[GeoNames](…)` → `<a href="…">GeoNames</a>`.
- `schema:inLanguage` description on Dataset: `[EU Vocabularies Languages NAL](…)` → `<a href="…">…</a>` (both `@nl` and `@en`).
- `schema:inLanguage` description on Distribution: same conversion.
