### PR TITLE
fix(browser): align validate summary counts with report rows

### DIFF
--- a/apps/browser/src/lib/components/validation/ValidationReport.svelte
+++ b/apps/browser/src/lib/components/validation/ValidationReport.svelte
@@ -2,7 +2,11 @@
   import { Accordion, AccordionItem } from 'flowbite-svelte';
   import SeverityBadge from './SeverityBadge.svelte';
   import * as m from '$lib/paraglide/messages';
-  import type { ShaclReport, ShaclResult } from '$lib/services/shacl-report.js';
+  import {
+    resultGroupKey,
+    type ShaclReport,
+    type ShaclResult,
+  } from '$lib/services/shacl-report.js';
   import { fetchShapes, type ShapesIndex } from '$lib/services/shacl-shapes.js';
   import ResultRow from './ResultRow.svelte';
   import { buildFocusNodeTypes } from './focus-node-types.js';
@@ -49,22 +53,10 @@
     });
   });
 
-  // Fold repeats of the same (path, message, constraint) across focus nodes —
-  // common when validating a catalog where N datasets share a flaw — and sort
-  // stably so the UI doesn’t shuffle between validations.
-  function groupKey(result: ShaclResult): string {
-    return [
-      result.severity,
-      result.path ?? '',
-      result.sourceConstraintComponent ?? '',
-      result.message,
-    ].join('\u0001');
-  }
-
   const grouped = $derived.by(() => {
     const buckets = new Map<string, ShaclResult[]>();
     for (const result of report.results) {
-      const key = groupKey(result);
+      const key = resultGroupKey(result);
       const list = buckets.get(key);
       if (list) list.push(result);
       else buckets.set(key, [result]);

--- a/apps/browser/src/lib/components/validation/ValidationSummary.svelte
+++ b/apps/browser/src/lib/components/validation/ValidationSummary.svelte
@@ -5,7 +5,10 @@
   import InfoCircleSolid from 'flowbite-svelte-icons/InfoCircleSolid.svelte';
   import SeverityBadge from './SeverityBadge.svelte';
   import * as m from '$lib/paraglide/messages';
-  import type { ShaclReport } from '$lib/services/shacl-report.js';
+  import {
+    resultGroupKey,
+    type ShaclReport,
+  } from '$lib/services/shacl-report.js';
   import type { ApiErrorDetails } from '$lib/services/validation.js';
 
   interface Props {
@@ -27,12 +30,11 @@
     if (state.kind !== 'report') {
       return { violations: 0, warnings: 0, infos: 0 };
     }
-    // Count unique messages per severity. Multiple focus nodes failing the
-    // same check collapse into one — the user wants to see the number of
-    // distinct problems to fix, not one row per affected node.
+    // Count distinct (severity, path, constraint, message) groups – the same
+    // grouping as ValidationReport so the summary badges match the row counts.
     const seen = new Map<string, 'Violation' | 'Warning' | 'Info'>();
     for (const result of state.report.results) {
-      const key = `${result.severity}\u0001${result.message}`;
+      const key = resultGroupKey(result);
       if (!seen.has(key)) seen.set(key, result.severity);
     }
     let violations = 0;

--- a/apps/browser/src/lib/services/shacl-report.test.ts
+++ b/apps/browser/src/lib/services/shacl-report.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseShaclReport } from './shacl-report.js';
+import { parseShaclReport, resultGroupKey } from './shacl-report.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeResult(partial: Record<string, any>) {
@@ -149,5 +149,32 @@ describe('parseShaclReport', () => {
       conforms: true,
       results: [],
     });
+  });
+});
+
+describe('resultGroupKey', () => {
+  it('distinguishes results with the same message but different paths', () => {
+    const a = {
+      severity: 'Warning' as const,
+      path: 'https://schema.org/name',
+      sourceConstraintComponent:
+        'http://www.w3.org/ns/shacl#MinCountConstraintComponent',
+      message: 'Add a value',
+    };
+    const b = { ...a, path: 'https://schema.org/description' };
+    expect(resultGroupKey(a)).not.toBe(resultGroupKey(b));
+  });
+
+  it('collapses repeats of the same constraint across focus nodes', () => {
+    const base = {
+      severity: 'Warning' as const,
+      path: 'https://schema.org/name',
+      sourceConstraintComponent:
+        'http://www.w3.org/ns/shacl#MinCountConstraintComponent',
+      message: 'Add a value',
+    };
+    expect(resultGroupKey({ ...base, focusNode: 'x' })).toBe(
+      resultGroupKey({ ...base, focusNode: 'y' }),
+    );
   });
 });

--- a/apps/browser/src/lib/services/shacl-report.ts
+++ b/apps/browser/src/lib/services/shacl-report.ts
@@ -34,6 +34,15 @@ export interface ShaclReport {
   results: ShaclResult[];
 }
 
+export function resultGroupKey(result: ShaclResult): string {
+  return [
+    result.severity,
+    result.path ?? '',
+    result.sourceConstraintComponent ?? '',
+    result.message,
+  ].join(String.fromCharCode(1));
+}
+
 type JsonLdNode = Record<string, unknown> & {
   '@id'?: string;
   '@type'?: string[];


### PR DESCRIPTION
Fix #1912.

## Summary

On the validate page, the warning/info badge counts in the summary did not match the number of rows rendered below.

The two components used different group keys when collapsing duplicate results:

- `ValidationSummary.svelte` grouped by `severity + message`
- `ValidationReport.svelte` grouped by `severity + path + sourceConstraintComponent + message`

So a check that fired with the same message against two different `sh:path` values (e.g. `schema:name` and `schema:description`) would collapse into a single badge in the summary but appear as two rows below.

## Changes

- Extract a shared `resultGroupKey` helper in `shacl-report.ts`.
- `ValidationSummary.svelte` and `ValidationReport.svelte` both use it, so the counts can’t drift apart again.
- Add regression tests for `resultGroupKey`.
