### PR TITLE
fix(spec): render maxCount 0 and ‘becomes forbidden’ in attribute tables

### DIFF
--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -63,7 +63,9 @@
                 {%- endif -%}
             </td>
             <td>
-                {% if property.minCount -%}
+                {% if property.maxCount == 0 -%}
+                    0
+                {% elsif property.minCount -%}
                     {% if property.minCount == property.maxCount -%}
                         {{ property.minCount }}
                     {% else -%}
@@ -73,7 +75,9 @@
             </td>
             <td>
                 {% assign is_required = false -%}
-                {% if property.minCount > 0 -%}
+                {% if property.maxCount == 0 -%}
+                    Discouraged
+                {% elsif property.minCount > 0 -%}
                     {% assign severity = property.severity | default: "Violation" -%}
                     {% if severity == "Violation" or property.severity == "Warning" -%}
                         Required
@@ -95,6 +99,8 @@
                         {% assign future_text = "must be IRI" -%}
                     {% elsif change.maxCount -%}
                         {% assign future_text = change.maxCount | prepend: "max " -%}
+                    {% elsif change.severity == "Violation" and property.maxCount == 0 -%}
+                        {% assign future_text = "becomes forbidden" -%}
                     {% elsif change.severity == "Violation" and property.nodeKind == "IRI" -%}
                         {% assign future_text = "must be IRI" -%}
                     {% elsif change.severity == "Violation" and property.datatype -%}

--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -100,7 +100,7 @@
                     {% elsif change.maxCount -%}
                         {% assign future_text = change.maxCount | prepend: "max " -%}
                     {% elsif change.severity == "Violation" and property.maxCount == 0 -%}
-                        {% assign future_text = "becomes forbidden" -%}
+                        {% assign future_text = "no longer allowed" -%}
                     {% elsif change.severity == "Violation" and property.nodeKind == "IRI" -%}
                         {% assign future_text = "must be IRI" -%}
                     {% elsif change.severity == "Violation" and property.datatype -%}


### PR DESCRIPTION
## Summary
- Render cardinality `0` for properties with `sh:maxCount 0` instead of leaving the cell empty.
- Label such properties as `Discouraged` in the Usage column instead of the misleading `Recommended`.
- When a `sh:maxCount 0` property has an `nde:futureChange` that escalates severity to `sh:Violation`, render the future change as `becomes forbidden` instead of `becomes required`.

Currently only `schema:genre` has this shape; it is deprecated and becomes a v2.0 violation, so the old rendering claimed a deprecated property was about to become required.

## Test plan
- [x] `make spec` in `requirements/` renders `schema:genre` as `Discouraged` with `v2.0: becomes forbidden` and cardinality `0`.