### PR TITLE
ci(requirements): fail build when rendered spec contains '[object Object]'

### DIFF
--- a/.github/workflows/requirements-publish.yml
+++ b/.github/workflows/requirements-publish.yml
@@ -28,6 +28,13 @@ jobs:
           cache: 'npm'
       - run: npx --yes @lde/docgen@latest from-shacl -f shacl.frame.jsonld shacl.ttl index.bs.liquid > index.bs
 
+      - name: Verify no '[object Object]' in rendered output
+        run: |
+          if grep -nF '[object Object]' index.bs; then
+            echo "::error::index.bs contains '[object Object]' — Liquid template stringified an object."
+            exit 1
+          fi
+
       - name: Build and validate
         uses: w3c/spec-prod@v2
         with:
@@ -72,6 +79,6 @@ jobs:
         uses: grafana/github-api-commit-action@v1
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          commit-message: "deploy: ${{ github.repository }}@${{ github.sha }}"
+          commit-message: 'deploy: ${{ github.repository }}@${{ github.sha }}'
           stage-all-files: true
           success-if-no-changes: true

--- a/requirements/Makefile
+++ b/requirements/Makefile
@@ -5,8 +5,16 @@ help:
 
 spec:
 	npx --yes @lde/docgen@latest from-shacl -f shacl.frame.jsonld shacl.ttl index.bs.liquid > index.bs
+	$(MAKE) check
 	docker run -v "`pwd`:/spec" -w /spec netwerkdigitaalerfgoed/bikeshed:latest
 
 watch:
 	npx --yes @lde/docgen@latest from-shacl -f shacl.frame.jsonld shacl.ttl index.bs.liquid > index.bs
+	$(MAKE) check
 	docker run -v "`pwd`:/spec" -w /spec netwerkdigitaalerfgoed/bikeshed:latest sh -c "bikeshed watch"
+
+check:
+	@if grep -nF '[object Object]' index.bs; then \
+		echo "ERROR: index.bs contains '[object Object]' — Liquid template stringified an object."; \
+		exit 1; \
+	fi


### PR DESCRIPTION
Guard against the rendered requirements spec ever containing the literal string `[object Object]`, which appears when a Liquid template stringifies an object (e.g. when `nde:version` comes back as `{"@value": "2.0"}` instead of a plain string).

The current `@lde/docgen@latest` (0.6.16) renders correctly, but the guard catches future regressions in either docgen or our SHACL/Liquid templates.

## Changes

- `requirements/Makefile`: new `check` target that greps the rendered `index.bs` for `[object Object]` and exits 1 on any hit. Chained from both `spec` and `watch`.
- `.github/workflows/requirements-publish.yml`: same grep runs in CI right after docgen, before the bikeshed/spec-prod step, so a regression blocks the publish PR.
