### PR TITLE
fix(browser): show extras count when focus nodes are blank

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -311,6 +311,7 @@
     }
   ],
   "validate_report_hide_extras": "Hide other items",
+  "validate_report_unnamed_item": "unnamed item",
   "severity_Violation": "Violation",
   "severity_Warning": "Warning",
   "severity_Info": "Suggestion"

--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -311,7 +311,7 @@
     }
   ],
   "validate_report_hide_extras": "Hide other items",
-  "validate_report_unnamed_item": "unnamed item",
+  "validate_report_blank_node": "blank node",
   "severity_Violation": "Violation",
   "severity_Warning": "Warning",
   "severity_Info": "Suggestion"

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -311,6 +311,7 @@
     }
   ],
   "validate_report_hide_extras": "Verberg andere items",
+  "validate_report_unnamed_item": "naamloos item",
   "severity_Violation": "Fout",
   "severity_Warning": "Waarschuwing",
   "severity_Info": "Suggestie"

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -311,7 +311,7 @@
     }
   ],
   "validate_report_hide_extras": "Verberg andere items",
-  "validate_report_unnamed_item": "naamloos item",
+  "validate_report_blank_node": "blank node",
   "severity_Violation": "Fout",
   "severity_Warning": "Waarschuwing",
   "severity_Info": "Suggestie"

--- a/apps/browser/src/lib/components/validation/ResultRow.svelte
+++ b/apps/browser/src/lib/components/validation/ResultRow.svelte
@@ -235,7 +235,7 @@
                   <code class="font-mono break-all">{display}</code>
                 {:else}
                   <span class="text-gray-500 italic dark:text-gray-400">
-                    {m.validate_report_unnamed_item()}
+                    {m.validate_report_blank_node()}
                   </span>
                 {/if}
               </li>

--- a/apps/browser/src/lib/components/validation/ResultRow.svelte
+++ b/apps/browser/src/lib/components/validation/ResultRow.svelte
@@ -104,6 +104,19 @@
       ? shortenUri(result.focusNode)
       : null,
   );
+  const showFocusBlock = $derived(
+    focusNodeDisplay !== null || extras.length > 0,
+  );
+
+  function extraDisplay(extra: ShaclResult): string | null {
+    if (extra.focusNode && !extra.focusNodeIsBlank) {
+      return shortenUri(extra.focusNode);
+    }
+    if (extra.value && extra.valueIsIri && !extra.value.startsWith('_:')) {
+      return shortenUri(extra.value);
+    }
+    return null;
+  }
 
   function lineFor(value: string): number | null {
     if (!sourceText) return null;
@@ -192,15 +205,19 @@
       </dd>
     {/if}
 
-    {#if focusNodeDisplay}
+    {#if showFocusBlock}
       <dt class="font-medium">{m.validate_report_focus_node()}</dt>
       <dd>
-        <code class="font-mono break-all">{focusNodeDisplay}</code>
+        {#if focusNodeDisplay}
+          <code class="font-mono break-all">{focusNodeDisplay}</code>
+        {/if}
         {#if extras.length > 0}
           <button
             type="button"
             onclick={() => (showAllFocusNodes = !showAllFocusNodes)}
-            class="ml-2 text-blue-700 underline hover:no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:text-blue-400 cursor-pointer"
+            class="text-blue-700 underline hover:no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:text-blue-400 cursor-pointer {focusNodeDisplay
+              ? 'ml-2'
+              : ''}"
           >
             {#if showAllFocusNodes}
               {m.validate_report_hide_extras()}
@@ -212,13 +229,16 @@
         {#if extras.length > 0 && showAllFocusNodes}
           <ul class="mt-1 space-y-0.5">
             {#each extras as extra, index (index)}
-              {#if extra.focusNode && !extra.focusNodeIsBlank}
-                <li>
-                  <code class="font-mono break-all">
-                    {shortenUri(extra.focusNode)}
-                  </code>
-                </li>
-              {/if}
+              {@const display = extraDisplay(extra)}
+              <li>
+                {#if display}
+                  <code class="font-mono break-all">{display}</code>
+                {:else}
+                  <span class="text-gray-500 italic dark:text-gray-400">
+                    {m.validate_report_unnamed_item()}
+                  </span>
+                {/if}
+              </li>
             {/each}
           </ul>
         {/if}

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 95.13,
+        lines: 95.16,
         functions: 92.8,
         branches: 83.42,
-        statements: 94.46,
+        statements: 94.49,
       },
     },
   },

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -785,9 +785,8 @@ dcat:DistributionSparqlMediaTypeRequiresProtocolShape
 nde-dataset:AgentShape
     a sh:NodeShape ;
     sh:targetObjectsOf schema:publisher, schema:creator ;
-    sh:message "Gebruik een web-URI die begint met http:// of https://"@nl, "Use a web URI starting with http:// or https://"@en ;
     sh:nodeKind sh:IRI ;
-    sh:pattern "^https?://" ;
+    sh:message "Gebruik een waarde van type URI (RDF-resource), geen tekst"@nl, "Use a value of type URI (RDF resource), not text"@en ;
     sh:property
         [
             sh:path schema:name ;
@@ -860,6 +859,12 @@ nde-dataset:AgentShape
             sh:description "Contactinformatie waar eindgebruikers terecht kunnen met vragen over de dataset. Gebruik bij voorkeur de gegevens van de afdeling die de dataset of catalogus beheert, niet die van een individuele medewerker."@nl, "Contact information where end users can get in touch with questions about the dataset. Preferably use the details of the department that manages the dataset or catalogue, rather than an individual employee."@en ;
         ]
 .
+
+nde-dataset:AgentUriPatternShape
+    a sh:NodeShape ;
+    sh:targetObjectsOf schema:publisher, schema:creator ;
+    sh:pattern "^https?://" ;
+    sh:message "Gebruik een web-URI die begint met http:// of https://"@nl, "Use a web URI starting with http:// or https://"@en .
 
 # Separate node shapes for Organization-specific constraints that must fire only on
 # schema:Organization instances (not on Person publishers/creators). Each carries its own


### PR DESCRIPTION
## Summary

- When the SHACL report groups multiple violations of the same constraint on different blank-node focus nodes (e.g. the 12 blank-node creators in the Noorderstruun catalog), the report row hid the entire \"On\" block. The user only saw a single error and had no indication that the same problem affected 11 other items.
- Render the focus-node block whenever there are extras, even when the head result's focus node is blank, so the \"+ N more items\" button is always reachable.
- List blank-node extras with a fallback “unnamed item” label instead of silently filtering them out.

Closes #1931

## Test plan

- [x] \`npx nx build @dataset-register/browser\`
- [x] \`npx nx test @dataset-register/browser\`
- [x] \`npx nx lint @dataset-register/browser\`
- [ ] Manual: validate https://onserfgoed.noorderstruun.nl/AtlantisPubliek/data/set/catalog.jsonld and confirm the \"+ N more items\" button appears for the blank-node creator violations and lists the extras when expanded.