### PR TITLE
fix(deps): converge @opentelemetry packages and run docker:build on PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,9 @@ updates:
         patterns:
           - '@fastify/*'
           - 'fastify'
+      opentelemetry:
+        patterns:
+          - '@opentelemetry/*'
       flowbite:
         patterns:
           - 'flowbite'

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: npx nx-cloud record -- echo Hello World
-      - run: npx nx affected -t lint test typecheck check build
+      - run: npx nx affected -t lint test typecheck check build docker:build
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/package-lock.json
+++ b/package-lock.json
@@ -15073,9 +15073,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
-      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "version": "0.216.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.216.0.tgz",
+      "integrity": "sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -15085,9 +15085,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
-      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -15100,16 +15100,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.214.0.tgz",
-      "integrity": "sha512-Tx/59RmjBgkXJ3qnsD04rpDrVWL53LU/czpgLJh+Ab98nAroe91I7vZ3uGN9mxwPS0jsZEnmqmHygVwB2vRMlA==",
+      "version": "0.216.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.216.0.tgz",
+      "integrity": "sha512-/4VRxjy3spitqFuSkAt9qNwICiDB5T3zqLr+DYd50O7HMMBgWAf9tAL8q98eTVbzwRyRIxsz5Kq1+U5xEyN6gA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/otlp-exporter-base": "0.214.0",
-        "@opentelemetry/otlp-transformer": "0.214.0",
-        "@opentelemetry/resources": "2.6.1",
-        "@opentelemetry/sdk-metrics": "2.6.1"
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-exporter-base": "0.216.0",
+        "@opentelemetry/otlp-transformer": "0.216.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-metrics": "2.7.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -15119,17 +15119,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.214.0.tgz",
-      "integrity": "sha512-pJIcghFGhx3VSCgP5U+yZx+OMNj0t+ttnhC8IjL5Wza7vWIczctF6t3AGcVQffi2dEqX+ZHANoBwoPR8y6RMKA==",
+      "version": "0.216.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.216.0.tgz",
+      "integrity": "sha512-N7GCCXbw/le32/MrVL4Oj/FU9emFfHEHyGwubpcZLOtcuhUtFFAZWzPKJL1Etm0iNo37JA2JvG4W+5zNe/1NKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
-        "@opentelemetry/otlp-exporter-base": "0.214.0",
-        "@opentelemetry/otlp-transformer": "0.214.0",
-        "@opentelemetry/resources": "2.6.1",
-        "@opentelemetry/sdk-metrics": "2.6.1"
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.216.0",
+        "@opentelemetry/otlp-exporter-base": "0.216.0",
+        "@opentelemetry/otlp-transformer": "0.216.0",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-metrics": "2.7.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -15139,13 +15139,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
-      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "version": "0.216.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.216.0.tgz",
+      "integrity": "sha512-sSnvb5f+FYa4mfYxj03rmmUh+aDwo3jok62dgIWUDw8ZCUPzEbgtv/YhZyKUSlKNNey7Uc5xmJgmtTLLIV6UDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/otlp-transformer": "0.214.0"
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/otlp-transformer": "0.216.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -15155,18 +15155,18 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
-      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "version": "0.216.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.216.0.tgz",
+      "integrity": "sha512-g4Rb6sAsxQAo11eDjixfKxelruBsQFdJ8Wo23FCj7D6OXbidgXMu2xaRSYs4RdlomzAXSJuc86RcS3xmE8A6uA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.214.0",
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1",
-        "@opentelemetry/sdk-logs": "0.214.0",
-        "@opentelemetry/sdk-metrics": "2.6.1",
-        "@opentelemetry/sdk-trace-base": "2.6.1",
-        "protobufjs": "^7.0.0"
+        "@opentelemetry/api-logs": "0.216.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/sdk-logs": "0.216.0",
+        "@opentelemetry/sdk-metrics": "2.7.1",
+        "@opentelemetry/sdk-trace-base": "2.7.1",
+        "protobufjs": "8.0.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -15175,13 +15175,37 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/protobufjs": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
+      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/core": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -15192,14 +15216,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
-      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "version": "0.216.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.216.0.tgz",
+      "integrity": "sha512-KB3rcwQuitq0JbbsCcNdqMhRJX3kArAYz/ovb0jGRaBQAIrt2roik3xQXuhYxS37zx0jSkUZcJu1z3Y2UCxbDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.214.0",
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/api-logs": "0.216.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -15210,13 +15234,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
-      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
+      "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1"
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -15226,13 +15250,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
-      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -28319,6 +28343,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -32488,7 +32513,7 @@
         "@comunica/query-sparql": "^5.1.3",
         "@comunica/types": "^5.1.3",
         "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.214.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.216.0",
         "@opentelemetry/resources": "^2.7.0",
         "@opentelemetry/sdk-metrics": "^2.4.0",
         "@opentelemetry/semantic-conventions": "^1.40.0",
@@ -32509,37 +32534,6 @@
         "nock": "^14.0.13",
         "rdfa-streaming-parser": "^3.0.1",
         "testcontainers": "^11.13.0"
-      }
-    },
-    "packages/core/node_modules/@opentelemetry/core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
-      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "packages/core/node_modules/@opentelemetry/resources": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
-      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     }
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "@comunica/query-sparql": "^5.1.3",
     "@comunica/types": "^5.1.3",
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/exporter-metrics-otlp-proto": "^0.214.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.216.0",
     "@opentelemetry/resources": "^2.7.0",
     "@opentelemetry/sdk-metrics": "^2.4.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 95.13,
+        lines: 95.16,
         functions: 92.8,
         branches: 83.42,
-        statements: 94.46,
+        statements: 94.49,
       },
     },
   },


### PR DESCRIPTION
## Why

`release.yml` has been failing on every push to main since the Nx 22.6.5 → 22.7.0 migration (`aad26236`, 2026-04-28). Inside the Dockerfile build, `npm ci --omit=dev` rejects the pruned `package.json` / `package-lock.json` pair:

```
Invalid: lock file's @dataset-register/core@0.0.1 does not satisfy @dataset-register/core@
Missing: @dataset-register/core@ from lock file
```

Reproduced locally with a fresh `node_modules`. Underlying error (caught and swallowed by `prune-lockfile`):

```
Following packages could not be mapped to the NPM lockfile:
- npm:@opentelemetry/core@2.7.0
    at nestMappedPackages (.../nx/dist/src/plugins/js/lock-file/npm-parser.js:418:15)
```

Three nested copies of `@opentelemetry/core` (2.6.1 / 2.7.0 / 2.7.1) live in our committed lockfile because `packages/core` directly depends on three otel packages whose internal cross-pins disagree:

- `@opentelemetry/exporter-metrics-otlp-proto@0.214.0` → exact `core@2.6.1`
- `@opentelemetry/resources@2.7.0`                    → exact `core@2.7.0`
- `@opentelemetry/sdk-metrics@2.7.1`                  → exact `core@2.7.1`

The same lockfile also worked under Nx 22.6.5 — it’s a regression in 22.7.0’s `nestMappedPackages`, but the right fix is to converge otel anyway (multiple otel core copies are a code smell).

## Changes

- **`packages/core/package.json`** — bump `@opentelemetry/exporter-metrics-otlp-proto` from `^0.214.0` to `^0.216.0`. The `^` ranges on `resources` and `sdk-metrics` then resolve to the matching `2.7.1` set, collapsing all otel core in the graph to a single `2.7.1`. Confirmed via `npm ls @opentelemetry/core --all`.
- **`.github/workflows/qa.yml`** — add `docker:build` to `nx affected` targets. PR CI was running `lint test typecheck check build` + E2E only; `docker:build` (and its dependent `prune-lockfile` / `copy-workspace-modules`) only ran post-merge in `release.yml`, which is why the Nx upgrade slipped through.
- **`.github/dependabot.yml`** — add an `opentelemetry` group. otel cross-pins its modules to exact versions of each other, so per-package Dependabot PRs cannot keep our four otel deps on a matched set. Bumping them as a unit prevents this same fracture from happening again.
- **`package-lock.json`** — regenerated; single `@opentelemetry/core@2.7.1`, `resources@2.7.1`, `sdk-metrics@2.7.1` entries.
- **`packages/core/vite.config.ts`** — vitest `autoUpdate` bumped two coverage thresholds by ~0.03 after the otel bump (artifact of running the full `nx run core:test`).
