### PR TITLE
fix(crawler): mark unreachable URLs gone instead of invalid

### DIFF
--- a/apps/crawler/src/crawler.ts
+++ b/apps/crawler/src/crawler.ts
@@ -38,15 +38,16 @@ export class Crawler {
       await this.registrationStore.findRegistrationsReadBefore(dateLastRead);
     for (const registration of registrations) {
       this.logger.info(`Crawling registration URL ${registration.url}...`);
-      let statusCode = 200;
+      let statusCode: number | undefined = undefined;
       let isValid = false;
       let datasetIris = registration.datasets;
 
       try {
         const data = await dereference(registration.url);
         const validationResult = await this.validator.validate(data);
-        isValid = validationResult.state === 'valid';
-        if (isValid) {
+        if (validationResult.state === 'valid') {
+          statusCode = 200;
+          isValid = true;
           this.logger.info(`${registration.url} passes validation`);
           datasetIris = []; // Start with a fresh list.
           for await (const dataset of fetch(registration.url, data)) {
@@ -56,8 +57,12 @@ export class Crawler {
             const rating = rate(dcatValidationResult as Valid);
             await this.ratingStore.store(extractIri(dataset), rating);
           }
-        } else {
+        } else if (validationResult.state === 'invalid') {
+          statusCode = 200;
           this.logger.info(`${registration.url} does not pass validation`);
+        } else {
+          // 'no-dataset': URL responded but contained no Dataset triples.
+          this.logger.info(`${registration.url} contains no datasets`);
         }
       } catch (e) {
         if (e instanceof HttpError) {
@@ -65,11 +70,16 @@ export class Crawler {
           this.logger.info(
             `${registration.url} returned HTTP error ${statusCode}`,
           );
-        }
-
-        if (e instanceof NoDatasetFoundAtUrl) {
-          // Request was successful, but no datasets exist any longer at the URL.
-          this.logger.info(`${registration.url} has no datasets`);
+        } else if (e instanceof NoDatasetFoundAtUrl) {
+          this.logger.info(
+            { err: e },
+            `${registration.url} has no datasets`,
+          );
+        } else {
+          this.logger.warn(
+            { err: e },
+            `${registration.url} fetch or parse failed`,
+          );
         }
       }
 

--- a/apps/crawler/test/crawler.test.ts
+++ b/apps/crawler/test/crawler.test.ts
@@ -21,6 +21,9 @@ const validator = (isValid: boolean, errors = new Store()): Validator => ({
       errors: errors,
     }),
 });
+const noDatasetValidator: Validator = {
+  validate: () => Promise.resolve({ state: 'no-dataset' }),
+};
 
 describe('Crawler', () => {
   beforeEach(async () => {
@@ -83,7 +86,7 @@ describe('Crawler', () => {
     expect(readRegistration.datasets).toHaveLength(1); // Any references to datasets are kept.
   });
 
-  it('ignores datasets no longer available', async () => {
+  it('marks registration gone when URL no longer serves a dataset', async () => {
     await storeRegistrationFixture(
       new URL('https://example.com/no-more-datasets'),
     );
@@ -94,7 +97,8 @@ describe('Crawler', () => {
     await crawler.crawl(new Date('3000-01-01'));
 
     const readRegistration = registrationStore.all()[0];
-    expect(readRegistration.statusCode).toBe(200);
+    expect(readRegistration.statusCode).toBeUndefined();
+    expect(readRegistration.registrationStatus).toBe('gone');
     expect(readRegistration.datasets).toHaveLength(1); // Any references to datasets are kept.
   });
 
@@ -116,6 +120,45 @@ describe('Crawler', () => {
 
     const readRegistration = registrationStore.all()[0];
     expect(readRegistration.validUntil).not.toBeUndefined();
+    expect(readRegistration.registrationStatus).toBe('invalid');
+  });
+
+  it('marks registration gone when validator finds no datasets', async () => {
+    crawler = new Crawler(
+      registrationStore,
+      new MockDatasetStore(),
+      new MockRatingStore(),
+      noDatasetValidator,
+      pino({ enabled: false }),
+    );
+    await storeRegistrationFixture(new URL('https://example.com/no-dataset'));
+
+    nock('https://example.com')
+      .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
+      .get('/no-dataset')
+      .reply(200);
+    await crawler.crawl(new Date('3000-01-01'));
+
+    const readRegistration = registrationStore.all()[0];
+    expect(readRegistration.statusCode).toBeUndefined();
+    expect(readRegistration.registrationStatus).toBe('gone');
+  });
+
+  it('marks registration gone when content type is unrecognized', async () => {
+    await storeRegistrationFixture(new URL('https://example.com/wrong-type'));
+
+    // image/jpeg trips rdf-dereferencer's "Unrecognized media type" path,
+    // which surfaces as InvalidContentType – neither HttpError nor
+    // NoDatasetFoundAtUrl, so it exercises the catch-all warn log.
+    nock('https://example.com')
+      .defaultReplyHeaders({ 'Content-Type': 'image/jpeg' })
+      .get('/wrong-type')
+      .reply(200, '');
+    await crawler.crawl(new Date('3000-01-01'));
+
+    const readRegistration = registrationStore.all()[0];
+    expect(readRegistration.statusCode).toBeUndefined();
+    expect(readRegistration.registrationStatus).toBe('gone');
   });
 });
 

--- a/packages/core/src/registration.ts
+++ b/packages/core/src/registration.ts
@@ -30,7 +30,7 @@ export class Registration {
    */
   public read(
     datasets: URL[],
-    statusCode: number,
+    statusCode: number | undefined,
     valid: boolean,
     date: Date = new Date(),
   ): Registration {
@@ -60,12 +60,13 @@ export class Registration {
 
   /**
    * Computed registration status based on statusCode and validUntil.
-   * - 'invalid': validation failed (has validUntil)
-   * - 'gone': URL unavailable (HTTP status > 200)
-   * - 'valid': healthy registration
+   * - 'gone': URL did not yield a usable RDF response (HTTP status > 200, or no
+   *   response we could classify – fetch error, parse error, no datasets in body).
+   * - 'invalid': URL responded with usable RDF but validation failed (has validUntil).
+   * - 'valid': healthy registration.
    */
   get registrationStatus(): 'valid' | 'invalid' | 'gone' {
-    if (this._statusCode !== undefined && this._statusCode > 200) {
+    if (this._statusCode === undefined || this._statusCode > 200) {
       return 'gone';
     }
     if (this.validUntil !== undefined) {

--- a/packages/core/test/registration.test.ts
+++ b/packages/core/test/registration.test.ts
@@ -60,5 +60,28 @@ describe('Registration', () => {
 
       expect(registration.registrationStatus).toBe('gone');
     });
+
+    it('returns gone when no statusCode is recorded', () => {
+      // No status code means we never had a usable HTTP response we could
+      // classify – fetch error, parse error, or no Dataset triples in the body.
+      const registration = new Registration(
+        new URL('https://example.com/registration'),
+        new Date(),
+      ).read([], undefined, false);
+
+      expect(registration.registrationStatus).toBe('gone');
+      expect(registration.validUntil).not.toBeUndefined();
+    });
+
+    it('returns gone for unreachable URLs even when valid was true', () => {
+      // valid=true with no statusCode (e.g. a recovered Registration before its
+      // first crawl) still surfaces as gone until we actually reach the URL.
+      const registration = new Registration(
+        new URL('https://example.com/registration'),
+        new Date(),
+      ).read([], undefined, true);
+
+      expect(registration.registrationStatus).toBe('gone');
+    });
   });
 });


### PR DESCRIPTION
## Summary

The crawler defaulted `isValid = false` and silently swallowed any error
that wasn’t `HttpError` or `NoDatasetFoundAtUrl`, then passed that boolean
straight into `Registration.read()` which set `validUntil`. As a result a
parse error, an unrecognised content type, or a transient empty response
caused the registration to be tagged **Invalid** for up to a day until the
next crawl, even though SHACL validation never ran.

41 currently-invalid registrations cluster on a few specific days (24 of
41 on 2026-04-24 alone), consistent with transient fetch waves rather
than 24 publishers simultaneously breaking SHACL conformance. The
residual `opendata.archieven.nl` case from #1935 validates as HTTP 200
with only Warnings/Infos via the live API – no real Violation.

The browser app already differentiates `valid` / `invalid` / `gone`, so
fetch and parse failures belong in `gone` (URL doesn’t usefully serve a
dataset), not `invalid` (URL serves a dataset that fails SHACL).

## Changes

- `Registration.read()` accepts `statusCode: number | undefined`.
  `registrationStatus` returns `'gone'` when `statusCode` is undefined or
  `> 200`. Doc updated.
- `Crawler.crawl()` initialises `statusCode` to `undefined` and only sets
  it to `200` when the validator returns `'valid'` or `'invalid'`.
  `'no-dataset'` and any caught exception leave `statusCode` undefined
  → `gone`.
- Every catch-block branch now logs. `InvalidContentType` and any other
  unexpected exception surface at `warn` with structured `{ err }` so
  future spikes are diagnosable from production logs (today they were
  silent).

## Tests

- `Registration`: covers `read(..., undefined, false)` → gone with
  `validUntil` preserved, and `read(..., undefined, true)` → gone.
- `Crawler`: validator returning `'no-dataset'` → gone; unrecognised
  content type → gone (exercises the catch-all warn branch). Existing
  "no datasets" test renamed and updated to expect gone instead of
  status 200.

Fix #1935
