### PR TITLE
docs(requirements): link distribution date attributes to #distribution-date

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,5 +48,8 @@
     "nock": "^14.0.13",
     "rdfa-streaming-parser": "^3.0.1",
     "testcontainers": "^11.13.0"
+  },
+  "nx": {
+    "projectType": "library"
   }
 }

--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -44,7 +44,8 @@
             <th scope="row">[{{ property.path }}]({{ property.path }})</th>
             <td>
                 {%- if is_date_shape -%}
-                    {%- if description != "" -%}{{ description }} {% endif -%}See [[#dataset-date]].
+                    {%- if description != "" -%}{{ description }} {% endif -%}
+                    {%- if name == 'Distribution' -%}See [[#distribution-date]].{%- else -%}See [[#dataset-date]].{%- endif -%}
                 {%- elsif property.path == "schema:publisher" or property.path == "schema:creator" -%}
                     {{ description }} See [[#creator-publisher-information]].
                 {%- elsif property.path == "schema:contactPoint" -%}

--- a/requirements/index.bs.liquid
+++ b/requirements/index.bs.liquid
@@ -574,7 +574,7 @@ See [[#distribution-attributes]] for a full overview.
 
 Publishers *SHOULD* make known when the [=distribution=] was originally created and when it was last updated,
 so [=consumers=] can efficiently stay up-to-date with the latest changes.
-Please note that this is different from [[#dataset-date|dataset description's dates]].
+Please note that this is different from the [[#dataset-date|dataset description’s dates]].
 Datetimes (`2019-08-15T08:05:00Z`) are preferred because they offer greater precision,
 but simple dates (`2019-04-14`) are also allowed.
 


### PR DESCRIPTION
## Summary

- Date-shape properties under the **Distribution attributes** table now link to `#distribution-date` instead of `#dataset-date`, so readers land in the section that actually describes distribution dates.
- Add the missing article in the cross-reference from `#distribution-date` back to `the [dataset description’s dates]`.
- Mark `@dataset-register/core` as `projectType: library` in its `package.json`. Without this, Nx defaults the project to `application`, which made `@nx/enforce-module-boundaries` reject all `apps/*` → `core` imports as “Imports of apps are forbidden” and broke the pre-commit lint hook.
