### PR TITLE
fix: drop dct:alternative from the dataset model

### DIFF
--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -11,7 +11,6 @@ import type { NamedNode } from '@rdfjs/types';
 const dataset = 'dataset';
 const identifier = 'identifier';
 const name = 'name';
-const alternateName = 'alternateName';
 const description = 'description';
 const license = 'license';
 const creator = 'creator';
@@ -175,7 +174,6 @@ function schemaOrgMultiValuedUnions(prefix: string): string {
   const type = `a ${prefix}:Dataset`;
   return [
     multiValuedUnion(type, `${prefix}:description`, description),
-    multiValuedUnion(type, `${prefix}:alternateName`, alternateName),
     multiValuedUnion(type, `${prefix}:isBasedOn`, source),
     multiValuedUnion(type, `${prefix}:isBasedOnUrl`, source),
     multiValuedUnion(
@@ -209,7 +207,6 @@ function dcatMultiValuedUnions(): string {
   const type = `a dcat:Dataset`;
   return [
     multiValuedUnion(type, `dct:description`, description),
-    multiValuedUnion(type, `dct:alternative`, alternateName),
     multiValuedUnion(type, `dct:source`, source),
     multiValuedUnion(
       type,
@@ -247,7 +244,6 @@ export const constructQuery = `
   CONSTRUCT {
     ?${dataset} a dcat:Dataset ;
       dct:title ?${name} ;
-      dct:alternative ?${alternateName} ;
       dct:description ?${description} ;
       dct:identifier ?${identifier} ;
       dct:license ?${license} ;

--- a/packages/core/src/transform.ts
+++ b/packages/core/src/transform.ts
@@ -41,7 +41,6 @@ export function addDefaultLanguageTags(quads: Quad[], lang = 'nl'): DatasetExt {
 
 const languageTagPredicates = new Set([
   dct('title').value,
-  dct('alternative').value,
   dct('description').value,
   dcat('keyword').value,
   foaf('name').value,

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 95.16,
+        lines: 95.15,
         functions: 92.8,
         branches: 83.42,
-        statements: 94.49,
+        statements: 94.48,
       },
     },
   },

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -1201,10 +1201,6 @@ dcat:DatasetShape
     ],
     nde-dataset:DcTitleLangStringProperty,
     [
-        sh:path dc:alternative ;
-        sh:description "Een alternatieve naam van de dataset."@nl, "An alternative name of the dataset."@en ;
-    ],
-    [
         sh:path dc:description ;
         sh:minCount 1 ;
         sh:severity sh:Warning ;


### PR DESCRIPTION
## Summary

Drop `dct:alternative` from the dataset data model. In production only one dataset uses it, the SHACL shape only documented it (no `sh:minCount`/`sh:maxCount`/`sh:datatype`/langString constraints), and the consumer-facing data model page already removed it.

Changes:

- `requirements/shacl.ttl`: remove the `dc:alternative` property entry from `dcat:DatasetShape`.
- `packages/core/src/transform.ts`: drop `dct('alternative').value` from the language-tagger predicate set so untagged literals on this property no longer get auto-tagged `@nl`.
- `packages/core/src/query.ts`: remove the schema.org-to-DCAT mapping for `schema:alternateName` → `dct:alternative` (both the schema.org and DCAT UNION branches and the CONSTRUCT projection), and the now-unused `alternateName` SPARQL variable. The publisher-side `publisherAlternateName` is unaffected and still maps `schema:alternateName` → `foaf:nick` on the publisher.

No test fixtures changed: the tests that reference `schema:alternateName` are all about Organization/Publisher alternate names, which remain unchanged.
