### PR TITLE
fix: drop duplicate foaf:mbox emission on publisher

### DIFF
--- a/apps/browser/src/lib/rdf.ts
+++ b/apps/browser/src/lib/rdf.ts
@@ -30,6 +30,12 @@ export const owlNs = createNamespace({
   terms: ['sameAs'],
 } as const);
 
+export const vcardNs = createNamespace({
+  iri: 'http://www.w3.org/2006/vcard/ns#',
+  prefix: 'vcard:',
+  terms: ['hasEmail'],
+} as const);
+
 /**
  * Schema.org namespace using https://, overriding LDkit's built-in http:// variant.
  */

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -3,7 +3,7 @@ import { dcterms, foaf, ldkit, xsd } from 'ldkit/namespaces';
 import { createLens, type SchemaInterface } from 'ldkit';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { error } from '@sveltejs/kit';
-import { owlNs, schemaNs as schema, voidExtNs, voidNs } from '../rdf.js';
+import { owlNs, schemaNs as schema, vcardNs, voidExtNs, voidNs } from '../rdf.js';
 import { BaseDatasetSchema, BaseDistributionSchema } from './datasets.js';
 import { shortenUri } from '$lib/utils/prefix';
 import { isUri, lookupTermLabels } from './network-of-terms.js';
@@ -62,12 +62,17 @@ const DetailPublisherSchema = {
     '@optional': true,
     '@multilang': true,
   },
-  email: {
-    '@id': foaf.mbox,
-    '@optional': true,
-  },
   sameAs: {
     '@id': owlNs.sameAs,
+    '@optional': true,
+  },
+} as const;
+
+// Contact point schema — the canonical location of the dataset's contact email.
+// vcard:hasEmail is stored as a mailto: IRI; UI strips the prefix for display.
+const DetailContactPointSchema = {
+  email: {
+    '@id': vcardNs.hasEmail,
     '@optional': true,
   },
 } as const;
@@ -120,6 +125,11 @@ export const DatasetDetailSchema = {
     '@id': dcterms.publisher,
     '@optional': true,
     '@schema': DetailPublisherSchema,
+  },
+  contactPoint: {
+    '@id': dcat.contactPoint,
+    '@optional': true,
+    '@schema': DetailContactPointSchema,
   },
   subjectOf: {
     '@id': schema.subjectOf,

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -548,13 +548,13 @@
                   >
                 {/if}
                 <LanguageBadge values={dataset.publisher.name} />
-                {#if dataset.publisher.email || dataset.publisher.sameAs}
+                {#if dataset.contactPoint?.email || dataset.publisher.sameAs}
                   <div
                     class="mt-1.5 flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-400"
                   >
-                    {#if dataset.publisher.email}
+                    {#if dataset.contactPoint?.email}
                       <a
-                        href="mailto:{dataset.publisher.email}"
+                        href={dataset.contactPoint.email}
                         class="inline-flex items-center gap-1.5 hover:text-blue-600 dark:hover:text-blue-400"
                       >
                         <svg
@@ -571,7 +571,7 @@
                           />
                         </svg>
                         <span class="break-all"
-                          >{dataset.publisher.email.replace(
+                          >{dataset.contactPoint.email.replace(
                             'mailto:',
                             '',
                           )}</span

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -39,7 +39,6 @@ const creatorType = 'creator_type';
 
 const publisherType = 'publisher_type';
 const publisherName = 'publisher_name';
-const publisherEmail = 'publisher_email';
 const contactPoint = 'contactPoint';
 const contactPointName = 'contactPoint_name';
 const contactPointEmail = 'contactPoint_email';
@@ -162,11 +161,6 @@ function schemaOrgContactPointUnion(prefix: string): string {
         ?${contactPoint} ${prefix}:email ?contactPointEmailRaw .
         BIND(IRI(CONCAT("mailto:", STR(?contactPointEmailRaw))) AS ?${contactPointEmail})
         OPTIONAL { ?${contactPoint} ${prefix}:name ?${contactPointName} . }
-      }
-      UNION {
-        ?${dataset} a ${prefix}:Dataset .
-        ?${dataset} ${prefix}:publisher ?${publisher} .
-        ?${publisher} ${prefix}:contactPoint/${prefix}:email ?${publisherEmail} .
       }`;
 }
 
@@ -279,7 +273,6 @@ export const constructQuery = `
       foaf:name ?${publisherName} ;
       foaf:nick ?${publisherAlternateName} ;
       dct:identifier ?${publisherIdentifier} ;
-      foaf:mbox ?${publisherEmail} ;
       owl:sameAs ?${publisherSameAs} .
 
     ?${creator} a ?${creatorType} ;
@@ -330,7 +323,6 @@ export const constructQuery = `
 
         OPTIONAL { ?${publisher} foaf:nick ?${publisherAlternateName} ; }
         OPTIONAL { ?${publisher} dct:identifier ?${publisherIdentifier} ; }
-        OPTIONAL { ?${publisher} foaf:mbox ?${publisherEmail} ; }
         OPTIONAL { ?${publisher} owl:sameAs ?${publisherSameAs} ; }
 
         OPTIONAL {

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -691,15 +691,6 @@ describe('Fetch', () => {
     expect(
       dataset.has(
         factory.quad(
-          factory.namedNode('https://example.com'),
-          foaf('mbox'),
-          factory.literal('datasets@example.com'),
-        ),
-      ),
-    ).toBe(true);
-    expect(
-      dataset.has(
-        factory.quad(
           factory.namedNode('https://example.com/creator1'),
           rdf('type'),
           foaf('Person'),

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -580,10 +580,12 @@ describe('Fetch', () => {
     // The DCAT file has a 4th gzip distribution (5 triples incl. downloadURL),
     // an extra byteSize triple, one more propagated license (4 vs 3 distributions),
     // a mediaType on the SPARQL distribution (suppressed for API distributions),
-    // and a dcat:theme triple (auto-assigned for Schema.org, explicit in DCAT).
+    // a dcat:theme triple (auto-assigned for Schema.org, explicit in DCAT),
+    // and a foaf:mbox triple on the publisher (no longer emitted from
+    // Schema.org input now that the contactPoint is the canonical email channel).
     // Fetch also replaces the `dct:temporal "..."` literal with a PeriodOfTime
     // blank node (1 → 4 quads: dct:temporal link + rdf:type + startDate + endDate).
-    expect(dataset.size).toEqual(dcatEquivalent.size + 8 - 9 + 3);
+    expect(dataset.size).toEqual(dcatEquivalent.size + 8 - 10 + 3);
 
     // Check that SPARQL endpoint has conformsTo triple
     const sparqlConformsToTriples = [...dataset].filter(

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 95.15,
+        lines: 95.13,
         functions: 92.8,
         branches: 83.42,
-        statements: 94.48,
+        statements: 94.46,
       },
     },
   },


### PR DESCRIPTION
## Summary

Stop emitting `foaf:mbox` on the publisher Agent. Email values from `schema:publisher/schema:contactPoint/schema:email` were being duplicated onto:

1. `vcard:hasEmail` on `dcat:contactPoint` (mailto: IRI), and
2. `foaf:mbox` on the publisher Agent (plain literal).

DCAT-AP-NL 3.0 only profiles `vcard:hasEmail` on the contactPoint; `foaf:mbox` on the publisher is not part of the profile. The literal form we emit also diverges from FOAF semantics: `foaf:mbox` is an Inverse Functional Property and the canonical form is a `mailto:` IRI, not a literal.

After this PR the contactPoint remains the canonical email channel; the publisher node carries `foaf:name`, `foaf:nick`, `dct:identifier`, and `owl:sameAs` only.

## Frontend update

The dataset detail page now reads the publisher's contact email from `dcat:contactPoint` / `vcard:hasEmail` instead of `foaf:mbox`:

- `apps/browser/src/lib/rdf.ts`: add a `vcardNs` namespace.
- `apps/browser/src/lib/services/dataset-detail.ts`: drop `email` from `DetailPublisherSchema`; add a `contactPoint` field to `DatasetDetailSchema` with its own `DetailContactPointSchema` reading `vcard:hasEmail`.
- `apps/browser/src/routes/datasets/[...uri]/+page.svelte`: render `dataset.contactPoint?.email`. Since `vcard:hasEmail` is stored as a `mailto:` IRI, the link `href` uses the value directly and the visible text strips the `mailto:` prefix.
