### PR TITLE
fix(browser): fetch contactPoint triples in detail CONSTRUCT

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -3,7 +3,13 @@ import { dcterms, foaf, ldkit, xsd } from 'ldkit/namespaces';
 import { createLens, type SchemaInterface } from 'ldkit';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { error } from '@sveltejs/kit';
-import { owlNs, schemaNs as schema, vcardNs, voidExtNs, voidNs } from '../rdf.js';
+import {
+  owlNs,
+  schemaNs as schema,
+  vcardNs,
+  voidExtNs,
+  voidNs,
+} from '../rdf.js';
 import { BaseDatasetSchema, BaseDistributionSchema } from './datasets.js';
 import { shortenUri } from '$lib/utils/prefix';
 import { isUri, lookupTermLabels } from './network-of-terms.js';
@@ -510,6 +516,10 @@ export async function fetchDatasetDetail(
           <${datasetUri}> schema:contentRating ?contentRating .
           ?contentRating ?p ?o .
           BIND(?contentRating AS ?s)
+        } UNION {
+          <${datasetUri}> dcat:contactPoint ?contactPoint .
+          ?contactPoint ?p ?o .
+          BIND(?contactPoint AS ?s)
         }
       }
     }


### PR DESCRIPTION
## Summary

Fix 500 on dataset detail pages where the dataset has a `dcat:contactPoint`.

#1948 added a `contactPoint` field to `DatasetDetailSchema` that reads `vcard:hasEmail` on the bnode, but the custom CONSTRUCT in `apps/browser/src/lib/services/dataset-detail.ts` was not updated to fetch the bnode’s triples. ldkit saw the `dataset → contactPoint` reference but no triples for the bnode and threw `Error decoding graph, <bn…> node not found`, returning a 500 on every dataset that exposes a contactPoint.

Add a UNION branch for `dcat:contactPoint` alongside the existing publisher / creator / subjectOf / contentRating branches so the contactPoint’s `vcard:hasEmail` is returned in the same CONSTRUCT result.

Example failing page before this fix:
https://datasetregister.netwerkdigitaalerfgoed.nl/en/datasets/https://opendata.archieven.nl/dataset/91899696F71541F4A4E7DE7FCBC266CD
