### PR TITLE
fix(core): accept datasets whose license lives on the distribution

### DIFF
--- a/packages/core/src/literal.ts
+++ b/packages/core/src/literal.ts
@@ -41,6 +41,22 @@ export const normalizeLicense = (variable: string) =>
         )`;
 
 /**
+ * Bind ?out to the normalized IRI form of ?in if ?in is an IRI; otherwise
+ * leave ?out unbound (via the ?unbound trick). Used for dataset-level license
+ * reads where we want to ignore literal placeholders rather than emit them.
+ * IRI() is only invoked inside the isIRI() branch — a bare FILTER(isIRI(...))
+ * does not prevent Comunica from eagerly evaluating IRI() on a literal.
+ */
+export const bindIriLicense = (rawVar: string, outVar: string) =>
+  `BIND(
+        IF(
+          isIRI(?${rawVar}),
+          IRI(REPLACE(REPLACE(STR(?${rawVar}), "deed.nl", ""), "http://creativecommons.org", "https://creativecommons.org")),
+          ?unbound
+        ) AS ?${outVar}
+      )`;
+
+/**
  * Normalize mediaType to IANA URI format.
  *
  * DCAT-3 requires dcat:mediaType to be URIs pointing to the IANA media type registry.
@@ -103,4 +119,3 @@ export const compressFormatFromMediaType = (
 export const convertUriToLiteral = (variable: string) =>
   `?${variable}Raw ;
         BIND(IF(isIRI(?${variable}Raw), STR(?${variable}Raw), ?${variable}Raw) AS ?${variable})`;
-

--- a/packages/core/src/literal.ts
+++ b/packages/core/src/literal.ts
@@ -19,13 +19,23 @@ export const convertToIri = (variable: string) =>
         BIND(IRI(?${variable}Raw) AS ?${variable})`;
 
 /**
+ * Normalize a license value. If the raw value is an IRI, strip the "deed.nl"
+ * suffix and upgrade http://creativecommons.org to https://. If the raw value
+ * is a literal, pass it through unchanged so that a non-IRI license (allowed
+ * by SHACL with sh:nodeKind sh:IRIOrLiteral) does not crash the CONSTRUCT
+ * with an invalid-IRI error.
+ *
  * https://github.com/netwerk-digitaal-erfgoed/dataset-register/issues/1141
  */
 export const normalizeLicense = (variable: string) =>
   `?${variable}Raw ;
         BIND(
-          IRI(
-            REPLACE(REPLACE(STR(?${variable}Raw), "deed.nl", ""), "http://creativecommons.org", "https://creativecommons.org")
+          IF(
+            isIRI(?${variable}Raw),
+            IRI(
+              REPLACE(REPLACE(STR(?${variable}Raw), "deed.nl", ""), "http://creativecommons.org", "https://creativecommons.org")
+            ),
+            ?${variable}Raw
           )
           AS ?${variable}
         )`;

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -1,5 +1,6 @@
 import factory from 'rdf-ext';
 import {
+  bindIriLicense,
   compressFormatFromMediaType,
   convertToIri,
   convertToXsdDate,
@@ -316,18 +317,27 @@ export const constructQuery = `
           dct:title ?${name} ;
           dct:publisher ?${publisher} .
 
-        # DCAT-AP-NL places dct:license only on the distribution, but DCAT
-        # and DCAT-AP both allow it on the dataset and many publishers do
-        # provide it there. Read the dataset license when present, but leave
-        # ?${license} unbound for literal placeholders (e.g. "see distributions")
-        # so a non-IRI value neither crashes the IRI() call nor pollutes the
-        # index. IRI() is only invoked inside the isIRI() branch — bare
-        # FILTER(isIRI(...)) doesn't prevent Comunica from eagerly evaluating
-        # IRI() on a literal.
+        # DCAT-AP-NL puts dct:license on the distribution. We index a
+        # denormalized dataset-level license for query convenience (browsers,
+        # external SPARQL consumers): prefer the publisher's own dataset
+        # license when it's an IRI, otherwise sample one IRI license from
+        # the distributions. Literal placeholders (e.g. KB's
+        # "zie distributies") are skipped so they don't pollute the index.
         OPTIONAL {
-          ?${dataset} dct:license ?${license}Raw .
-          BIND(IF(isIRI(?${license}Raw), IRI(REPLACE(REPLACE(STR(?${license}Raw), "deed.nl", ""), "http://creativecommons.org", "https://creativecommons.org")), ?unbound) AS ?${license})
+          ?${dataset} dct:license ?datasetLicenseRaw .
+          ${bindIriLicense('datasetLicenseRaw', 'datasetLicenseExplicit')}
         }
+        OPTIONAL {
+          {
+            SELECT ?${dataset} (SAMPLE(?distLic) AS ?distributionLicenseSample) WHERE {
+              ?${dataset} dcat:distribution ?distForLicense .
+              ?distForLicense a dcat:Distribution ;
+                dct:license ?distLicRaw .
+              ${bindIriLicense('distLicRaw', 'distLic')}
+            } GROUP BY ?${dataset}
+          }
+        }
+        BIND(COALESCE(?datasetLicenseExplicit, ?distributionLicenseSample) AS ?${license})
 
         ?${publisher} a ?foafOrganizationOrPerson ;
           a ?${publisherType} ;
@@ -431,7 +441,15 @@ function schemaOrgQuery(prefix: string): string {
     ?${dataset} a ${prefix}:Dataset ;
       ${prefix}:name ?${name} .
 
-    OPTIONAL { ?${dataset} ${prefix}:license ${normalizeLicense(license)} }
+    # Dataset-level license: the schema.org convention places license here, so
+    # consumers (such as the browser app) read it directly from the dataset.
+    # Read the publisher's value and project it only when it's an IRI; literal
+    # values are accepted as input (SHACL allows them with sh:IRIOrLiteral)
+    # but leave ?${license} unbound so they don't end up as junk literals.
+    OPTIONAL {
+      ?${dataset} ${prefix}:license ?datasetLicenseRaw .
+      ${bindIriLicense('datasetLicenseRaw', license)}
+    }
 
     OPTIONAL {
       ?${dataset} ${prefix}:creator ?${creator} .        

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -316,7 +316,18 @@ export const constructQuery = `
           dct:title ?${name} ;
           dct:publisher ?${publisher} .
 
-        OPTIONAL { ?${dataset} dct:license ${normalizeLicense(license)} }
+        # DCAT-AP-NL places dct:license only on the distribution, but DCAT
+        # and DCAT-AP both allow it on the dataset and many publishers do
+        # provide it there. Read the dataset license when present, but leave
+        # ?${license} unbound for literal placeholders (e.g. "see distributions")
+        # so a non-IRI value neither crashes the IRI() call nor pollutes the
+        # index. IRI() is only invoked inside the isIRI() branch — bare
+        # FILTER(isIRI(...)) doesn't prevent Comunica from eagerly evaluating
+        # IRI() on a literal.
+        OPTIONAL {
+          ?${dataset} dct:license ?${license}Raw .
+          BIND(IF(isIRI(?${license}Raw), IRI(REPLACE(REPLACE(STR(?${license}Raw), "deed.nl", ""), "http://creativecommons.org", "https://creativecommons.org")), ?unbound) AS ?${license})
+        }
 
         ?${publisher} a ?foafOrganizationOrPerson ;
           a ?${publisherType} ;
@@ -338,6 +349,7 @@ export const constructQuery = `
           ?${dataset} dcat:distribution ?${distribution} .
           ?${distribution} a dcat:Distribution .
           ?${distribution} dcat:accessURL ${convertToIri(distributionUrl)} .
+          ?${distribution} dct:license ${normalizeLicense(distributionLicense)} .
           OPTIONAL {
             ?${distribution} dcat:mediaType ${normalizeMediaType(distributionMediaType)} .
           }
@@ -369,8 +381,6 @@ export const constructQuery = `
             ?${distribution} dct:language ?${distributionLanguage}Raw .
             ${normalizeLanguage(`?${distributionLanguage}Raw`, distributionLanguage)}
           }
-          OPTIONAL { ?${distribution} dct:license ${normalizeLicense(distributionLicense + 'Provided')} }
-          BIND(COALESCE(?${distributionLicense}Provided, ?${license}) AS ?${distributionLicense})
           OPTIONAL { ?${distribution} dct:title ?${distributionName} }
           OPTIONAL { ?${distribution} dcat:byteSize ?${distributionSize} }
           OPTIONAL {

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -311,12 +311,13 @@ export const constructQuery = `
         ${schemaOrgQuery('schema')}
       } UNION {
         ${schemaOrgQuery('httpSchema')}
-      } UNION { 
+      } UNION {
         ?${dataset} a dcat:Dataset ;
           dct:title ?${name} ;
-          dct:publisher ?${publisher} ;
-          dct:license ${normalizeLicense(license)} .
-          
+          dct:publisher ?${publisher} .
+
+        OPTIONAL { ?${dataset} dct:license ${normalizeLicense(license)} }
+
         ?${publisher} a ?foafOrganizationOrPerson ;
           a ?${publisherType} ;
           foaf:name ?${publisherName} .
@@ -368,7 +369,8 @@ export const constructQuery = `
             ?${distribution} dct:language ?${distributionLanguage}Raw .
             ${normalizeLanguage(`?${distributionLanguage}Raw`, distributionLanguage)}
           }
-          OPTIONAL { ?${distribution} dct:license ${normalizeLicense(distributionLicense)} }
+          OPTIONAL { ?${distribution} dct:license ${normalizeLicense(distributionLicense + 'Provided')} }
+          BIND(COALESCE(?${distributionLicense}Provided, ?${license}) AS ?${distributionLicense})
           OPTIONAL { ?${distribution} dct:title ?${distributionName} }
           OPTIONAL { ?${distribution} dcat:byteSize ?${distributionSize} }
           OPTIONAL {
@@ -417,10 +419,11 @@ export const constructQuery = `
 function schemaOrgQuery(prefix: string): string {
   return `
     ?${dataset} a ${prefix}:Dataset ;
-      ${prefix}:name ?${name} ; 
-      ${prefix}:license ${normalizeLicense(license)} .
+      ${prefix}:name ?${name} .
 
-    OPTIONAL { 
+    OPTIONAL { ?${dataset} ${prefix}:license ${normalizeLicense(license)} }
+
+    OPTIONAL {
       ?${dataset} ${prefix}:creator ?${creator} .        
       ?${creator} a ?creatorTypeRaw ;
         ${prefix}:name ?${creatorName} .

--- a/packages/core/test/datasets/dataset-dcat-license-on-distribution.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-license-on-distribution.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "@type": "dcat:Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/license-on-distribution",
+  "dct:title": "Dataset with license only on distribution",
+  "dct:publisher": {
+    "@id": "https://example.com/publisher",
+    "@type": "foaf:Organization",
+    "foaf:name": "Example Publisher"
+  },
+  "dcat:distribution": {
+    "@type": "dcat:Distribution",
+    "dcat:accessURL": { "@id": "https://example.com/dataset.ttl" },
+    "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" }
+  }
+}

--- a/packages/core/test/datasets/dataset-dcat-literal-license.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-literal-license.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "@type": "dcat:Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/literal-license",
+  "dct:title": "Dataset with literal license",
+  "dct:license": "see distributions",
+  "dct:publisher": {
+    "@id": "https://example.com/publisher",
+    "@type": "foaf:Organization",
+    "foaf:name": "Example Publisher"
+  },
+  "dcat:distribution": {
+    "@type": "dcat:Distribution",
+    "dcat:accessURL": { "@id": "https://example.com/dataset.ttl" },
+    "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" }
+  }
+}

--- a/packages/core/test/datasets/dataset-dcat-valid-with-policy.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-valid-with-policy.jsonld
@@ -30,6 +30,9 @@
     "dcat:accessURL": {
       "@id": "http://example.com/sparql"
     },
+    "dct:license": {
+      "@id": "https://creativecommons.org/publicdomain/zero/1.0/"
+    },
     "odrl:hasPolicy": {
       "@type": "odrl:Offer",
       "odrl:profile": {

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -957,7 +957,7 @@ describe('Fetch', () => {
     );
   });
 
-  it('emits DCAT dataset whose license lives only on the distribution', async () => {
+  it('denormalizes distribution license onto a DCAT dataset that has none', async () => {
     const response = await file('dataset-dcat-license-on-distribution.jsonld');
     nock('https://example.com')
       .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
@@ -974,10 +974,15 @@ describe('Fetch', () => {
       'http://data.bibliotheken.nl/id/dataset/license-on-distribution',
     );
 
+    // Dataset has no own license; the distribution's CC0 is sampled onto it
+    // so query consumers can find the license at the dataset level.
     const datasetLicenses = [
       ...dataset.match(datasetUri, dct('license'), null),
     ];
-    expect(datasetLicenses).toHaveLength(0);
+    expect(datasetLicenses).toHaveLength(1);
+    expect(datasetLicenses[0].object.value).toBe(
+      'https://creativecommons.org/publicdomain/zero/1.0/',
+    );
 
     const distributionLicenses = [...dataset].filter(
       (quad) =>
@@ -990,10 +995,11 @@ describe('Fetch', () => {
     );
   });
 
-  it('ignores a literal dct:license on a DCAT dataset and emits the distribution license', async () => {
+  it('skips a literal dct:license on a DCAT dataset and samples one from distributions', async () => {
     // KB-style data: dataset has a free-text dct:license placeholder
     // ("see distributions") and the actual license lives on the distribution.
     // The DCAT branch must not crash on the literal and must not emit it.
+    // The distribution's CC0 is then sampled onto the dataset.
     const response = await file('dataset-dcat-literal-license.jsonld');
     nock('https://example.com')
       .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
@@ -1013,7 +1019,11 @@ describe('Fetch', () => {
     const datasetLicenses = [
       ...dataset.match(datasetUri, dct('license'), null),
     ];
-    expect(datasetLicenses).toHaveLength(0);
+    expect(datasetLicenses).toHaveLength(1);
+    expect(datasetLicenses[0].object.termType).toBe('NamedNode');
+    expect(datasetLicenses[0].object.value).toBe(
+      'https://creativecommons.org/publicdomain/zero/1.0/',
+    );
 
     const distributionLicenses = [...dataset].filter(
       (quad) =>

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -990,7 +990,10 @@ describe('Fetch', () => {
     );
   });
 
-  it('tolerates a literal dct:license value', async () => {
+  it('ignores a literal dct:license on a DCAT dataset and emits the distribution license', async () => {
+    // KB-style data: dataset has a free-text dct:license placeholder
+    // ("see distributions") and the actual license lives on the distribution.
+    // The DCAT branch must not crash on the literal and must not emit it.
     const response = await file('dataset-dcat-literal-license.jsonld');
     nock('https://example.com')
       .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
@@ -1010,9 +1013,7 @@ describe('Fetch', () => {
     const datasetLicenses = [
       ...dataset.match(datasetUri, dct('license'), null),
     ];
-    expect(datasetLicenses).toHaveLength(1);
-    expect(datasetLicenses[0].object.termType).toBe('Literal');
-    expect(datasetLicenses[0].object.value).toBe('see distributions');
+    expect(datasetLicenses).toHaveLength(0);
 
     const distributionLicenses = [...dataset].filter(
       (quad) =>

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -956,6 +956,74 @@ describe('Fetch', () => {
       ),
     );
   });
+
+  it('emits DCAT dataset whose license lives only on the distribution', async () => {
+    const response = await file('dataset-dcat-license-on-distribution.jsonld');
+    nock('https://example.com')
+      .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
+      .get('/dcat-license-on-distribution')
+      .reply(200, response);
+
+    const datasets = await fetchDatasetsAsArray(
+      new URL('https://example.com/dcat-license-on-distribution'),
+    );
+
+    expect(datasets).toHaveLength(1);
+    const dataset = datasets[0];
+    const datasetUri = factory.namedNode(
+      'http://data.bibliotheken.nl/id/dataset/license-on-distribution',
+    );
+
+    const datasetLicenses = [
+      ...dataset.match(datasetUri, dct('license'), null),
+    ];
+    expect(datasetLicenses).toHaveLength(0);
+
+    const distributionLicenses = [...dataset].filter(
+      (quad) =>
+        quad.predicate.equals(dct('license')) &&
+        !quad.subject.equals(datasetUri),
+    );
+    expect(distributionLicenses).toHaveLength(1);
+    expect(distributionLicenses[0].object.value).toBe(
+      'https://creativecommons.org/publicdomain/zero/1.0/',
+    );
+  });
+
+  it('tolerates a literal dct:license value', async () => {
+    const response = await file('dataset-dcat-literal-license.jsonld');
+    nock('https://example.com')
+      .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
+      .get('/dcat-literal-license')
+      .reply(200, response);
+
+    const datasets = await fetchDatasetsAsArray(
+      new URL('https://example.com/dcat-literal-license'),
+    );
+
+    expect(datasets).toHaveLength(1);
+    const dataset = datasets[0];
+    const datasetUri = factory.namedNode(
+      'http://data.bibliotheken.nl/id/dataset/literal-license',
+    );
+
+    const datasetLicenses = [
+      ...dataset.match(datasetUri, dct('license'), null),
+    ];
+    expect(datasetLicenses).toHaveLength(1);
+    expect(datasetLicenses[0].object.termType).toBe('Literal');
+    expect(datasetLicenses[0].object.value).toBe('see distributions');
+
+    const distributionLicenses = [...dataset].filter(
+      (quad) =>
+        quad.predicate.equals(dct('license')) &&
+        !quad.subject.equals(datasetUri),
+    );
+    expect(distributionLicenses).toHaveLength(1);
+    expect(distributionLicenses[0].object.value).toBe(
+      'https://creativecommons.org/publicdomain/zero/1.0/',
+    );
+  });
 });
 
 describe('discoverDatacatalog', () => {

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -649,6 +649,24 @@ describe('Validator', () => {
     expect(report.state).toEqual('valid');
   });
 
+  it('does not warn when dataset license is absent but distribution carries one', async () => {
+    // DCAT-AP-NL places license on the distribution. The dataset-level
+    // schema:license shape must not double-warn in that case; the
+    // DistributionLicenseRequiredShape covers the must-exist-somewhere rule.
+    const report = (await validate(
+      'dataset-dcat-license-on-distribution.jsonld',
+    )) as Valid;
+    expect(report.state).toEqual('valid');
+    const licenseResults = [
+      ...report.errors.match(
+        null,
+        shacl('resultPath'),
+        rdf.namedNode('https://schema.org/license'),
+      ),
+    ];
+    expect(licenseResults).toHaveLength(0);
+  });
+
   it('emits uniqueLang violation once per focus node, not once per shape', async () => {
     // Regression: Organization and Person shapes both targeted objects of
     // dct:publisher and dct:creator with identical foaf:name constraints, so

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -123,28 +123,30 @@ nde-dataset:DatasetShape
         ] ,
         [
             sh:path schema:license ;
-            sh:minCount 1 ;
-            sh:maxCount 1 ;
-            sh:severity sh:Warning ;
-            sh:description """Licentie die van toepassing is op de dataset.
-                Als de dataset een licentie heeft, wordt deze overgenomen door alle distributies die geen eigen licentie hebben."""@nl, """License applicable to the dataset. As a convenience, this license is inherited by all distributions that do not specify their own license. Publishers MUST make known under which <a href="https://www.w3.org/TR/dwbp/#licenses">license</a> the dataset may be used.
-
-This license specifies the conditions under which the metadata records in the dataset may be accessed and reused. It does not cover the heritage objects (either physical or digital) that the metadata describes. Access conditions for these objects should be specified in their own descriptions within the dataset.
-
-The DERA requires metadata to be published openly, so this value SHOULD be an open license that allows consumers to reuse the data, such as `https://creativecommons.org/publicdomain/zero/1.0/` (CC0), `https://creativecommons.org/licenses/by/4.0/` (CC BY 4.0), or `https://creativecommons.org/licenses/by-sa/4.0/` (CC BY-SA 4.0). Adopting a non-open license will severely limit reuse and does not comply with the DERA principles.
-
-The value MUST be the canonical URI of a license. For example, use `https://creativecommons.org/publicdomain/zero/1.0/` instead of `https://creativecommons.org/publicdomain/zero/1.0/deed.nl`."""@en ;
-            sh:message "Voeg één licentie toe"@nl, "Add one license"@en ;
-        ] ,
-        [
-            sh:path schema:license ;
             sh:nodeKind sh:IRIOrLiteral ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:nodeKind sh:IRI ;
             ] ;
             sh:severity sh:Warning ;
+            sh:description """Licentie die van toepassing is op de dataset. Als de dataset een licentie heeft, wordt deze overgenomen door alle distributies die geen eigen licentie hebben.
+
+Een licentie moet beschikbaar zijn op de distributie of op de dataset."""@nl, """License applicable to the dataset. If the dataset has a license, it is inherited by all distributions that do not specify their own license. Publishers MUST make known under which <a href="https://www.w3.org/TR/dwbp/#licenses">license</a> the dataset may be used.
+
+This license specifies the conditions under which the metadata records in the dataset may be accessed and reused. It does not cover the heritage objects (either physical or digital) that the metadata describes. Access conditions for these objects should be specified in their own descriptions within the dataset.
+
+A license must be available on either the distribution or the dataset.
+
+The DERA requires metadata to be published openly, so this value SHOULD be an open license that allows consumers to reuse the data, such as `https://creativecommons.org/publicdomain/zero/1.0/` (CC0), `https://creativecommons.org/licenses/by/4.0/` (CC BY 4.0), or `https://creativecommons.org/licenses/by-sa/4.0/` (CC BY-SA 4.0). Adopting a non-open license will severely limit reuse and does not comply with the DERA principles.
+
+The value MUST be the canonical URI of a license. For example, use `https://creativecommons.org/publicdomain/zero/1.0/` instead of `https://creativecommons.org/publicdomain/zero/1.0/deed.nl`."""@en ;
             sh:message "Gebruik een waarde van type URI (RDF-resource), geen tekst"@nl, "Use a value of type URI (RDF resource), not text"@en ;
+        ] ,
+        [
+            sh:path schema:license ;
+            sh:maxCount 1 ;
+            sh:severity sh:Warning ;
+            sh:message "Gebruik maximaal één licentie"@nl, "Use at most one license"@en ;
         ] ,
         [
             sh:path schema:license ;


### PR DESCRIPTION
## Summary

The register rejected datasets that follow DCAT-AP-NL — where `dct:license` belongs on the distribution, not the dataset — with a misleading **"No dataset found at URL …"** error. Concrete trigger:

```
https://data.bibliotheken.nl/sparql?query=CONSTRUCT%20%7B%20%3Fs%20%3Fp%20%3Fo%20.%20%7D%20WHERE%20%7B%20GRAPH%20%3Chttps%3A%2F%2Fdata.bibliotheken.nl%2Fdatasetbeschrijvingen%3E%20%7B%20%3Fs%20%3Fp%20%3Fo%20.%20%7D%20%7D
```

returns 16 valid `dcat:Dataset` resources, each carrying a real CC0 IRI on every distribution and only a free-text `dct:license "zie distributies"` placeholder on the dataset itself.

Root cause: the SPARQL CONSTRUCT required `dct:license` on the dataset *and* coerced it with `IRI(...)`. The literal crashed Comunica; the error surfaced as `NoDatasetFoundAtUrl`.

## Changes

- **`query.ts` — DCAT branch**: distribution license is required (matches DCAT-AP-NL and SHACL `sh:minCount 1` on `dcat:Distribution`). Dataset license is denormalized for the browser: prefer the publisher's own dataset license when it's an IRI, else `SAMPLE` one IRI license from the distributions. Literal placeholders are skipped via `BIND(IF(isIRI(...), IRI(...), ?unbound))` — a bare `FILTER` doesn't stop Comunica from eagerly evaluating `IRI()` on a literal.
- **`query.ts` — schema.org branch**: dataset license read via the same IRI-only gate. Literals are accepted as input (SHACL keeps `sh:IRIOrLiteral`) but no longer projected into the index as junk literals.
- **`literal.ts`**: new helper `bindIriLicense()` for the IF-gated IRI-only BIND; `normalizeLicense()` keeps its literal-tolerant behavior for distribution-level use.
- **`shacl.ttl`**: drop the dataset-level `sh:minCount 1` "Add one license" Warning on `schema:license`. `DistributionLicenseRequiredShape` continues to enforce license-must-exist-somewhere.
- **Tests**: two new fetch cases (denormalize-from-distribution; literal-license skipped and sampled) with fixtures; one new validator case; updated ODRL fixture to declare a distribution license.

## KB endpoint after the fix

16 datasets emit. Each dataset and each of its 32 distributions carries CC0 in the index, so the browser shows the license at the dataset level just like it does for schema.org publishers.
