### PR TITLE
fix(core): drop URI-shaped values from dcat:keyword projection

### DIFF
--- a/packages/core/src/literal.ts
+++ b/packages/core/src/literal.ts
@@ -109,13 +109,3 @@ export const compressFormatFromMediaType = (
     ) AS ?${compressFormatVariable}
   )`;
 
-/**
- * Convert URI keywords to string literals while preserving language-tagged literals.
- *
- * Some datasets use URIs as keywords (e.g., SKOS Concepts) while others use
- * language-tagged literals. This normalizes URIs to string literals so they
- * can be processed uniformly, while preserving language tags on literals.
- */
-export const convertUriToLiteral = (variable: string) =>
-  `?${variable}Raw ;
-        BIND(IF(isIRI(?${variable}Raw), STR(?${variable}Raw), ?${variable}Raw) AS ?${variable})`;

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -174,8 +174,8 @@ function schemaOrgMultiValuedUnions(prefix: string): string {
     multiValuedUnion(
       type,
       `${prefix}:keywords`,
-      `${keyword}Raw`,
-      `BIND(IF(isIRI(?${keyword}Raw), STR(?${keyword}Raw), ?${keyword}Raw) AS ?${keyword})`,
+      keyword,
+      `FILTER(!REGEX(STR(?${keyword}), "^https?://"))`,
     ),
     multiValuedUnion(
       type,
@@ -206,8 +206,8 @@ function dcatMultiValuedUnions(): string {
     multiValuedUnion(
       type,
       `dcat:keyword`,
-      `${keyword}Raw`,
-      `BIND(IF(isIRI(?${keyword}Raw), STR(?${keyword}Raw), ?${keyword}Raw) AS ?${keyword})`,
+      keyword,
+      `FILTER(!REGEX(STR(?${keyword}), "^https?://"))`,
     ),
     multiValuedUnion(
       type,

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -443,6 +443,28 @@ describe('Fetch', () => {
     expect((literalTheme?.object as Literal).language).toEqual('nl');
   });
 
+  it('drops URI-shaped schema:keywords from dcat:keyword output', async () => {
+    const response = await file('dataset-schema-org-keyword-uri.jsonld');
+    nock('http://data.bibliotheken.nl')
+      .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
+      .get('/id/dataset/keyword-uri')
+      .reply(200, response);
+
+    const datasets = await fetchDatasetsAsArray(
+      new URL('http://data.bibliotheken.nl/id/dataset/keyword-uri'),
+    );
+
+    expect(datasets).toHaveLength(1);
+    const dataset = datasets[0];
+    const datasetUri = factory.namedNode(
+      'http://data.bibliotheken.nl/id/dataset/keyword-uri',
+    );
+    const keywordValues = [
+      ...dataset.match(datasetUri, dcat('keyword'), null),
+    ].map((quad) => quad.object.value);
+    expect(keywordValues).toEqual(['photographs']);
+  });
+
   it('preserves user-provided themes alongside default EDUC theme', async () => {
     const response = await file('dataset-dcat-valid-minimal.jsonld');
     const datasetWithTheme = response.replace(


### PR DESCRIPTION
## Summary
- `dcat:keyword` is meant for free-text labels; SHACL already warns when `schema:keywords` contains an `http(s)://` value and is set to escalate that warning to a violation at requirements v2.
- The CONSTRUCT query, however, stringified URI-typed keywords (via `STR(?keywordRaw)`) and passed them through as `dcat:keyword` literals. The browser then rendered naked URLs as keyword chips alongside genuine free-text keywords (e.g. on `https://datasetregister.netwerkdigitaalerfgoed.nl/datasets/https://n2t.net/ark:/11978/dataset`).
- Replace the URI-to-literal BIND with a `FILTER(!REGEX(STR(?keyword), "^https?://"))` on both the schema.org and DCAT branches so URI-shaped keywords never reach the published graph. The unused `convertUriToLiteral` helper is removed.

## Test plan
- [x] `npx nx test @dataset-register/core` (186 pass; the unrelated `sparql.test.ts` suite is skipped locally because it needs Docker)
- [x] `npx nx lint @dataset-register/core`
- [x] `npx nx typecheck @dataset-register/core`
- [x] New `fetch.test.ts` case asserts the existing `dataset-schema-org-keyword-uri.jsonld` fixture projects only `photographs` (not the Getty URI) to `dcat:keyword`