### PR TITLE
docs(requirements): label v2.0 changes for sh:or and sh:not shapes

### DIFF
--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -119,6 +119,22 @@
                         {% assign future_text = property.datatype | replace: 'http://www.w3.org/2001/XMLSchema#', 'xsd:' | replace: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'rdf:' | prepend: 'must be ' -%}
                     {% elsif change.severity == "Violation" and is_date_shape -%}
                         {% assign future_text = "must be valid ISO 8601" -%}
+                    {% elsif change.severity == "Violation" and property.or -%}
+                        {%- assign has_iri_alt = false -%}
+                        {%- assign has_date_alt = false -%}
+                        {%- for alt in property.or -%}
+                            {%- if alt.nodeKind == "IRI" -%}{%- assign has_iri_alt = true -%}{%- endif -%}
+                            {%- assign alt_pattern = alt.pattern | default: "" -%}
+                            {%- if alt_pattern contains "{4}" -%}{%- assign has_date_alt = true -%}{%- endif -%}
+                        {%- endfor -%}
+                        {%- if has_iri_alt and has_date_alt -%}
+                            {% assign future_text = "must be valid ISO 8601 or IRI" -%}
+                        {%- endif -%}
+                    {% elsif change.severity == "Violation" and property.not.pattern -%}
+                        {%- assign not_pattern = property.not.pattern -%}
+                        {%- if not_pattern contains "https?" or not_pattern contains "http" -%}
+                            {% assign future_text = "IRIs not allowed" -%}
+                        {%- endif -%}
                     {% elsif change.severity == "Violation" and is_required == false -%}
                         {% assign future_text = "becomes required" -%}
                     {% endif -%}


### PR DESCRIPTION
## Summary

The spec table’s `v2.0:` hints come from `requirements/attributes.liquid`. Its futureChange decision tree only handled shapes whose constraint sits directly on the property (`pattern`, `nodeKind`, `datatype`, `maxCount`). Two real cases fell through:

- `schema:temporalCoverage` — constraint lives inside `sh:or` (IRI alt + ISO 8601 regex alt). The template hit the catch‑all and rendered `v2.0: becomes required`, which is wrong — `sh:minCount` stays at `sh:Info`; only the *format* becomes a violation in v2.0.
- `schema:keywords` — constraint is `sh:not [ sh:pattern "^https?://" ]`. No branch matched, so no v2.0 hint rendered at all.

This PR adds two branches to the cascade (placed before the `becomes required` fallback):

- `sh:or` containing an IRI alternative + a date‑shaped pattern → `must be valid ISO 8601 or IRI`
- `sh:not` with a URI‑shaped pattern → `IRIs not allowed`

Label wording follows the spec’s existing conventions: `IRI` (50 occurrences in the rendered HTML vs 15 for `URI`) and `must be valid ISO 8601` (already used by date shapes).

After regeneration:

| Property | Before | After |
|---|---|---|
| `schema:keywords` | *(no v2.0 note)* | `v2.0: IRIs not allowed` |
| `schema:spatialCoverage` | `v2.0: must be IRI` | unchanged |
| `schema:temporalCoverage` | `v2.0: becomes required` | `v2.0: must be valid ISO 8601 or IRI` |

`requirements/index.bs` and `requirements/index.html` are gitignored generated artifacts; only the template is tracked.
