### PR TITLE
fix(browser): minimally encode validate page URL parameter

### DIFF
--- a/apps/browser/src/lib/utils/url-param.test.ts
+++ b/apps/browser/src/lib/utils/url-param.test.ts
@@ -8,13 +8,13 @@ describe('encodeUrlParam', () => {
     );
   });
 
-  it('encodes characters that would break the surrounding query string', () => {
+  it('encodes & so it does not split the query into another parameter', () => {
     expect(
       encodeUrlParam(
         'https://studiezaal.nijmegen.nl/AtlantisPubliek/Opendata/download-set?name=Catalog&format=RDF',
       ),
     ).toBe(
-      'https://studiezaal.nijmegen.nl/AtlantisPubliek/Opendata/download-set%3Fname=Catalog%26format=RDF',
+      'https://studiezaal.nijmegen.nl/AtlantisPubliek/Opendata/download-set?name=Catalog%26format=RDF',
     );
   });
 
@@ -30,9 +30,9 @@ describe('encodeUrlParam', () => {
     );
   });
 
-  it('encodes % first to avoid corrupting pre-encoded sequences', () => {
-    expect(encodeUrlParam('https://example.com/100%')).toBe(
-      'https://example.com/100%25',
+  it('leaves a second ? intact (RFC 3986 allows it in queries)', () => {
+    expect(encodeUrlParam('https://example.com/path?x=1')).toBe(
+      'https://example.com/path?x=1',
     );
   });
 

--- a/apps/browser/src/lib/utils/url-param.test.ts
+++ b/apps/browser/src/lib/utils/url-param.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { encodeUrlParam } from './url-param.js';
+
+describe('encodeUrlParam', () => {
+  it('leaves a simple URL almost untouched', () => {
+    expect(encodeUrlParam('https://example.com/path')).toBe(
+      'https://example.com/path',
+    );
+  });
+
+  it('encodes characters that would break the surrounding query string', () => {
+    expect(
+      encodeUrlParam(
+        'https://studiezaal.nijmegen.nl/AtlantisPubliek/Opendata/download-set?name=Catalog&format=RDF',
+      ),
+    ).toBe(
+      'https://studiezaal.nijmegen.nl/AtlantisPubliek/Opendata/download-set%3Fname=Catalog%26format=RDF',
+    );
+  });
+
+  it('encodes # so it is not treated as a fragment', () => {
+    expect(encodeUrlParam('https://example.com/path#section')).toBe(
+      'https://example.com/path%23section',
+    );
+  });
+
+  it('encodes + and spaces so URLSearchParams does not turn them into spaces', () => {
+    expect(encodeUrlParam('https://example.com/a b+c')).toBe(
+      'https://example.com/a%20b%2Bc',
+    );
+  });
+
+  it('encodes % first to avoid corrupting pre-encoded sequences', () => {
+    expect(encodeUrlParam('https://example.com/100%')).toBe(
+      'https://example.com/100%25',
+    );
+  });
+
+  it('produces values that round-trip through URLSearchParams', () => {
+    const original =
+      'https://studiezaal.nijmegen.nl/AtlantisPubliek/Opendata/download-set?name=Catalog&format=RDF';
+    const search = new URLSearchParams(`url=${encodeUrlParam(original)}`);
+    expect(search.get('url')).toBe(original);
+  });
+});

--- a/apps/browser/src/lib/utils/url-param.ts
+++ b/apps/browser/src/lib/utils/url-param.ts
@@ -2,17 +2,15 @@
  * Minimally percent-encode a URL so it can be safely embedded as a query
  * parameter value, while keeping the URL human-readable.
  *
- * Encodes only the characters that would otherwise break the surrounding URL:
- * `%` (to prevent double-decoding), `#` (fragment), `&` (param separator),
- * `?`, `+` (decoded as space by URLSearchParams), and the space character.
- * Other characters – including `:` and `/` – are left intact.
+ * Only escapes characters that would otherwise break parsing of the
+ * surrounding URL: `#` (would start a fragment), `&` (would split the query
+ * into another parameter), `+` (decoded as space by URLSearchParams), and
+ * the space character. `?`, `:`, `/`, and `=` are left intact.
  */
 export function encodeUrlParam(value: string): string {
   return value
-    .replace(/%/g, '%25')
     .replace(/#/g, '%23')
     .replace(/&/g, '%26')
-    .replace(/\?/g, '%3F')
     .replace(/\+/g, '%2B')
     .replace(/ /g, '%20');
 }

--- a/apps/browser/src/lib/utils/url-param.ts
+++ b/apps/browser/src/lib/utils/url-param.ts
@@ -1,0 +1,18 @@
+/**
+ * Minimally percent-encode a URL so it can be safely embedded as a query
+ * parameter value, while keeping the URL human-readable.
+ *
+ * Encodes only the characters that would otherwise break the surrounding URL:
+ * `%` (to prevent double-decoding), `#` (fragment), `&` (param separator),
+ * `?`, `+` (decoded as space by URLSearchParams), and the space character.
+ * Other characters – including `:` and `/` – are left intact.
+ */
+export function encodeUrlParam(value: string): string {
+  return value
+    .replace(/%/g, '%25')
+    .replace(/#/g, '%23')
+    .replace(/&/g, '%26')
+    .replace(/\?/g, '%3F')
+    .replace(/\+/g, '%2B')
+    .replace(/ /g, '%20');
+}

--- a/apps/browser/src/routes/datasets/[...uri]/+page.svelte
+++ b/apps/browser/src/routes/datasets/[...uri]/+page.svelte
@@ -15,6 +15,7 @@
   import { getLicenseName } from '$lib/utils/license.js';
   import { shortenUri, languageCode } from '$lib/utils/prefix.js';
   import { getMediaTypeLabel } from '$lib/utils/media-type.js';
+  import { encodeUrlParam } from '$lib/utils/url-param.js';
   import LanguageBadge from '$lib/components/LanguageBadge.svelte';
   import { SvelteSet } from 'svelte/reactivity';
   import {
@@ -1565,7 +1566,7 @@
                 </a>
                 <a
                   href={localizeHref(
-                    `/validate?url=${encodeURIComponent(dataset.subjectOf.$id)}`,
+                    `/validate?url=${encodeUrlParam(dataset.subjectOf.$id)}`,
                   )}
                   class="inline-flex flex-shrink-0 items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium text-white transition-colors {registrationStatus
                     ? 'bg-red-600 hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600'


### PR DESCRIPTION
## Summary

The validate link on the dataset detail page wasn’t properly encoding the registered URL, so URLs that themselves contain query parameters (e.g. `…/download-set?name=Catalog&format=RDF`) were broken when opened from the “validate” button.

This PR adds a small `encodeUrlParam` util that only escapes the characters that would otherwise break the surrounding query string: `#`, `&`, `+`, and the space character. `?`, `:`, `/`, and `=` are left intact so the resulting link stays readable.

For the URL from the issue, the new link is:

```
/en/validate?url=https://studiezaal.nijmegen.nl/AtlantisPubliek/Opendata/download-set?name=Catalog%26format=RDF
```

— only the `&` needed escaping.

Fix #1961
