### PR TITLE
fix: scope schema:name description to the matching shape

### DIFF
--- a/apps/browser/src/lib/services/shacl-shapes.ts
+++ b/apps/browser/src/lib/services/shacl-shapes.ts
@@ -40,10 +40,12 @@ export function fetchShapes(signal?: AbortSignal): Promise<ShapesIndex> {
 
 /**
  * Given a path IRI and the focusNode's rdf:type (optional), pick the best
- * matching shape. Prefers a direct hit by `sh:sourceShape` IRI, then
- * `sh:targetClass` match; when multiple shapes share a path we pick the
- * first one carrying a `sh:description`, since that description applies to
- * the property as a whole regardless of which specific constraint failed.
+ * matching shape. Prefers a direct hit by `sh:sourceShape` IRI, then a class
+ * match against the focus node's type. When focusNodeType is known we never
+ * fall back across siblings: descriptions on `schema:name` (and similar
+ * shared paths) belong to a specific class, and inheriting one from another
+ * NodeShape would mislead the reader – e.g. the data-catalog description
+ * surfacing on a contact-point validation result.
  */
 export function selectShape(
   index: ShapesIndex,
@@ -59,13 +61,9 @@ export function selectShape(
   const candidates = index.byPath.get(pathIri);
   if (!candidates?.length) return undefined;
   if (focusNodeType) {
-    const matching = candidates.find((c) => c.targetClass === focusNodeType);
-    if (matching) return matching;
+    return candidates.find((c) => c.targetClass === focusNodeType);
   }
   if (candidates.length === 1) return candidates[0];
-  // Multiple property shapes share this path (different constraints on the
-  // same property). The generic property description is shared across them,
-  // so pick the first candidate that actually carries one.
   return candidates.find((c) => c.description) ?? undefined;
 }
 
@@ -84,7 +82,8 @@ function indexShapes(json: unknown, locale: string): ShapesIndex {
     const types = node['@type'];
     if (!Array.isArray(types) || !types.includes(`${SH}NodeShape`)) continue;
 
-    const targetClass = pickIri(node[`${SH}targetClass`]);
+    const targetClass =
+      pickIri(node[`${SH}targetClass`]) ?? pickIri(node[`${SH}class`]);
     const propertyRefs = node[`${SH}property`];
     if (!Array.isArray(propertyRefs)) continue;
 

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -990,6 +990,7 @@ nde-dataset:ContactPointShape
     sh:property [
         sh:path schema:name ;
         sh:minCount 1 ;
+        sh:description "Naam van het contactpunt, bij voorkeur een afdeling (“Afdeling datasets”) in plaats van een individuele medewerker. Geef de waarde een taaltag, zodat een meertalige afdelingsnaam of een niet-Latijnse persoonsnaam in de juiste taal getoond kan worden."@nl, "Name of the contact point, preferably a department (“Datasets department”) rather than an individual employee. Tag the value with a language so that a multilingual department name or a non-Latin personal name can be shown in the appropriate language."@en ;
         sh:message "Vul een naam in voor het contactpunt"@nl, "Enter a name for the contact point"@en ;
     ] ,
     [


### PR DESCRIPTION
## Summary

A publisher reported that the validate page surfaced a misleading description on a `schema:ContactPoint` `schema:name` warning:

> schema:name · Naam van de datacatalogus
> Waarde: Joost Dofferhoff

The langString warning itself is intentional and stays — department names are often multilingual (“Afdeling datasets” / “Datasets department”) and personal names can be non-Latin, both of which benefit from a language tag. The bug is the description label, which belonged to a different shape entirely.

## Changes

- **`requirements/shacl.ttl`**: add a bilingual `sh:description` to the `minCount` property shape inside `nde-dataset:ContactPointShape` (per `requirements/AGENTS.md`, descriptions live on the main shape). The text now reflects the contactPoint context and spells out the rationale for the language tag.
- **`apps/browser/src/lib/services/shacl-shapes.ts`**: fix `selectShape` so a known `focusNodeType` never falls back across sibling shapes. Previously, when no candidate matched the focus class, the resolver returned the first candidate carrying any description — pulling the DataCatalog description onto a ContactPoint result. The indexer now reads `sh:class` in addition to `sh:targetClass` (the `DatacatalogShape` declares its class via `sh:class`), so DataCatalog is correctly excluded for non-DataCatalog focus types.

After this change, a contactPoint name warning shows no inherited description rather than a wrong one. A follow-up could teach the resolver to associate ContactPoint shapes with their focus class via `sh:targetObjectsOf`, but that is out of scope here.
