### PR TITLE
fix(validate): surface the underlying fetch error when a URL can't be loaded

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -7,6 +7,7 @@ import fastify, {
 import bearerAuth from '@fastify/bearer-auth';
 import {
   AllowedRegistrationDomainStore,
+  CouldNotFetchUrl,
   DatasetStore,
   dereference,
   discoverDatacatalog,
@@ -121,6 +122,12 @@ export async function server(
             statusCode: e.statusCode === 404 ? 404 : 406,
           }),
         );
+        return null;
+      }
+
+      if (e instanceof CouldNotFetchUrl) {
+        reply.log.info(`Could not fetch URL ${url.toString()}: ${e.message}`);
+        await reply.sendHydraError(Object.assign(e, { statusCode: 502 }));
         return null;
       }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -7,7 +7,6 @@ import fastify, {
 import bearerAuth from '@fastify/bearer-auth';
 import {
   AllowedRegistrationDomainStore,
-  CouldNotFetchUrl,
   DatasetStore,
   dereference,
   discoverDatacatalog,
@@ -125,16 +124,8 @@ export async function server(
         return null;
       }
 
-      if (e instanceof CouldNotFetchUrl) {
-        reply.log.info(`Could not fetch URL ${url.toString()}: ${e.message}`);
-        await reply.sendHydraError(Object.assign(e, { statusCode: 502 }));
-        return null;
-      }
-
       if (e instanceof FetchError) {
-        reply.log.info(
-          `No dataset found at URL ${url.toString()}: ${e.message}`,
-        );
+        reply.log.info(`Error at URL ${url.toString()}: ${e.message}`);
         await reply.sendHydraError(Object.assign(e, { statusCode: 406 }));
         return null;
       }

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -134,7 +134,7 @@ describe('Server', () => {
     expect(response.statusCode).toEqual(200);
   });
 
-  it('returns 502 when the URL cannot be fetched (e.g. redirect loop)', async () => {
+  it('surfaces the fetch reason when the URL cannot be fetched (e.g. redirect loop)', async () => {
     const wrapped = new TypeError('fetch failed', {
       cause: new Error('redirect count exceeded'),
     });
@@ -147,7 +147,7 @@ describe('Server', () => {
         '@id': 'https://example.com/loop',
       }),
     });
-    expect(response.statusCode).toEqual(502);
+    expect(response.statusCode).toEqual(406);
     expect(response.json()['title']).toContain(
       'Could not fetch URL https://example.com/loop',
     );

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -134,6 +134,26 @@ describe('Server', () => {
     expect(response.statusCode).toEqual(200);
   });
 
+  it('returns 502 when the URL cannot be fetched (e.g. redirect loop)', async () => {
+    const wrapped = new TypeError('fetch failed', {
+      cause: new Error('redirect count exceeded'),
+    });
+    nock('https://example.com/').get('/loop').replyWithError(wrapped);
+    const response = await httpServer.inject({
+      method: 'PUT',
+      url: '/datasets/validate',
+      headers: { 'Content-Type': 'application/ld+json' },
+      payload: JSON.stringify({
+        '@id': 'https://example.com/loop',
+      }),
+    });
+    expect(response.statusCode).toEqual(502);
+    expect(response.json()['title']).toContain(
+      'Could not fetch URL https://example.com/loop',
+    );
+    expect(response.json()['description']).toContain('redirect count exceeded');
+  });
+
   it('rejects validation requests that point to URL with invalid Content-Type', async () => {
     nock('https://example.com/')
       .get('/invalid-content-type')

--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -16,10 +16,10 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
       thresholds: {
         autoUpdate: true,
-        lines: 97.08,
+        lines: 97.19,
         functions: 100,
-        branches: 83.33,
-        statements: 97.08,
+        branches: 84,
+        statements: 97.19,
       },
     },
   },

--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -16,10 +16,10 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
       thresholds: {
         autoUpdate: true,
-        lines: 97.19,
+        lines: 97.08,
         functions: 100,
-        branches: 84,
-        statements: 97.19,
+        branches: 83.33,
+        statements: 97.08,
       },
     },
   },

--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -256,6 +256,8 @@
   "validate_result_not_found_body": "The Dataset Register couldn’t resolve this URL. Check that it is publicly reachable and returns a dataset description.",
   "validate_result_no_dataset_title": "No datasets found at URL",
   "validate_result_no_dataset_body": "The URL resolves, but no schema:Dataset or dcat:Dataset was found. See the requirements for details.",
+  "validate_result_fetch_failed_title": "Couldn’t fetch the URL",
+  "validate_result_fetch_failed_body": "The Dataset Register couldn’t fetch this URL. Check that it is publicly reachable and serves RDF (for example via content negotiation for application/ld+json or text/turtle).",
   "validate_summary_valid": "Valid",
   "validate_summary_valid_body": "Your dataset description meets the requirements.",
   "validate_summary_submit_cta": "Submit to the Dataset Register",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -256,6 +256,8 @@
   "validate_result_not_found_body": "Het Datasetregister kan deze URL niet ophalen. Controleer of deze publiek bereikbaar is en een datasetbeschrijving teruggeeft.",
   "validate_result_no_dataset_title": "Geen datasets gevonden op URL",
   "validate_result_no_dataset_body": "De URL is bereikbaar, maar bevat geen schema:Dataset of dcat:Dataset. Zie de requirements voor details.",
+  "validate_result_fetch_failed_title": "Kan URL niet ophalen",
+  "validate_result_fetch_failed_body": "Het Datasetregister kan deze URL niet ophalen. Controleer of de URL publiek bereikbaar is en RDF teruggeeft (bijvoorbeeld via content negotiation voor application/ld+json of text/turtle).",
   "validate_summary_valid": "Geldig",
   "validate_summary_valid_body": "Je datasetbeschrijving voldoet aan de vereisten.",
   "validate_summary_submit_cta": "Aanmelden bij het Dataset Register",

--- a/apps/browser/src/lib/components/validation/ValidationSummary.svelte
+++ b/apps/browser/src/lib/components/validation/ValidationSummary.svelte
@@ -19,6 +19,7 @@
       | { kind: 'parse-error'; message: string }
       | { kind: 'not-found'; details?: ApiErrorDetails }
       | { kind: 'no-dataset'; details?: ApiErrorDetails }
+      | { kind: 'fetch-failed'; details?: ApiErrorDetails }
       | { kind: 'error'; message: string };
     submitHref?: string;
     onExpand?: (section: 'warnings' | 'infos') => void;
@@ -152,6 +153,14 @@
     <p class="mt-1 text-sm">
       {state.details?.description ?? m.validate_result_no_dataset_body()}
     </p>
+  {:else if state.kind === 'fetch-failed'}
+    <span class="font-semibold">{m.validate_result_fetch_failed_title()}</span>
+    <p class="mt-1 text-sm">{m.validate_result_fetch_failed_body()}</p>
+    {#if state.details?.description}
+      <p class="mt-1 font-mono text-sm break-words">
+        {state.details.description}
+      </p>
+    {/if}
   {:else if state.kind === 'error'}
     <span class="font-semibold">{m.validate_parse_failed_title()}</span>
     <p class="mt-1 text-sm">{state.message}</p>

--- a/apps/browser/src/lib/services/validation.ts
+++ b/apps/browser/src/lib/services/validation.ts
@@ -1,4 +1,5 @@
 import { PUBLIC_API_ENDPOINT } from '$env/static/public';
+import { COULD_NOT_FETCH_URL_PREFIX } from '@dataset-register/core/constants';
 import { parseShaclReport, type ShaclReport } from './shacl-report.js';
 
 export interface ApiErrorDetails {
@@ -37,10 +38,11 @@ export async function validateByUrl(
     return { kind: 'not-found', details: await readHydraError(response) };
   }
   if (response.status === 406) {
-    return { kind: 'no-dataset', details: await readHydraError(response) };
-  }
-  if (response.status === 502) {
-    return { kind: 'fetch-failed', details: await readHydraError(response) };
+    const details = await readHydraError(response);
+    if (details?.title?.startsWith(COULD_NOT_FETCH_URL_PREFIX)) {
+      return { kind: 'fetch-failed', details };
+    }
+    return { kind: 'no-dataset', details };
   }
   if (response.status === 200 || response.status === 400) {
     const json = await response.json();

--- a/apps/browser/src/lib/services/validation.ts
+++ b/apps/browser/src/lib/services/validation.ts
@@ -10,6 +10,7 @@ export type UrlValidationOutcome =
   | { kind: 'report'; report: ShaclReport }
   | { kind: 'not-found'; details?: ApiErrorDetails }
   | { kind: 'no-dataset'; details?: ApiErrorDetails }
+  | { kind: 'fetch-failed'; details?: ApiErrorDetails }
   | { kind: 'error'; message: string };
 
 export type InlineValidationOutcome =
@@ -37,6 +38,9 @@ export async function validateByUrl(
   }
   if (response.status === 406) {
     return { kind: 'no-dataset', details: await readHydraError(response) };
+  }
+  if (response.status === 502) {
+    return { kind: 'fetch-failed', details: await readHydraError(response) };
   }
   if (response.status === 200 || response.status === 400) {
     const json = await response.json();

--- a/apps/browser/src/routes/validate/+page.svelte
+++ b/apps/browser/src/routes/validate/+page.svelte
@@ -28,6 +28,7 @@
     | { kind: 'parse-error'; message: string }
     | { kind: 'not-found'; details?: ApiErrorDetails }
     | { kind: 'no-dataset'; details?: ApiErrorDetails }
+    | { kind: 'fetch-failed'; details?: ApiErrorDetails }
     | { kind: 'error'; message: string };
 
   let summaryState = $state<SummaryState>({ kind: 'empty' });
@@ -116,6 +117,8 @@
       summaryState = { kind: 'not-found', details: outcome.details };
     } else if (outcome.kind === 'no-dataset') {
       summaryState = { kind: 'no-dataset', details: outcome.details };
+    } else if (outcome.kind === 'fetch-failed') {
+      summaryState = { kind: 'fetch-failed', details: outcome.details };
     } else {
       summaryState = { kind: 'error', message: outcome.message };
     }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,2 +1,4 @@
 export const REGISTRATION_STATUS_BASE_URI =
   'https://data.netwerkdigitaalerfgoed.nl/registry/';
+
+export const COULD_NOT_FETCH_URL_PREFIX = 'Could not fetch URL';

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -32,6 +32,14 @@ export class NoDatasetFoundAtUrl extends FetchError {
   }
 }
 
+export class CouldNotFetchUrl extends FetchError {
+  constructor(url: URL, reason: string) {
+    super(`Could not fetch URL ${url.toString()}: ${reason}`, {
+      cause: `Could not fetch ${url.toString()}: ${reason}. Please check that the URL is publicly reachable and returns RDF.`,
+    });
+  }
+}
+
 export class InvalidContentType extends FetchError {
   constructor(url: URL, mediaType: string) {
     super(`Invalid Content-Type at ${url.toString()}`, {
@@ -163,10 +171,26 @@ function handleComunicaError(e: unknown, url: URL): never {
       throw new InvalidContentType(url, mediaTypeMatch[1]);
     }
 
+    if (e.cause instanceof Error) {
+      throw new CouldNotFetchUrl(url, deepestErrorMessage(e));
+    }
     throw new NoDatasetFoundAtUrl(url, e.message);
   }
 
   throw e;
+}
+
+function deepestErrorMessage(error: Error): string {
+  let current: unknown = error;
+  let message = error.message;
+  for (let depth = 0; depth < 10; depth++) {
+    if (!(current instanceof Error) || current.cause === undefined) break;
+    current = current.cause;
+    if (current instanceof Error && current.message) {
+      message = current.message;
+    }
+  }
+  return message;
 }
 
 const HYDRA = 'http://www.w3.org/ns/hydra/core#';

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -1,6 +1,7 @@
 import { QueryEngine } from '@comunica/query-sparql';
 import factory from 'rdf-ext';
 import { Store } from 'n3';
+import { COULD_NOT_FETCH_URL_PREFIX } from './constants.ts';
 import { constructQuery, dcat, rdf } from './query.ts';
 import { pipeline } from 'node:stream';
 import {
@@ -34,8 +35,8 @@ export class NoDatasetFoundAtUrl extends FetchError {
 
 export class CouldNotFetchUrl extends FetchError {
   constructor(url: URL, reason: string) {
-    super(`Could not fetch URL ${url.toString()}: ${reason}`, {
-      cause: `Could not fetch ${url.toString()}: ${reason}. Please check that the URL is publicly reachable and returns RDF.`,
+    super(`${COULD_NOT_FETCH_URL_PREFIX} ${url.toString()}: ${reason}`, {
+      cause: `${reason}. Please check that the URL is publicly reachable and returns RDF.`,
     });
   }
 }

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -1,5 +1,6 @@
 import { URL } from 'url';
 import {
+  CouldNotFetchUrl,
   dereference as fetchDereference,
   discoverDatacatalog,
   fetch,
@@ -904,6 +905,21 @@ describe('Fetch', () => {
     await expect(
       fetchDatasetsAsArray(new URL('https://example.com/200')),
     ).rejects.toThrow(NoDatasetFoundAtUrl);
+  });
+
+  it('surfaces the underlying fetch cause in the error message', async () => {
+    const wrapped = new TypeError('fetch failed', {
+      cause: new Error('redirect count exceeded'),
+    });
+    nock('https://example.com').get('/loop').replyWithError(wrapped);
+
+    expect.assertions(2);
+    try {
+      await fetchDatasetsAsArray(new URL('https://example.com/loop'));
+    } catch (e) {
+      expect(e).toBeInstanceOf(CouldNotFetchUrl);
+      expect((e as Error).cause).toMatch(/redirect count exceeded/);
+    }
   });
 
   it('handles paginated JSON-LD responses', async () => {


### PR DESCRIPTION
## Summary

When the validate-by-URL flow couldn’t reach the target server (e.g. an infinite redirect, DNS failure, TLS error), users saw a misleading message:

> The provided URL does not contain either a schema:Dataset or a dcat:Dataset: fetch failed. Please ensure your submitted URL includes at least one dataset description.

“fetch failed” was Node’s generic outer message; the actual reason (e.g. “redirect count exceeded”) lives on `error.cause`. And the “URL does not contain a dataset” framing is wrong when the problem is network-level – nothing was fetched at all.

This change separates real fetch failures from “fetched OK, but no dataset”:

- **`packages/core/src/fetch.ts`** — new `CouldNotFetchUrl` error class. `handleComunicaError` walks the `.cause` chain and throws `CouldNotFetchUrl(url, deepestErrorMessage(e))` when there is a native Error cause; otherwise still throws `NoDatasetFoundAtUrl`. The deepest message (“redirect count exceeded”, “getaddrinfo ENOTFOUND …”, “unable to verify the first certificate”, etc.) is what propagates to the user.
- **`packages/core/src/constants.ts`** — exports `COULD_NOT_FETCH_URL_PREFIX` so both API (via the error class) and browser (via title matching) share the same stable string.
- **`apps/api/src/server.ts`** — `CouldNotFetchUrl` flows through the existing `FetchError` → 406 path (same status as `NoDatasetFoundAtUrl` and `InvalidContentType`), so monitoring counters aren’t affected. The Hydra `title` carries the discriminator.
- **`apps/browser`** — new `fetch-failed` outcome rendered when the 406 response’s Hydra `title` starts with `COULD_NOT_FETCH_URL_PREFIX`. Localized title + body (en + nl) in `ValidationSummary.svelte`; the API’s raw description is shown as a small monospace detail line so the underlying reason is still visible.

Triggered while looking at `https://collectie.huisvanhilde.nl/nde/datacatalog.html`, whose server 303-redirects every RDF `Accept` back to `/`, which then 303s back to the same URL – Node’s fetch hits the redirect cap and throws.

## Notes

- Added an API server test that injects a `TypeError('fetch failed', { cause: Error('redirect count exceeded') })` via `nock.replyWithError` and asserts a 406 with the cause surfaced in the Hydra `description`.
