### PR TITLE
fix(browser): show only the bare fetch reason in the validate detail

### DIFF
--- a/apps/browser/src/lib/components/validation/ValidationSummary.svelte
+++ b/apps/browser/src/lib/components/validation/ValidationSummary.svelte
@@ -9,7 +9,10 @@
     resultGroupKey,
     type ShaclReport,
   } from '$lib/services/shacl-report.js';
-  import type { ApiErrorDetails } from '$lib/services/validation.js';
+  import {
+    fetchErrorReason,
+    type ApiErrorDetails,
+  } from '$lib/services/validation.js';
 
   interface Props {
     state:
@@ -154,12 +157,11 @@
       {state.details?.description ?? m.validate_result_no_dataset_body()}
     </p>
   {:else if state.kind === 'fetch-failed'}
+    {@const reason = fetchErrorReason(state.details?.title)}
     <span class="font-semibold">{m.validate_result_fetch_failed_title()}</span>
     <p class="mt-1 text-sm">{m.validate_result_fetch_failed_body()}</p>
-    {#if state.details?.description}
-      <p class="mt-1 font-mono text-sm break-words">
-        {state.details.description}
-      </p>
+    {#if reason}
+      <p class="mt-1 font-mono text-sm break-words">{reason}</p>
     {/if}
   {:else if state.kind === 'error'}
     <span class="font-semibold">{m.validate_parse_failed_title()}</span>

--- a/apps/browser/src/lib/services/validation.test.ts
+++ b/apps/browser/src/lib/services/validation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { fetchErrorReason } from './validation.js';
+
+describe('fetchErrorReason', () => {
+  it('extracts the reason from a CouldNotFetchUrl title', () => {
+    expect(
+      fetchErrorReason(
+        'Could not fetch URL https://example.com/loop: redirect count exceeded',
+      ),
+    ).toBe('redirect count exceeded');
+  });
+
+  it('handles URLs containing colons (e.g. ports)', () => {
+    expect(
+      fetchErrorReason(
+        'Could not fetch URL https://example.com:8080/x: redirect count exceeded',
+      ),
+    ).toBe('redirect count exceeded');
+  });
+
+  it('returns undefined for unrelated titles', () => {
+    expect(
+      fetchErrorReason('No dataset found at URL https://example.com'),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when no title is given', () => {
+    expect(fetchErrorReason(undefined)).toBeUndefined();
+  });
+});

--- a/apps/browser/src/lib/services/validation.ts
+++ b/apps/browser/src/lib/services/validation.ts
@@ -7,6 +7,21 @@ export interface ApiErrorDetails {
   description?: string;
 }
 
+/**
+ * Pull the bare reason out of a CouldNotFetchUrl Hydra title.
+ *
+ * Title shape: `${COULD_NOT_FETCH_URL_PREFIX} <url>: <reason>`. Splitting on
+ * ': ' (colon-space) avoids matching the colons inside the URL, since URLs
+ * cannot contain ': '.
+ */
+export function fetchErrorReason(
+  title: string | undefined,
+): string | undefined {
+  if (!title?.startsWith(COULD_NOT_FETCH_URL_PREFIX)) return undefined;
+  const idx = title.indexOf(': ');
+  return idx >= 0 ? title.slice(idx + 2) : undefined;
+}
+
 export type UrlValidationOutcome =
   | { kind: 'report'; report: ShaclReport }
   | { kind: 'not-found'; details?: ApiErrorDetails }


### PR DESCRIPTION
## Summary

Follow-up to #1973. The fetch-failed banner showed the API’s Hydra `description` verbatim as a monospace detail under the localized body, but the description ends with the same suggestion the localized body already gives:

> The Dataset Register couldn’t fetch this URL. Check that it is publicly reachable and serves RDF (for example via content negotiation for application/ld+json or text/turtle).
>
> `redirect count exceeded. Please check that the URL is publicly reachable and returns RDF.`

That suggestion is correct on the API side – non-browser consumers (Postman, scripts, OpenAPI docs page) benefit from the friendly advice – so this change is browser-only: extract the bare reason from the Hydra `title` (the stable `Could not fetch URL <url>: <reason>` shape) and render that:

> The Dataset Register couldn’t fetch this URL. Check that it is publicly reachable and serves RDF…
>
> `redirect count exceeded`

`fetchErrorReason()` lives in `apps/browser/src/lib/services/validation.ts` and is unit-tested for URLs with embedded colons (e.g. ports), unrelated titles, and missing titles.
