### PR TITLE
feat(validate): switch to Inline tab when a validator deep link is pasted

### DIFF
--- a/apps/browser/src/lib/components/validation/UrlValidationForm.svelte
+++ b/apps/browser/src/lib/components/validation/UrlValidationForm.svelte
@@ -26,6 +26,7 @@
       allowed?: boolean,
     ) => void;
     onStart: () => void;
+    onValidatorLink?: (hash: string) => void;
     goToLine?: (line: number) => void;
     source?: { text: string; contentType: ContentType } | null;
   }
@@ -35,6 +36,7 @@
     autoSubmit = false,
     onOutcome,
     onStart,
+    onValidatorLink,
     goToLine = $bindable(),
     source = $bindable(null),
   }: Props = $props();
@@ -106,6 +108,19 @@
       return null;
     }
   }
+
+  // Detect a pasted validator self-link with an inline `#rdf=` payload and
+  // hand the fragment to the parent so it can switch to the Inline tab.
+  $effect(() => {
+    const current = url;
+    const parsed = parseUrl(current);
+    if (!parsed || !/(?:^|#|&)rdf=/.test(parsed.hash)) return;
+    const hashValue = parsed.hash.replace(/^#/, '');
+    untrack(() => {
+      url = '';
+      onValidatorLink?.(hashValue);
+    });
+  });
 
   $effect(() => {
     const current = url;

--- a/apps/browser/src/routes/validate/+page.svelte
+++ b/apps/browser/src/routes/validate/+page.svelte
@@ -153,10 +153,25 @@
     activeGoToLine?.(line);
   }
 
-  const hasInlineHash =
-    typeof window !== 'undefined' && /(?:^|&)rdf=/.test(window.location.hash);
+  let hasInlineHash = $state(
+    typeof window !== 'undefined' && /(?:^|&)rdf=/.test(window.location.hash),
+  );
+  // Bumping this key forces InlineValidationForm to remount so its `onMount`
+  // re-reads the freshly written `window.location.hash`.
+  let inlineSeedVersion = $state(0);
   const urlTabOpen = $derived(data.tab !== 'inline' && !hasInlineHash);
   const inlineTabOpen = $derived(data.tab === 'inline' || hasInlineHash);
+
+  function handleValidatorLink(hashValue: string): void {
+    const newUrl = new URL(window.location.href);
+    newUrl.searchParams.delete('url');
+    newUrl.searchParams.delete('tab');
+    newUrl.hash = `#${hashValue}`;
+    history.replaceState(history.state, '', newUrl.toString());
+    hasInlineHash = true;
+    inlineSeedVersion += 1;
+    resetValidation();
+  }
 
   const activeTab =
     'inline-block rounded-t-lg border-b-2 border-blue-700 p-4 text-blue-700 dark:border-blue-400 dark:text-blue-400 cursor-pointer';
@@ -205,6 +220,7 @@
             autoSubmit={Boolean(data.prefillUrl)}
             onOutcome={handleUrlOutcome}
             onStart={handleStart}
+            onValidatorLink={handleValidatorLink}
             bind:goToLine={urlGoToLine}
             bind:source={urlSource}
           />
@@ -218,11 +234,13 @@
         onclick={resetValidation}
       >
         <div class="pt-4">
-          <InlineValidationForm
-            onOutcome={handleInlineOutcome}
-            onStart={handleStart}
-            bind:goToLine={inlineGoToLine}
-          />
+          {#key inlineSeedVersion}
+            <InlineValidationForm
+              onOutcome={handleInlineOutcome}
+              onStart={handleStart}
+              bind:goToLine={inlineGoToLine}
+            />
+          {/key}
         </div>
       </TabItem>
     </Tabs>


### PR DESCRIPTION
## Summary

When a user pastes a validator self-link of the form `https://datasetregister.netwerkdigitaalerfgoed.nl/validate#rdf=…` into the URL input on the **URL** tab, the page now automatically switches to the **Inline** tab and loads the encoded RDF.

- `UrlValidationForm` watches the input for a URL with an `#rdf=` fragment, clears the field, and emits the fragment via a new `onValidatorLink` callback.
- `validate/+page.svelte` writes the fragment back to `window.location.hash`, flips the tab state, and bumps a `{#key}` so `InlineValidationForm` remounts and re-runs its `onMount` hash seeding.
