### PR TITLE
fix(browser): resolve descriptions for blank-node sourceShapes

### DIFF
--- a/apps/browser/src/lib/services/shacl-shapes.test.ts
+++ b/apps/browser/src/lib/services/shacl-shapes.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  indexShapes,
+  selectShape,
+  type ShapesIndex,
+} from './shacl-shapes.js';
+
+const SH = 'http://www.w3.org/ns/shacl#';
+const SCHEMA = 'https://schema.org/';
+const LANG_STRING = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString';
+
+describe('selectShape', () => {
+  it('returns the metadata for a blank-node sourceShape', () => {
+    // The API emits stable blank-node IDs across `/shacl` and validation
+    // results, so a sibling shape (one of several constraints on the same
+    // path) must resolve to its parent's shared description.
+    const contactPointMeta = {
+      description: 'Naam van het contactpunt, bij voorkeur een afdeling.',
+      targetClass: undefined,
+    };
+    const index: ShapesIndex = {
+      byPath: new Map([[`${SCHEMA}name`, [contactPointMeta]]]),
+      byId: new Map([['_:df_13_226', contactPointMeta]]),
+    };
+    expect(
+      selectShape(index, `${SCHEMA}name`, undefined, '_:df_13_226'),
+    ).toEqual(contactPointMeta);
+  });
+
+  it('prefers the candidate matching the focus node class on shared paths', () => {
+    const dataCatalogMeta = {
+      description: 'Naam van de datacatalogus',
+      targetClass: `${SCHEMA}DataCatalog`,
+    };
+    const datasetMeta = {
+      description: 'De naam van de dataset.',
+      targetClass: `${SCHEMA}Dataset`,
+    };
+    const index: ShapesIndex = {
+      byPath: new Map([[`${SCHEMA}name`, [dataCatalogMeta, datasetMeta]]]),
+      byId: new Map(),
+    };
+    expect(selectShape(index, `${SCHEMA}name`, `${SCHEMA}Dataset`)).toEqual(
+      datasetMeta,
+    );
+  });
+
+  it('returns undefined when no class-bound candidate matches the focus node', () => {
+    // Previously the resolver fell back to the first candidate carrying a
+    // description, surfacing a DataCatalog description on unrelated focus
+    // nodes.
+    const dataCatalogMeta = {
+      description: 'Naam van de datacatalogus',
+      targetClass: `${SCHEMA}DataCatalog`,
+    };
+    const index: ShapesIndex = {
+      byPath: new Map([[`${SCHEMA}name`, [dataCatalogMeta]]]),
+      byId: new Map(),
+    };
+    expect(
+      selectShape(index, `${SCHEMA}name`, `${SCHEMA}ContactPoint`),
+    ).toBeUndefined();
+  });
+});
+
+describe('indexShapes', () => {
+  it('shares the main shape description across sibling property shapes', () => {
+    // Mirrors `nde-dataset:ContactPointShape` in requirements/shacl.ttl: a
+    // NodeShape with two property shapes on `schema:name`. Only the main
+    // (minCount) shape carries `sh:description`; per requirements/AGENTS.md
+    // siblings should surface the same description.
+    const json = [
+      {
+        '@id': 'https://example.org/ContactPointShape',
+        '@type': [`${SH}NodeShape`],
+        [`${SH}targetObjectsOf`]: [{ '@id': `${SCHEMA}contactPoint` }],
+        [`${SH}property`]: [{ '@id': '_:main' }, { '@id': '_:sibling' }],
+      },
+      {
+        '@id': '_:main',
+        [`${SH}path`]: [{ '@id': `${SCHEMA}name` }],
+        [`${SH}minCount`]: [{ '@value': '1' }],
+        [`${SH}description`]: [
+          { '@value': 'Naam van het contactpunt.', '@language': 'nl' },
+        ],
+      },
+      {
+        '@id': '_:sibling',
+        [`${SH}path`]: [{ '@id': `${SCHEMA}name` }],
+        [`${SH}datatype`]: [{ '@id': LANG_STRING }],
+      },
+    ];
+    const index = indexShapes(json, 'nl');
+    expect(index.byId.get('_:main')?.description).toBe(
+      'Naam van het contactpunt.',
+    );
+    expect(index.byId.get('_:sibling')?.description).toBe(
+      'Naam van het contactpunt.',
+    );
+  });
+
+  it('binds metadata to the NodeShape’s class via sh:class as well as sh:targetClass', () => {
+    // `DatacatalogShape` declares its class through `sh:class schema:DataCatalog`
+    // (not `sh:targetClass`); the indexer must read both.
+    const json = [
+      {
+        '@id': 'https://example.org/DatacatalogShape',
+        '@type': [`${SH}NodeShape`],
+        [`${SH}class`]: [{ '@id': `${SCHEMA}DataCatalog` }],
+        [`${SH}property`]: [{ '@id': '_:catalog-name' }],
+      },
+      {
+        '@id': '_:catalog-name',
+        [`${SH}path`]: [{ '@id': `${SCHEMA}name` }],
+        [`${SH}description`]: [
+          { '@value': 'Naam van de datacatalogus', '@language': 'nl' },
+        ],
+      },
+    ];
+    const index = indexShapes(json, 'nl');
+    const candidate = index.byPath.get(`${SCHEMA}name`)?.[0];
+    expect(candidate?.targetClass).toBe(`${SCHEMA}DataCatalog`);
+  });
+});

--- a/apps/browser/src/lib/services/shacl-shapes.ts
+++ b/apps/browser/src/lib/services/shacl-shapes.ts
@@ -39,13 +39,14 @@ export function fetchShapes(signal?: AbortSignal): Promise<ShapesIndex> {
 }
 
 /**
- * Given a path IRI and the focusNode's rdf:type (optional), pick the best
- * matching shape. Prefers a direct hit by `sh:sourceShape` IRI, then a class
- * match against the focus node's type. When focusNodeType is known we never
- * fall back across siblings: descriptions on `schema:name` (and similar
- * shared paths) belong to a specific class, and inheriting one from another
- * NodeShape would mislead the reader – e.g. the data-catalog description
- * surfacing on a contact-point validation result.
+ * Pick the property-shape metadata that describes a SHACL validation result.
+ *
+ * Prefers a direct hit by `sh:sourceShape` – the API emits stable blank-node
+ * IDs across the `/shacl` and validation endpoints, so blank-node sourceShapes
+ * match too. Falls back to a path lookup, narrowed by the focus node's
+ * rdf:type when that is known: descriptions on shared paths like
+ * `schema:name` belong to a specific class, and inheriting one from another
+ * NodeShape would mislead the reader.
  */
 export function selectShape(
   index: ShapesIndex,
@@ -53,7 +54,7 @@ export function selectShape(
   focusNodeType?: string,
   sourceShapeIri?: string,
 ): ShapeMetadata | undefined {
-  if (sourceShapeIri && !sourceShapeIri.startsWith('_:')) {
+  if (sourceShapeIri) {
     const direct = index.byId.get(sourceShapeIri);
     if (direct) return direct;
   }
@@ -67,7 +68,7 @@ export function selectShape(
   return candidates.find((c) => c.description) ?? undefined;
 }
 
-function indexShapes(json: unknown, locale: string): ShapesIndex {
+export function indexShapes(json: unknown, locale: string): ShapesIndex {
   const nodes = normalizeNodes<Record<string, unknown>>(json);
   const byId = new Map<string, Record<string, unknown>>();
   for (const node of nodes) {
@@ -87,6 +88,12 @@ function indexShapes(json: unknown, locale: string): ShapesIndex {
     const propertyRefs = node[`${SH}property`];
     if (!Array.isArray(propertyRefs)) continue;
 
+    // Collect every property shape this NodeShape owns. Per requirements/AGENTS.md
+    // the main shape for a property carries `sh:description`; sibling shapes
+    // (different constraints on the same path) only carry `sh:message`. Group
+    // siblings by path so each sibling can surface the main shape's description.
+    type Sibling = { refId: string; pathIri: string; description?: string };
+    const siblings: Sibling[] = [];
     for (const ref of propertyRefs) {
       const refId =
         ref && typeof ref === 'object' && '@id' in ref
@@ -95,25 +102,30 @@ function indexShapes(json: unknown, locale: string): ShapesIndex {
       if (!refId) continue;
       const propertyShape = byId.get(refId);
       if (!propertyShape) continue;
-
+      const pathIri = pickIri(propertyShape[`${SH}path`]);
+      if (!pathIri) continue;
       const description = pickLocalized(
         propertyShape[`${SH}description`],
         locale,
       );
-      if (!description) continue;
+      siblings.push({ refId, pathIri, description });
+    }
 
-      const metadata: ShapeMetadata = {
-        description,
-        targetClass,
-      };
-
-      const pathIri = pickIri(propertyShape[`${SH}path`]);
-      if (pathIri) {
-        const list = byPath.get(pathIri);
-        if (list) list.push(metadata);
-        else byPath.set(pathIri, [metadata]);
+    const descriptionByPath = new Map<string, string>();
+    for (const sibling of siblings) {
+      if (sibling.description && !descriptionByPath.has(sibling.pathIri)) {
+        descriptionByPath.set(sibling.pathIri, sibling.description);
       }
-      if (!refId.startsWith('_:')) shapeById.set(refId, metadata);
+    }
+
+    for (const sibling of siblings) {
+      const description = descriptionByPath.get(sibling.pathIri);
+      if (!description) continue;
+      const metadata: ShapeMetadata = { description, targetClass };
+      const list = byPath.get(sibling.pathIri);
+      if (list) list.push(metadata);
+      else byPath.set(sibling.pathIri, [metadata]);
+      shapeById.set(sibling.refId, metadata);
     }
   }
 


### PR DESCRIPTION
## Summary

#1972 did not fix the original report after deploy — the contact point name warning on https://datasetregister.netwerkdigitaalerfgoed.nl/validate still shows:

> schema:name · Naam van de datacatalogus
> Waarde: Joost Dofferhoff

## Why the previous fix missed

The API returns a result whose `sh:sourceShape` is a server-generated blank node (e.g. `_:df_13_226`) and whose `sh:focusNode` is also a server-side blank node (e.g. `_:df_59675_0`). The client built `focusNodeTypes` by re-parsing the source text, whose blank-node IDs are independent and do not match. As a result `focusNodeType` was undefined and the strict-class branch added in #1972 never fired — control fell through to the path-only fallback, which still picked the DataCatalog description first.

## What this fixes

I confirmed that the API’s blank-node IDs are stable: the sourceShape ID returned in a validation result also appears under the same `@id` in `/shacl`. That lets us match sourceShape directly, blank-node or not.

- `selectShape`: look up `sh:sourceShape` unconditionally (drop the `_:` exclusion).
- `indexShapes`:
  - Index every property shape by its `@id` (blank or IRI).
  - Share the main shape’s `sh:description` across siblings on the same path within a NodeShape, per `requirements/AGENTS.md` (siblings carry only `sh:message`).
  - Read `sh:class` as well as `sh:targetClass` (kept from #1972).

## Tests

Added `apps/browser/src/lib/services/shacl-shapes.test.ts` covering: blank-node sourceShape resolution, class-bound siblings on shared paths, the no-misleading-fallback contract, sibling description sharing, and `sh:class`-based class binding.
