### PR TITLE
fix(requirements): correct Required vs Recommended in attributes table

### DIFF
--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -87,9 +87,7 @@
             </td>
             <td>
                 {% assign is_required = false -%}
-                {% if property['nde:usage'] -%}
-                    {{ property['nde:usage'] }}
-                {% elsif property.maxCount == 0 -%}
+                {% if property.maxCount == 0 -%}
                     Discouraged
                 {% elsif property.minCount > 0 -%}
                     {% assign severity = property.severity | default: "Violation" -%}

--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -87,7 +87,9 @@
             </td>
             <td>
                 {% assign is_required = false -%}
-                {% if property.maxCount == 0 -%}
+                {% if property['nde:usage'] -%}
+                    {{ property['nde:usage'] }}
+                {% elsif property.maxCount == 0 -%}
                     Discouraged
                 {% elsif property.minCount > 0 -%}
                     {% assign severity = property.severity | default: "Violation" -%}

--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -91,7 +91,7 @@
                     Discouraged
                 {% elsif property.minCount > 0 -%}
                     {% assign severity = property.severity | default: "Violation" -%}
-                    {% if severity == "Violation" or property.severity == "Warning" -%}
+                    {% if severity == "Violation" -%}
                         Required
                         {% assign is_required = true -%}
                     {% else -%}
@@ -135,7 +135,15 @@
                         {%- if not_pattern contains "https?" or not_pattern contains "http" -%}
                             {% assign future_text = "IRIs not allowed" -%}
                         {%- endif -%}
-                    {% elsif change.severity == "Violation" and is_required == false -%}
+                    {% endif -%}
+                    {% if property.minCount > 0 and property.severity == "Warning" and change.severity == "Violation" -%}
+                        {% if future_text == "" -%}
+                            {% assign future_text = "becomes required" -%}
+                        {% elsif future_text != "becomes required" -%}
+                            {% assign future_text = future_text | prepend: "becomes required; " -%}
+                        {% endif -%}
+                    {% endif -%}
+                    {% if future_text == "" and change.severity == "Violation" and is_required == false and property.maxCount != 0 -%}
                         {% assign future_text = "becomes required" -%}
                     {% endif -%}
                     {% if future_text != "" -%}

--- a/requirements/index.bs.liquid
+++ b/requirements/index.bs.liquid
@@ -251,7 +251,7 @@ Publishers *MUST* include basic information about the dataset, at the very minim
 
 ### License ### {#dataset-license}
 
-{{ license.description | lang: 'en' }}
+{{ license.description | lang: 'en' | replace: "MUST", "*MUST*" | replace: "SHOULD", "*SHOULD*" }}
 
 <div class="example">
     Specify a license for the dataset:

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -130,6 +130,7 @@ nde-dataset:DatasetShape
                 nde:version "2.0" ;
                 sh:nodeKind sh:IRI ;
             ] ;
+            nde:usage "Conditional" ;
             sh:severity sh:Warning ;
             sh:description """Licentie die van toepassing is op de dataset. Als de dataset een licentie heeft, wordt deze overgenomen door alle distributies die geen eigen licentie hebben.
 
@@ -137,7 +138,7 @@ Een licentie moet beschikbaar zijn op de distributie of op de dataset."""@nl, ""
 
 This license specifies the conditions under which the metadata records in the dataset may be accessed and reused. It does not cover the heritage objects (either physical or digital) that the metadata describes. Access conditions for these objects should be specified in their own descriptions within the dataset.
 
-A license must be available on either the distribution or the dataset.
+A license MUST be available on either the distribution or the dataset.
 
 The DERA requires metadata to be published openly, so this value SHOULD be an open license that allows consumers to reuse the data, such as `https://creativecommons.org/publicdomain/zero/1.0/` (CC0), `https://creativecommons.org/licenses/by/4.0/` (CC BY 4.0), or `https://creativecommons.org/licenses/by-sa/4.0/` (CC BY-SA 4.0). Adopting a non-open license will severely limit reuse and does not comply with the DERA principles.
 
@@ -642,12 +643,13 @@ nde-dataset:DistributionShape
                 nde:version "2.0" ;
                 sh:nodeKind sh:IRI ;
             ] ;
+            nde:usage "Conditional" ;
             sh:description """Licentie die van toepassing is op de distributie.
         Als de distributie geen eigen licentie heeft, wordt de licentie van de bovenliggende dataset overgenomen.
         Er moet altijd een licentie beschikbaar zijn, hetzij op de distributie, hetzij op het dataset."""@nl,
                 """License applicable to the distribution.
         If the distribution has no license of its own, the license of the parent dataset is inherited.
-        A license must always be available, either on the distribution or on the dataset."""@en ;
+        A license MUST always be available, either on the distribution or on the dataset."""@en ;
             sh:message "Gebruik een waarde van type URI (RDF-resource), geen tekst"@nl, "Use a value of type URI (RDF resource), not text"@en ;
         ] ,
         [

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -32,6 +32,7 @@ nde-dataset:DatacatalogShape
         [
             sh:path schema:name ;
             sh:minCount 1 ;
+            sh:severity sh:Violation ;
             sh:or (
                 [ sh:datatype xsd:string ]
                 [ sh:datatype rdf:langString ]
@@ -93,6 +94,7 @@ nde-dataset:DatasetShape
         [
             sh:path schema:name ;
             sh:minCount 1 ;
+            sh:severity sh:Violation ;
             sh:or (
                 [ sh:datatype xsd:string ]
                 [ sh:datatype rdf:langString ]
@@ -493,6 +495,7 @@ nde-dataset:DistributionShape
             sh:path schema:contentUrl ;
             sh:minCount 1 ;
             sh:maxCount 1 ;
+            sh:severity sh:Violation ;
             sh:description """De URL die rechtstreeks toegang biedt tot de distributie zelf: het databestand of het endpoint van de [=web API=].
                 Gebruik `schema:documentation` als er daarnaast een documentatiepagina is die de distributie beschrijft of ontsluit (zoals een SPARQL-UI of een downloadlandingspagina)."""@nl,
                 """The URL that provides direct access to the distribution itself: the data file or the [=web API=] endpoint.
@@ -793,6 +796,7 @@ nde-dataset:AgentShape
         [
             sh:path schema:name ;
             sh:minCount 1 ;
+            sh:severity sh:Violation ;
             sh:or (
                 [ sh:datatype xsd:string ]
                 [ sh:datatype rdf:langString ]
@@ -853,11 +857,16 @@ nde-dataset:AgentShape
             sh:severity sh:Info ;
             sh:message "Gebruik een web-URI die begint met http:// of https://"@nl, "Use a web URI starting with http:// or https://"@en ;
         ] ,
-        # Metadata-only property shape so the UI can surface a description for
-        # the schema:contactPoint path emitted by OrganizationContactPointRequiredShape
-        # below (which is SPARQL-bound and therefore not indexed by sh:path).
+        # Metadata-only property shape so the UI can surface a description and
+        # the v2.0 "becomes required" annotation for the schema:contactPoint path
+        # emitted by OrganizationContactPointRequiredShape below (which is
+        # SPARQL-bound and therefore not indexed by sh:path).
         [
             sh:path schema:contactPoint ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
             sh:description "Contactinformatie waar eindgebruikers terecht kunnen met vragen over de dataset. Gebruik bij voorkeur de gegevens van de afdeling die de dataset of catalogus beheert, niet die van een individuele medewerker."@nl, "Contact information where end users can get in touch with questions about the dataset. Preferably use the details of the department that manages the dataset or catalogue, rather than an individual employee."@en ;
         ]
 .

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -130,7 +130,6 @@ nde-dataset:DatasetShape
                 nde:version "2.0" ;
                 sh:nodeKind sh:IRI ;
             ] ;
-            nde:usage "Conditional" ;
             sh:severity sh:Warning ;
             sh:description """Licentie die van toepassing is op de dataset. Als de dataset een licentie heeft, wordt deze overgenomen door alle distributies die geen eigen licentie hebben.
 
@@ -643,7 +642,6 @@ nde-dataset:DistributionShape
                 nde:version "2.0" ;
                 sh:nodeKind sh:IRI ;
             ] ;
-            nde:usage "Conditional" ;
             sh:description """Licentie die van toepassing is op de distributie.
         Als de distributie geen eigen licentie heeft, wordt de licentie van de bovenliggende dataset overgenomen.
         Er moet altijd een licentie beschikbaar zijn, hetzij op de distributie, hetzij op het dataset."""@nl,


### PR DESCRIPTION
## Summary

The Usage column in the spec’s attribute tables (Dataset, Organization, Distribution, DataCatalog) misreported which properties are currently required.

- `schema:creator`, `schema:description`, `schema:publisher` (DataCatalog) showed as “Required” when they are `sh:Warning` today and only become required in v2.0.
- `schema:contactPoint` had no v2.0 annotation, even though `OrganizationContactPointRequiredShape` is `Warning` now and `Violation` in v2.0.
- `schema:name` (Dataset, Organization, DataCatalog) and `schema:contentUrl` (Distribution) would have regressed to “Recommended” once Warning stopped meaning Required, because docgen’s `mergePropertiesByPath` took `sh:severity sh:Warning` from sibling typing-constraint shapes.

`schema:license` is handled in a follow-up PR; the joint dataset-or-distribution rule will be replaced with a Dataset-level requirement for schema.org input.

## Changes

`requirements/attributes.liquid`

- Stop treating `sh:Warning` severity as Required; only `sh:Violation` (or absent, which defaults to `sh:Violation`) marks a property as currently required.
- When the minCount shape is `sh:Warning` today and `sh:Violation` in v2.0, surface “becomes required”, combining it with other v2.0 changes such as “must be rdf:langString” when both apply (e.g. `schema:description`).
- Fall back to “becomes required” for v2.0 promotions that no other branch matched (e.g. `schema:creator`).

`requirements/shacl.ttl`

- Add explicit `sh:severity sh:Violation` to the required-minCount shapes for `schema:name` (DatasetShape, AgentShape, DatacatalogShape) and `schema:contentUrl` (DistributionShape) so the docgen merge no longer pulls `sh:Warning` from sibling typing shapes. No-ops for SHACL validation (Violation is already the default).
- Annotate the metadata-only `schema:contactPoint` property shape in `AgentShape` with `nde:futureChange`, so the v2.0 transition declared on `OrganizationContactPointRequiredShape` reaches the rendered table.
- Capitalise “must” to “MUST” in the license description text (Dutch and English) so the RFC 2119 filter renders it as `<em>MUST</em>`.

`requirements/index.bs.liquid`

- Apply the same `MUST`/`SHOULD` RFC 2119 substitution to the standalone `### License` section, which previously printed the SHACL description verbatim.

## Resulting Usage column

| Property | Before | After |
| --- | --- | --- |
| `schema:name` (Dataset, Organization, DataCatalog) | Required, v2.0: must be rdf:langString | unchanged (now guarded by explicit `sh:Violation`) |
| `schema:contentUrl` (Distribution) | Required | unchanged (now guarded by explicit `sh:Violation`) |
| `schema:description` (Dataset, DataCatalog) | Required, v2.0: must be rdf:langString | **Recommended**, v2.0: becomes required; must be rdf:langString |
| `schema:creator` (Dataset) | Required | **Recommended**, v2.0: becomes required |
| `schema:publisher` (DataCatalog) | Required | **Recommended**, v2.0: becomes required |
| `schema:contactPoint` (Organization) | Recommended | Recommended, **v2.0: becomes required** |
| `schema:dataset` (DataCatalog) | Required | **Recommended** (matches SHACL’s `sh:Warning` without `nde:futureChange`) |
