### PR TITLE
fix(browser): shrink validate share-URL with deflate-raw

### DIFF
--- a/apps/browser/src/lib/components/validation/InlineValidationForm.svelte
+++ b/apps/browser/src/lib/components/validation/InlineValidationForm.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
   import {
-    compressToEncodedURIComponent,
-    decompressFromEncodedURIComponent,
-  } from 'lz-string';
+    decodeFromShareUrl,
+    encodeForShareUrl,
+  } from './share-link.js';
   import { Label, Select, Tooltip } from 'flowbite-svelte';
   import AlignLeftOutline from 'flowbite-svelte-icons/AlignLeftOutline.svelte';
   import ClipboardOutline from 'flowbite-svelte-icons/ClipboardOutline.svelte';
@@ -61,10 +61,13 @@
   });
   let innerFocus = $state<(() => void) | undefined>(undefined);
 
-  // Hash-based deep link: on mount, seed the editor from `#rdf=<lz>` and
-  // optionally `#ct=<mime>`. The fragment stays client-side so pasted RDF
-  // never reaches the server or access logs.
-  function readHash(): { text?: string; contentType?: ContentType } {
+  // Hash-based deep link: on mount, seed the editor from `#rdf=<payload>`
+  // and optionally `#ct=<mime>`. The fragment stays client-side so pasted
+  // RDF never reaches the server or access logs.
+  async function readHash(): Promise<{
+    text?: string;
+    contentType?: ContentType;
+  }> {
     if (typeof window === 'undefined') return {};
     const hash = window.location.hash.replace(/^#/, '');
     if (!hash) return {};
@@ -72,7 +75,7 @@
     const encoded = params.get('rdf');
     const ct = params.get('ct') as ContentType | null;
     if (!encoded) return {};
-    const decoded = decompressFromEncodedURIComponent(encoded);
+    const decoded = await decodeFromShareUrl(encoded);
     return decoded
       ? {
           text: decoded,
@@ -81,8 +84,8 @@
       : {};
   }
 
-  onMount(() => {
-    const seed = readHash();
+  onMount(async () => {
+    const seed = await readHash();
     if (seed.text) {
       text = seed.text;
       if (seed.contentType) {
@@ -100,10 +103,10 @@
     const contentType = selectedContentType;
     if (typeof window === 'undefined') return;
     clearTimeout(hashTimer);
-    hashTimer = setTimeout(() => {
+    hashTimer = setTimeout(async () => {
       const fragment = new URLSearchParams();
       if (body) {
-        fragment.set('rdf', compressToEncodedURIComponent(body));
+        fragment.set('rdf', await encodeForShareUrl(body));
         if (userOverride) fragment.set('ct', contentType);
       }
       const url = new URL(window.location.href);

--- a/apps/browser/src/lib/components/validation/share-link.test.ts
+++ b/apps/browser/src/lib/components/validation/share-link.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { compressToEncodedURIComponent } from 'lz-string';
+import {
+  decodeFromShareUrl,
+  encodeForShareUrl,
+} from './share-link.js';
+
+const LIMA_TURTLE = `@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix schema:<http://schema.org/> .
+
+<https://data.mediakunst.net/dataset/lima-single-channel-artworks>
+    a schema:Dataset ;
+    schema:identifier "https://data.mediakunst.net/dataset/lima-single-channel-artworks"^^xsd:string ;
+    schema:name "Dataset of single channel video artworks from the Li-MA collection"@en, "Dataset van eenkanaalse videokunstwerken uit de LI-MA collectie"@nl ;
+    schema:description "A dataset consisting of all single channel video artworks that exist in the collection LI-MA - Living Media Art."@en, "Een dataset bestaande uit alle eenkanaalse videokunstwerken die zich bevinden in de collectie van LI-MA - Living Media Art."@nl ;
+    schema:creator <https://li-ma.nl/> ;
+    schema:publisher <https://li-ma.nl/> ;
+    schema:about <http://vocab.getty.edu/aat/300102067> ;
+    schema:temporalCoverage "1960/.." ;
+    schema:dateCreated "2026-03-19"^^schema:Date ;
+    schema:dateModified "2026-03-19"^^schema:Date ;
+    schema:datePublished "2026-03-19"^^schema:Date ;
+    schema:inLanguage "nl-NL"^^xsd:string, "en-US"^^xsd:string ;
+    schema:version "1.0"^^xsd:string ;
+    schema:keywords "mediakunst"@nl, "digitale kunst"@nl, "digital art"@en, "media art"@en ;
+    schema:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+    schema:includedInDataCatalog <https://data.mediakunst.net/datacatalog> ;
+    schema:distribution [
+        a schema:DataDownload ;
+        schema:name "Datadump in RDF"^^xsd:string ;
+        schema:description "Datadump in turtle formaat van de single channel videowerken uit de LI-Ma collectie."@nl, "Datadump in RDF turtle format of the single channel artworks in the LI-MA-collection." ;
+        schema:encodingFormat "text/turtle"^^xsd:string ;
+        schema:dateCreated "2026-03-19"^^schema:Date ;
+        schema:dateModified "2026-03-19"^^schema:Date ;
+        schema:datePublished "2026-03-19"^^schema:Date ;
+        schema:inLanguage "nl-NL"^^xsd:string, "en-US"^^xsd:string ;
+        schema:contentUrl <https://data.mediakunst.net/dataset/lima-single-channel-artworks.ttl> ;
+        schema:license <https://creativecommons.org/publicdomain/zero/1.0/>
+    ]
+.
+
+<https://data.mediakunst.net/datacatalog>
+    a schema:DataCatalog  ;
+    schema:name "Open Data collectie van LI-MA"@nl, "Open Data collection of LI-MA"@en ;
+    schema:description "Alle open data beschikbaar gesteld door LI-MA"@nl, "All open datasets ad published by LI-MA."@en ;
+    schema:publisher <https://li-ma.nl/> ;
+    schema:dataset <https://data.mediakunst.net/dataset/lima-single-channel-artworks> .
+
+<https://li-ma.nl/>
+    a schema:Organization ;
+    schema:name "LI-MA Mediakunst"@nl, "LI-MA Digital art"@en ;
+    schema:identifier "NL-lima"^^xsd:string ;
+    schema:contactPoint [
+        a schema:ContactPoint ;
+        schema:email "contact@li-ma.nl"^^xsd:string ;
+        schema:name "Joost Dofferhoff"^^xsd:string
+    ] .`;
+
+describe('share-link', () => {
+  it('round-trips arbitrary text exactly', async () => {
+    const encoded = await encodeForShareUrl(LIMA_TURTLE);
+    expect(await decodeFromShareUrl(encoded)).toBe(LIMA_TURTLE);
+  });
+
+  it('decodes legacy lz-string fragments produced before this change', async () => {
+    const legacy = compressToEncodedURIComponent(LIMA_TURTLE);
+    expect(await decodeFromShareUrl(legacy)).toBe(LIMA_TURTLE);
+  });
+
+  it('produces a meaningfully shorter URL fragment than lz-string', async () => {
+    const next = await encodeForShareUrl(LIMA_TURTLE);
+    const legacy = compressToEncodedURIComponent(LIMA_TURTLE);
+    // Sanity baseline so a regression in the encoder gets caught.
+    expect(next.length).toBeLessThan(legacy.length * 0.65);
+  });
+
+  it('decodes its own empty-string output', async () => {
+    const encoded = await encodeForShareUrl('');
+    expect(await decodeFromShareUrl(encoded)).toBe('');
+  });
+
+  it('returns undefined for garbage in the current format', async () => {
+    expect(await decodeFromShareUrl('~1!!!not-base64!!!')).toBeUndefined();
+  });
+});

--- a/apps/browser/src/lib/components/validation/share-link.ts
+++ b/apps/browser/src/lib/components/validation/share-link.ts
@@ -1,0 +1,91 @@
+import {
+  compressToEncodedURIComponent,
+  decompressFromEncodedURIComponent,
+} from 'lz-string';
+
+// Compress validate-page paste content into a URL fragment value, and
+// decompress legacy or current fragments back into text.
+//
+// Encoding uses browser-native `CompressionStream('deflate-raw')` plus
+// base64url. Deflate's own LZ77 + Huffman comfortably beats lz-string on
+// typical RDF: a ~3 kB Turtle paste shrinks from ~2 kB (lz-string) to
+// ~1.2 kB. A static schema.org/DCAT dictionary was attempted but the
+// dictionary bytes have to be carried in the compressed stream (raw
+// deflate has no preset-dictionary header), so they cost more than they
+// save at this payload size.
+//
+// Output format:
+//   - `~1<base64url-payload>` — current format, deflate-raw + base64url.
+//   - any other prefix — legacy lz-string output, decoded for backward
+//     compatibility with URLs shared before this change.
+//
+// `~` is RFC 3986 unreserved and is not part of lz-string's alphabet,
+// so the prefix disambiguates cleanly.
+
+const FORMAT_PREFIX = '~1';
+
+export async function encodeForShareUrl(text: string): Promise<string> {
+  const bytes = new TextEncoder().encode(text);
+  const compressed = await deflateRaw(bytes);
+  return FORMAT_PREFIX + base64UrlEncode(compressed);
+}
+
+export async function decodeFromShareUrl(
+  encoded: string,
+): Promise<string | undefined> {
+  if (encoded.startsWith(FORMAT_PREFIX)) {
+    const payload = encoded.slice(FORMAT_PREFIX.length);
+    const bytes = base64UrlDecode(payload);
+    if (!bytes) return undefined;
+    const inflated = await inflateRaw(bytes);
+    if (!inflated) return undefined;
+    return new TextDecoder().decode(inflated);
+  }
+  // Legacy lz-string fragments produced before the format prefix existed.
+  const legacy = decompressFromEncodedURIComponent(encoded);
+  return legacy || undefined;
+}
+
+async function deflateRaw(bytes: Uint8Array): Promise<Uint8Array> {
+  const stream = new Blob([bytes as BlobPart])
+    .stream()
+    .pipeThrough(new CompressionStream('deflate-raw'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+async function inflateRaw(bytes: Uint8Array): Promise<Uint8Array | undefined> {
+  try {
+    const stream = new Blob([bytes as BlobPart])
+      .stream()
+      .pipeThrough(new DecompressionStream('deflate-raw'));
+    return new Uint8Array(await new Response(stream).arrayBuffer());
+  } catch {
+    return undefined;
+  }
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(value: string): Uint8Array | undefined {
+  try {
+    const padded =
+      value.replace(/-/g, '+').replace(/_/g, '/') +
+      '==='.slice((value.length + 3) % 4);
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  } catch {
+    return undefined;
+  }
+}
+
+// Exposed for diagnostic tooling that wants to compare formats. The form
+// component should always go through `encodeForShareUrl`.
+export const legacyEncodeForShareUrl = compressToEncodedURIComponent;


### PR DESCRIPTION
## Summary

A mail-shared validate URL has been getting truncated by mail clients because the lz-string-compressed `#rdf=...` fragment was still ~2 kB for a fairly modest schema.org/DCAT Turtle paste.

This replaces the encoder with browser-native `CompressionStream('deflate-raw')` + base64url. On the LI-MA reference paste the share-URL fragment goes from 2008 chars to 1190 — about -41% — enough to fit comfortably inside the conservative ~1.5 kB envelope that mainstream mail clients accept without rewriting.

## Notes

- I tried prepending a static schema.org/DCAT dictionary (the "brotli-with-shared-dictionary" trick), expecting another 15-25% on top. Measured: it *increased* output to 1706 chars, because raw deflate has no preset-dictionary header, so the dictionary bytes have to live in the compressed stream. Deflate's own LZ77 window already finds the prefix/predicate repetition. Dropped the dictionary; the comment block in `share-link.ts` records the experiment.
- I skipped the pre-compression text normalization step (stripping `^^xsd:string`, collapsing whitespace) — anything semantic would silently mutate a paste between share and round-trip, and whitespace cleanup is irrelevant to deflate.

## Compatibility

Existing `#rdf=` URLs already in the wild (mail threads, chat history) keep working: the new format is prefixed with `~1` (RFC 3986 unreserved, not in lz-string's alphabet) and the decoder falls back to lz-string when the prefix is absent.

## Follow-up

If shared payloads start growing past what deflate-raw can carry (very large datasets), the next step is a server-side paste flow (`POST /paste` returning a short ID) with a hybrid threshold: keep `#rdf=` for small payloads, switch to `?paste=<id>` above ~1.5 kB. Out of scope here.
