### PR TITLE
fix(requirements): require schema:license on the Dataset

### DIFF
--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -650,9 +650,9 @@ describe('Validator', () => {
   });
 
   it('does not warn when dataset license is absent but distribution carries one', async () => {
-    // DCAT-AP-NL places license on the distribution. The dataset-level
-    // schema:license shape must not double-warn in that case; the
-    // DistributionLicenseRequiredShape covers the must-exist-somewhere rule.
+    // DCAT-AP-NL places license on the distribution. The schema.org
+    // DatasetShape requires schema:license, but this fixture is pure DCAT
+    // (dcat:Dataset) so the schema.org shape does not fire on it.
     const report = (await validate(
       'dataset-dcat-license-on-distribution.jsonld',
     )) as Valid;

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -125,23 +125,25 @@ nde-dataset:DatasetShape
         ] ,
         [
             sh:path schema:license ;
+            sh:minCount 1 ;
+            sh:severity sh:Violation ;
+            sh:description """Licentie die van toepassing is op de dataset. Deze licentie wordt overgenomen door alle distributies die geen eigen licentie hebben."""@nl, """License applicable to the dataset. This license is inherited by all distributions that do not specify their own license. Publishers MUST make known under which <a href="https://www.w3.org/TR/dwbp/#licenses">license</a> the dataset may be used.
+
+This license specifies the conditions under which the metadata records in the dataset may be accessed and reused. It does not cover the heritage objects (either physical or digital) that the metadata describes. Access conditions for these objects should be specified in their own descriptions within the dataset.
+
+The DERA requires metadata to be published openly, so this value SHOULD be an open license that allows consumers to reuse the data, such as `https://creativecommons.org/publicdomain/zero/1.0/` (CC0), `https://creativecommons.org/licenses/by/4.0/` (CC BY 4.0), or `https://creativecommons.org/licenses/by-sa/4.0/` (CC BY-SA 4.0). Adopting a non-open license will severely limit reuse and does not comply with the DERA principles.
+
+The value MUST be the canonical URI of a license. For example, use `https://creativecommons.org/publicdomain/zero/1.0/` instead of `https://creativecommons.org/publicdomain/zero/1.0/deed.nl`."""@en ;
+            sh:message "Voeg een licentie toe"@nl, "Add a license"@en ;
+        ] ,
+        [
+            sh:path schema:license ;
             sh:nodeKind sh:IRIOrLiteral ;
             nde:futureChange [
                 nde:version "2.0" ;
                 sh:nodeKind sh:IRI ;
             ] ;
             sh:severity sh:Warning ;
-            sh:description """Licentie die van toepassing is op de dataset. Als de dataset een licentie heeft, wordt deze overgenomen door alle distributies die geen eigen licentie hebben.
-
-Een licentie moet beschikbaar zijn op de distributie of op de dataset."""@nl, """License applicable to the dataset. If the dataset has a license, it is inherited by all distributions that do not specify their own license. Publishers MUST make known under which <a href="https://www.w3.org/TR/dwbp/#licenses">license</a> the dataset may be used.
-
-This license specifies the conditions under which the metadata records in the dataset may be accessed and reused. It does not cover the heritage objects (either physical or digital) that the metadata describes. Access conditions for these objects should be specified in their own descriptions within the dataset.
-
-A license MUST be available on either the distribution or the dataset.
-
-The DERA requires metadata to be published openly, so this value SHOULD be an open license that allows consumers to reuse the data, such as `https://creativecommons.org/publicdomain/zero/1.0/` (CC0), `https://creativecommons.org/licenses/by/4.0/` (CC BY 4.0), or `https://creativecommons.org/licenses/by-sa/4.0/` (CC BY-SA 4.0). Adopting a non-open license will severely limit reuse and does not comply with the DERA principles.
-
-The value MUST be the canonical URI of a license. For example, use `https://creativecommons.org/publicdomain/zero/1.0/` instead of `https://creativecommons.org/publicdomain/zero/1.0/deed.nl`."""@en ;
             sh:message "Gebruik een waarde van type URI (RDF-resource), geen tekst"@nl, "Use a value of type URI (RDF resource), not text"@en ;
         ] ,
         [
@@ -642,12 +644,8 @@ nde-dataset:DistributionShape
                 nde:version "2.0" ;
                 sh:nodeKind sh:IRI ;
             ] ;
-            sh:description """Licentie die van toepassing is op de distributie.
-        Als de distributie geen eigen licentie heeft, wordt de licentie van de bovenliggende dataset overgenomen.
-        Er moet altijd een licentie beschikbaar zijn, hetzij op de distributie, hetzij op het dataset."""@nl,
-                """License applicable to the distribution.
-        If the distribution has no license of its own, the license of the parent dataset is inherited.
-        A license MUST always be available, either on the distribution or on the dataset."""@en ;
+            sh:description """Licentie die van toepassing is op deze distributie en die de licentie van de bovenliggende dataset overschrijft. Optioneel; gebruik dit alleen wanneer de distributie een andere licentie heeft dan de dataset."""@nl,
+                """License applicable to this distribution, overriding the parent dataset's license. Optional; only set this when the distribution carries a different license from the dataset."""@en ;
             sh:message "Gebruik een waarde van type URI (RDF-resource), geen tekst"@nl, "Use a value of type URI (RDF resource), not text"@en ;
         ] ,
         [
@@ -709,28 +707,6 @@ nde-dataset:DistributionShape
             sh:severity sh:Info ;
             sh:message "Voeg een beschrijving toe"@nl, "Add a description"@en ;
         ] .
-
-# Dedicated SPARQL constraint shape, structured the same way as the two
-# Organization-required shapes below: sh:targetObjectsOf for the entry, sh:message
-# and sh:severity at the node-shape level (where shacl-engine reads them
-# reliably), and the sh:sparql blank node carrying only the sh:select.
-nde-dataset:DistributionLicenseRequiredShape
-    a sh:NodeShape ;
-    sh:targetObjectsOf schema:distribution ;
-    sh:message "Voeg een licentie toe aan de distributie of de bovenliggende dataset"@nl, "Add a license to the distribution or its parent dataset"@en ;
-    sh:sparql [
-        sh:select """
-            PREFIX schema: <https://schema.org/>
-            SELECT $this ?path
-            WHERE {
-                $this a schema:DataDownload .
-                ?dataset schema:distribution $this .
-                FILTER NOT EXISTS { $this schema:license ?distLicense }
-                FILTER NOT EXISTS { ?dataset schema:license ?datasetLicense }
-                BIND(schema:license AS ?path)
-            }
-        """ ;
-    ] .
 
 # SPARQL endpoints must declare the SPARQL protocol URI in schema:usageInfo so the
 # Dataset Register can identify them as APIs. A SPARQL MIME type in schema:encodingFormat


### PR DESCRIPTION
## Summary

Restore the schema.org-profile rule that `schema:license` is required on the Dataset, and drop the joint dataset-or-distribution constraint introduced when DCAT-AP-NL 3.0 support landed.

The repo originally required `schema:license` on the Dataset (`sh:minCount 1`). Commit 510a43c (“feat(requirements): add DCAT-AP-NL 3.0 requirements”) deliberately relaxed it: “Make dataset schema:license optional with inheritance”, replacing the per-row rule with the SPARQL-bound `DistributionLicenseRequiredShape` that demanded a license on either the distribution or the dataset.

In the schema.org world, license overwhelmingly lives on the Dataset (CreativeWork) — Google’s Dataset Search guidance, the schema.org Dataset example, and the bulk of harvested NDE records all treat it that way. The joint rule produced misleading spec output (Distribution + Dataset both shown as `Recommended`, even though one of them was required at validation time) and complicated the description of where license belongs.

This PR keeps the DCAT side untouched: `dct:license` continues to be required on `dcat:Distribution`, per DCAT-AP-NL 3.0.

## Changes

`requirements/shacl.ttl`

- Split the schema:license shape on `nde-dataset:DatasetShape` into two property shapes following the AGENTS.md convention: a main minCount/severity shape carrying the description plus an “Add a license” message, and a separate nodeKind shape that keeps the “use IRI not text” message and the v2.0 IRI-only futureChange.
- Mark the minCount shape `sh:severity sh:Violation`, restoring the pre-DCAT-3.0 hard requirement.
- Remove `nde-dataset:DistributionLicenseRequiredShape`.
- Rewrite the Distribution license `sh:description` so it reads as an optional per-distribution override rather than a co-required field.

`packages/core/test/validator.test.ts`

- Update the stale comment that referenced `DistributionLicenseRequiredShape`; the test still validates that pure-DCAT input is accepted without firing schema:license violations.

## Resulting Usage column

| Property | Before | After |
| --- | --- | --- |
| `schema:license` (Dataset) | Recommended, v2.0: must be IRI | **Required**, v2.0: must be IRI |
| `schema:license` (Distribution) | Recommended, v2.0: must be IRI | unchanged |

## Notes

- This PR is stacked on #1984 to avoid `requirements/shacl.ttl` conflicts; rebase onto `main` once that one merges.
