### PR TITLE
fix(requirements): render cardinality for properties without sh:minCount/maxCount

### DIFF
--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -75,15 +75,38 @@
                 {%- endif -%}
             </td>
             <td>
-                {% if property.maxCount == 0 -%}
-                    0
-                {% elsif property.minCount -%}
-                    {% if property.minCount == property.maxCount -%}
-                        {{ property.minCount }}
-                    {% else -%}
-                        {{ property.minCount }}..{{ property.maxCount | default: "n" }}
-                    {% endif -%}
-                {% endif -%}
+                {%- assign current_min = property.minCount | default: 0 -%}
+                {%- assign current_max = property.maxCount | default: "n" -%}
+                {%- if property.maxCount == 0 -%}
+                    {%- assign current_card = "0" -%}
+                {%- elsif property.minCount and property.minCount == property.maxCount -%}
+                    {%- capture current_card %}{{ property.minCount }}{% endcapture -%}
+                {%- else -%}
+                    {%- capture current_card %}{{ current_min }}..{{ current_max }}{% endcapture -%}
+                {%- endif -%}
+                {{ current_card }}
+                {%- if property['nde:futureChange'] -%}
+                    {%- assign change = property['nde:futureChange'] -%}
+                    {%- assign future_min = current_min -%}
+                    {%- assign future_max = current_max -%}
+                    {%- if change.minCount -%}{%- assign future_min = change.minCount -%}{%- endif -%}
+                    {%- if change.maxCount -%}{%- assign future_max = change.maxCount -%}{%- endif -%}
+                    {%- if change.severity == "Violation" and current_min == 0 and property.maxCount != 0 -%}
+                        {%- unless change.datatype or change.pattern or change.nodeKind or property.datatype or property.pattern or property.nodeKind or property.or or property.not -%}
+                            {%- assign future_min = 1 -%}
+                        {%- endunless -%}
+                    {%- endif -%}
+                    {%- if future_max == 0 -%}
+                        {%- assign future_card = "0" -%}
+                    {%- elsif future_min == future_max -%}
+                        {%- capture future_card %}{{ future_min }}{% endcapture -%}
+                    {%- else -%}
+                        {%- capture future_card %}{{ future_min }}..{{ future_max }}{% endcapture -%}
+                    {%- endif -%}
+                    {%- if future_card != current_card -%}
+                        <br><small>v{{ change['nde:version'] }}: {{ future_card }}</small>
+                    {%- endif -%}
+                {%- endif -%}
             </td>
             <td>
                 {% assign is_required = false -%}


### PR DESCRIPTION
## Summary

Several rows in the attributes tables (e.g. `schema:contactPoint`, `schema:encodingFormat`) rendered an empty cardinality cell because their requiredness is enforced outside a simple `sh:minCount` on the property shape (via `sh:xone` or a SPARQL shape). This change:

- Falls back to `0..n` (or `0..maxCount` / `minCount..n`) when a merged property has no explicit `sh:minCount`/`sh:maxCount`, so the cell is never blank.
- Adds a `v{version}: …` annotation in the cardinality column when `nde:futureChange` actually moves the cardinality – either by setting `sh:minCount`/`sh:maxCount`, or by upgrading a constraint-free property to `sh:Violation` (genuine “becomes required”).
- Skips the annotation when the v2.0 change is constraint-tightening (datatype/pattern/nodeKind/or/not), since those are already described in the Usage column and don’t move the cardinality.

Rendered effect:

| Property | Before | After |
|---|---|---|
| `schema:contactPoint` (Organization) | *(empty)* | `0..n` / `v2.0: 1..n` |
| `schema:encodingFormat` (Distribution) | *(empty)* | `0..n` / `v2.0: 0..1` |

All other attribute-table rows across Dataset, Organization, Distribution and DataCatalog were audited; no false positives or regressions.
