### PR TITLE
feat(api): add POST /allowed-domains endpoint

### DIFF
--- a/apps/api/src/assets/api.yaml
+++ b/apps/api/src/assets/api.yaml
@@ -34,16 +34,10 @@ paths:
             examples:
               valid:
                 summary: A valid dataset
-                value:
-                  {
-                    '@id': 'https://example.com/dataset',
-                  }
+                value: { '@id': 'https://example.com/dataset' }
               invalid:
                 summary: An invalid dataset
-                value:
-                  {
-                    '@id': 'https://example.com/invalid-dataset',
-                  }
+                value: { '@id': 'https://example.com/invalid-dataset' }
       responses:
         202:
           description: All dataset descriptions at the submitted URL are valid according to the <a href="https://netwerk-digitaal-erfgoed.github.io/requirements-datasets/">Requirements for Datasets</a>. The datasets will added to the Dataset Register shortly.
@@ -156,16 +150,10 @@ paths:
             examples:
               valid:
                 summary: A valid dataset
-                value:
-                  {
-                    '@id': 'https://example.com/dataset',
-                  }
+                value: { '@id': 'https://example.com/dataset' }
               invalid:
                 summary: An invalid dataset
-                value:
-                  {
-                    '@id': 'https://example.com/invalid-dataset',
-                  }
+                value: { '@id': 'https://example.com/invalid-dataset' }
       responses:
         200:
           $ref: '#/components/responses/Valid'
@@ -177,7 +165,7 @@ paths:
           description: The URL can be resolved but it contains no datasets.
   /allowed-domains:
     get:
-      summary: Check whether a URL's domain is on the allow list
+      summary: Check whether a URL’s domain is on the allow list
       description: |-
         Check whether the domain of the given URL is on the allow list.
         Only URLs on allowed domains can be registered via POST /datasets.
@@ -191,11 +179,45 @@ paths:
           example: 'https://example.com/dataset.ttl'
       responses:
         200:
-          description: The URL's domain is on the allow list.
+          description: The URL’s domain is on the allow list.
         400:
           description: Missing or invalid URL parameter.
         404:
-          description: The URL's domain is not on the allow list.
+          description: The URL’s domain is not on the allow list.
+    post:
+      summary: Add a domain to the allow list
+      description: |-
+        Add a domain to the allow list, so that URLs on that domain (or any of its subdomains)
+        can be registered via POST /datasets. This operation requires authentication
+        via a Bearer token.
+
+        The domain must be a registrable domain (e.g. `example.com`), not a subdomain
+        or full URL. Adding a domain that is already on the allow list is a no-op.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - domain
+              properties:
+                domain:
+                  type: string
+                  description: Registrable domain to add to the allow list.
+            examples:
+              valid:
+                summary: Add a domain
+                value: { 'domain': 'example.com' }
+      responses:
+        204:
+          description: The domain has been added to the allow list.
+        400:
+          description: Missing or invalid domain.
+        401:
+          description: Missing or invalid Authorization header.
   /shacl:
     get:
       summary: Get the SHACL shape that is used to validate dataset descriptions.

--- a/apps/api/src/assets/api.yaml
+++ b/apps/api/src/assets/api.yaml
@@ -191,8 +191,10 @@ paths:
         can be registered via POST /datasets. This operation requires authentication
         via a Bearer token.
 
-        The domain must be a registrable domain (e.g. `example.com`), not a subdomain
-        or full URL. Adding a domain that is already on the allow list is a no-op.
+        Pass either a registrable domain (e.g. `example.com`) or a specific subdomain
+        (e.g. `sub.example.com`) to allow only that subdomain. Submitting a subdomain
+        whose registrable parent is already on the list is a no-op, since the parent
+        already covers it.
       security:
         - bearerAuth: []
       requestBody:
@@ -206,7 +208,7 @@ paths:
               properties:
                 domain:
                   type: string
-                  description: Registrable domain to add to the allow list.
+                  description: Registrable domain or full hostname to add to the allow list.
             examples:
               valid:
                 summary: Add a domain

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -299,14 +299,19 @@ export async function server(
           if (result.error || result.domain === null) {
             return reply.code(400).send();
           }
-          // Only accept registrable domains, not subdomains or full hostnames.
-          if (result.input !== result.domain) {
-            return reply.code(400).send();
+
+          // Skip subdomains whose registrable parent is already allowed:
+          // they are already covered transitively.
+          if (
+            result.input !== result.domain &&
+            (await allowedRegistrationDomainStore.contains(result.domain))
+          ) {
+            return reply.code(204).send();
           }
 
-          await allowedRegistrationDomainStore.add(result.domain);
+          await allowedRegistrationDomainStore.add(result.input);
 
-          request.log.info(`Added ${result.domain} to allowed domains`);
+          request.log.info(`Added ${result.input} to allowed domains`);
 
           return reply.code(204).send();
         },

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -280,6 +280,38 @@ export async function server(
     await server.register(async function protectedRoutes(protectedServer) {
       await protectedServer.register(bearerAuth, { keys: [apiAccessToken] });
 
+      protectedServer.post(
+        '/allowed-domains',
+        {
+          schema: {
+            body: {
+              type: 'object',
+              required: ['domain'],
+              properties: {
+                domain: { type: 'string' },
+              },
+            },
+          },
+        },
+        async (request, reply) => {
+          const { domain } = request.body as { domain: string };
+          const result = psl.parse(domain);
+          if (result.error || result.domain === null) {
+            return reply.code(400).send();
+          }
+          // Only accept registrable domains, not subdomains or full hostnames.
+          if (result.input !== result.domain) {
+            return reply.code(400).send();
+          }
+
+          await allowedRegistrationDomainStore.add(result.domain);
+
+          request.log.info(`Added ${result.domain} to allowed domains`);
+
+          return reply.code(204).send();
+        },
+      );
+
       protectedServer.delete('/datasets', async (request, reply) => {
         const { url: urlParam } = request.query as { url?: string };
         if (!urlParam) {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -506,7 +506,12 @@ describe('POST /allowed-domains', () => {
     expect(response.statusCode).toEqual(400);
   });
 
-  it('returns 400 for a subdomain', async () => {
+  it('adds a subdomain when its registrable parent is not on the list', async () => {
+    expect(await allowedDomainStore.contains('sub.subdomain-only.com')).toBe(
+      false,
+    );
+    expect(await allowedDomainStore.contains('subdomain-only.com')).toBe(false);
+
     const response = await httpServerWithAuth.inject({
       method: 'POST',
       url: '/allowed-domains',
@@ -515,9 +520,36 @@ describe('POST /allowed-domains', () => {
         'Content-Type': 'application/json',
         Accept: '*/*',
       },
-      payload: JSON.stringify({ domain: 'sub.example.com' }),
+      payload: JSON.stringify({ domain: 'sub.subdomain-only.com' }),
     });
-    expect(response.statusCode).toEqual(400);
+
+    expect(response.statusCode).toEqual(204);
+    expect(await allowedDomainStore.contains('sub.subdomain-only.com')).toBe(
+      true,
+    );
+    // The registrable parent must not have been added.
+    expect(await allowedDomainStore.contains('subdomain-only.com')).toBe(false);
+  });
+
+  it('is a no-op for a subdomain whose registrable parent is already allowed', async () => {
+    await allowedDomainStore.add('parent-allowed.com');
+
+    const response = await httpServerWithAuth.inject({
+      method: 'POST',
+      url: '/allowed-domains',
+      headers: {
+        Authorization: `Bearer ${testToken}`,
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+      },
+      payload: JSON.stringify({ domain: 'sub.parent-allowed.com' }),
+    });
+
+    expect(response.statusCode).toEqual(204);
+    // The subdomain must not have been stored, since the parent already covers it.
+    expect(await allowedDomainStore.contains('sub.parent-allowed.com')).toBe(
+      false,
+    );
   });
 
   it('returns 204 and adds a registrable domain', async () => {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -433,6 +433,130 @@ describe('Server', () => {
   });
 });
 
+describe('POST /allowed-domains', () => {
+  let httpServerWithAuth: FastifyInstance<Server>;
+  let allowedDomainStore: MockAllowedRegistrationDomainStore;
+  const testToken = 'test-api-token';
+
+  beforeAll(async () => {
+    const shacl = await readUrl('../../requirements/shacl.ttl');
+    allowedDomainStore = new MockAllowedRegistrationDomainStore();
+    httpServerWithAuth = await server(
+      new MockDatasetStore(),
+      new MockRegistrationStore(),
+      allowedDomainStore,
+      new ShaclEngineValidator(shacl),
+      shacl,
+      '/',
+      { logger: false },
+      new MockRatingStore(),
+      testToken,
+    );
+  });
+
+  it('returns 401 without Authorization header', async () => {
+    const response = await httpServerWithAuth.inject({
+      method: 'POST',
+      url: '/allowed-domains',
+      headers: { 'Content-Type': 'application/json', Accept: '*/*' },
+      payload: JSON.stringify({ domain: 'example.com' }),
+    });
+    expect(response.statusCode).toEqual(401);
+  });
+
+  it('returns 401 with invalid token', async () => {
+    const response = await httpServerWithAuth.inject({
+      method: 'POST',
+      url: '/allowed-domains',
+      headers: {
+        Authorization: 'Bearer invalid-token',
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+      },
+      payload: JSON.stringify({ domain: 'example.com' }),
+    });
+    expect(response.statusCode).toEqual(401);
+  });
+
+  it('returns 400 without domain in body', async () => {
+    const response = await httpServerWithAuth.inject({
+      method: 'POST',
+      url: '/allowed-domains',
+      headers: {
+        Authorization: `Bearer ${testToken}`,
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+      },
+      payload: JSON.stringify({}),
+    });
+    expect(response.statusCode).toEqual(400);
+  });
+
+  it('returns 400 for an invalid domain', async () => {
+    const response = await httpServerWithAuth.inject({
+      method: 'POST',
+      url: '/allowed-domains',
+      headers: {
+        Authorization: `Bearer ${testToken}`,
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+      },
+      payload: JSON.stringify({ domain: 'not a domain' }),
+    });
+    expect(response.statusCode).toEqual(400);
+  });
+
+  it('returns 400 for a subdomain', async () => {
+    const response = await httpServerWithAuth.inject({
+      method: 'POST',
+      url: '/allowed-domains',
+      headers: {
+        Authorization: `Bearer ${testToken}`,
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+      },
+      payload: JSON.stringify({ domain: 'sub.example.com' }),
+    });
+    expect(response.statusCode).toEqual(400);
+  });
+
+  it('returns 204 and adds a registrable domain', async () => {
+    expect(await allowedDomainStore.contains('newly-allowed.com')).toBe(false);
+
+    const response = await httpServerWithAuth.inject({
+      method: 'POST',
+      url: '/allowed-domains',
+      headers: {
+        Authorization: `Bearer ${testToken}`,
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+      },
+      payload: JSON.stringify({ domain: 'newly-allowed.com' }),
+    });
+
+    expect(response.statusCode).toEqual(204);
+    expect(await allowedDomainStore.contains('newly-allowed.com')).toBe(true);
+  });
+
+  it('returns 204 when adding a domain that is already allowed', async () => {
+    await allowedDomainStore.add('already-allowed.com');
+
+    const response = await httpServerWithAuth.inject({
+      method: 'POST',
+      url: '/allowed-domains',
+      headers: {
+        Authorization: `Bearer ${testToken}`,
+        'Content-Type': 'application/json',
+        Accept: '*/*',
+      },
+      payload: JSON.stringify({ domain: 'already-allowed.com' }),
+    });
+
+    expect(response.statusCode).toEqual(204);
+    expect(await allowedDomainStore.contains('already-allowed.com')).toBe(true);
+  });
+});
+
 describe('DELETE /datasets', () => {
   let httpServerWithAuth: FastifyInstance<Server>;
   let deleteRegistrationStore: MockRegistrationStore;

--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -16,10 +16,10 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
       thresholds: {
         autoUpdate: true,
-        lines: 97.08,
+        lines: 97.34,
         functions: 100,
-        branches: 83.33,
-        statements: 97.08,
+        branches: 85.18,
+        statements: 97.34,
       },
     },
   },

--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig(() => ({
         autoUpdate: true,
         lines: 97.34,
         functions: 100,
-        branches: 85.18,
+        branches: 85.71,
         statements: 97.34,
       },
     },

--- a/packages/core/src/mock.ts
+++ b/packages/core/src/mock.ts
@@ -58,6 +58,12 @@ export class MockAllowedRegistrationDomainStore implements AllowedRegistrationDo
   contains(domainName: string): Promise<boolean> {
     return Promise.resolve(this.domainNames.includes(domainName));
   }
+
+  async add(domainName: string): Promise<void> {
+    if (!this.domainNames.includes(domainName)) {
+      this.domainNames.push(domainName);
+    }
+  }
 }
 
 export class MockDatasetStore implements DatasetStore {

--- a/packages/core/src/registration.ts
+++ b/packages/core/src/registration.ts
@@ -94,6 +94,12 @@ export interface AllowedRegistrationDomainStore {
    * Returns true if the store contains at least one of `domainNames`.
    */
   contains(...domainNames: Array<string>): Promise<boolean>;
+
+  /**
+   * Add `domainName` to the allow list. Idempotent: adding an already-allowed
+   * domain is a no-op.
+   */
+  add(domainName: string): Promise<void>;
 }
 
 export function toRdf(registration: Registration) {

--- a/packages/core/src/sparql.ts
+++ b/packages/core/src/sparql.ts
@@ -331,8 +331,21 @@ export class SparqlAllowedRegistrationDomainStore implements AllowedRegistration
           ?s <https://data.netwerkdigitaalerfgoed.nl/allowed_domain_names/def/domain_name> ?domainNames .
           VALUES ?domainNames { ${domainNames
             .map((domainName) => `"${domainName}"`)
-            .join(' ')} 
+            .join(' ')}
           }
+        }
+      }`);
+  }
+
+  async add(domainName: string): Promise<void> {
+    if (await this.contains(domainName)) {
+      return;
+    }
+    const escapedDomainName = JSON.stringify(domainName);
+    await this.client.update(`
+      INSERT DATA {
+        GRAPH <${this.graphIri}> {
+          [] <https://data.netwerkdigitaalerfgoed.nl/allowed_domain_names/def/domain_name> ${escapedDomainName} .
         }
       }`);
   }

--- a/packages/core/test/sparql.test.ts
+++ b/packages/core/test/sparql.test.ts
@@ -350,6 +350,33 @@ describe('SPARQL', () => {
         true,
       );
     });
+
+    it('adds allowed domain names', async () => {
+      expect(
+        await allowedRegistrationDomainStore.contains('added-via-store.test'),
+      ).toBe(false);
+
+      await allowedRegistrationDomainStore.add('added-via-store.test');
+
+      expect(
+        await allowedRegistrationDomainStore.contains('added-via-store.test'),
+      ).toBe(true);
+    });
+
+    it('does not duplicate when adding the same domain twice', async () => {
+      await allowedRegistrationDomainStore.add('duplicate.test');
+      await allowedRegistrationDomainStore.add('duplicate.test');
+
+      const result = await sparqlClient.query(`
+        SELECT (COUNT(*) AS ?count) WHERE {
+          GRAPH <${allowedDomainsGraphIri}> {
+            ?s <https://data.netwerkdigitaalerfgoed.nl/allowed_domain_names/def/domain_name> "duplicate.test" .
+          }
+        }
+      `);
+      const bindings = await result.toArray();
+      expect(parseInt(bindings[0]!.get('count')!.value)).toEqual(1);
+    });
   });
 
   describe('SparqlRatingStores', () => {


### PR DESCRIPTION
## Summary

Adds `POST /allowed-domains` so domains can be added to the registration allow list via the API instead of running SPARQL `INSERT DATA` directly against the triple store. The endpoint is protected by the same Bearer token as `DELETE /datasets`.

## Changes

- Extend `AllowedRegistrationDomainStore` with an idempotent `add()` method, implemented in both `SparqlAllowedRegistrationDomainStore` and `MockAllowedRegistrationDomainStore`.
- New protected `POST /allowed-domains` route accepting `{ "domain": "example.com" }`.
- Input is validated via `psl`; invalid domains are rejected with `400`.
- Accepts either a registrable domain (`example.com`) or a specific subdomain (`sub.example.com`) when an admin wants to allow only that subdomain.
- Submitting a subdomain whose registrable parent is already on the list is a no-op (`204` without writing), since the parent already covers it.
- Re-submitting an existing entry is also a no-op.
- Document the endpoint in the OpenAPI spec.
- Tests covering auth (`401`), validation (`400`), success (`204`), subdomain handling and idempotency at both API and store layer.
