### PR TITLE
refactor(core): extract ALLOWED_DOMAIN_NAME_PREDICATE constant

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,4 +1,7 @@
 export const REGISTRATION_STATUS_BASE_URI =
   'https://data.netwerkdigitaalerfgoed.nl/registry/';
 
+export const ALLOWED_DOMAIN_NAME_PREDICATE =
+  'https://data.netwerkdigitaalerfgoed.nl/allowed_domain_names/def/domain_name';
+
 export const COULD_NOT_FETCH_URL_PREFIX = 'Could not fetch URL';

--- a/packages/core/src/sparql.ts
+++ b/packages/core/src/sparql.ts
@@ -9,6 +9,7 @@ import {
   toRdf,
 } from './registration.js';
 import { Rating, RatingStore } from './rate.js';
+import { ALLOWED_DOMAIN_NAME_PREDICATE } from './constants.js';
 import type { DatasetCore, Quad } from '@rdfjs/types';
 import { URL } from 'node:url';
 
@@ -328,9 +329,9 @@ export class SparqlAllowedRegistrationDomainStore implements AllowedRegistration
     return await this.client.queryBoolean(`
       ASK {
         GRAPH <${this.graphIri}> {
-          ?s <https://data.netwerkdigitaalerfgoed.nl/allowed_domain_names/def/domain_name> ?domainNames .
+          ?s <${ALLOWED_DOMAIN_NAME_PREDICATE}> ?domainNames .
           VALUES ?domainNames { ${domainNames
-            .map((domainName) => `"${domainName}"`)
+            .map((domainName) => JSON.stringify(domainName))
             .join(' ')}
           }
         }
@@ -341,11 +342,10 @@ export class SparqlAllowedRegistrationDomainStore implements AllowedRegistration
     if (await this.contains(domainName)) {
       return;
     }
-    const escapedDomainName = JSON.stringify(domainName);
     await this.client.update(`
       INSERT DATA {
         GRAPH <${this.graphIri}> {
-          [] <https://data.netwerkdigitaalerfgoed.nl/allowed_domain_names/def/domain_name> ${escapedDomainName} .
+          [] <${ALLOWED_DOMAIN_NAME_PREDICATE}> ${JSON.stringify(domainName)} .
         }
       }`);
   }


### PR DESCRIPTION
## Summary

Follow-up cleanup to #1990.

- Extract `ALLOWED_DOMAIN_NAME_PREDICATE` to `packages/core/src/constants.ts`. The IRI was duplicated between `contains()` and `add()` in `SparqlAllowedRegistrationDomainStore`.
- Use `JSON.stringify(domainName)` consistently for SPARQL string-literal escaping in both `contains()` and `add()`. Previously `contains()` did naive `"${domainName}"` interpolation while `add()` used `JSON.stringify`.
