### PR TITLE
ci: cache Playwright browsers to avoid re-downloading Chromium each run

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -38,8 +38,30 @@ jobs:
       # - run: npx nx-cloud record -- echo Hello World
       - run: npx nx affected -t lint test typecheck check build docker:build
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | cut -d ' ' -f 2)" >> "$GITHUB_OUTPUT"
+        working-directory: apps/browser
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        # On a cache hit, only (re)install the OS dependencies, which are not
+        # cacheable; the browser binaries are restored from the cache. On a miss,
+        # download the browser together with its dependencies. The cache key is
+        # derived from the installed Playwright version, so a Dependabot bump of
+        # @playwright/test invalidates it automatically – no manual version sync.
+        run: |
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install --with-deps chromium
+          fi
         working-directory: apps/browser
 
       - name: Run E2E tests


### PR DESCRIPTION
## Problem

The `Run E2E tests` flow in `qa.yml` runs `npx playwright install --with-deps chromium` on **every** run with no caching, so the Chromium build is re-downloaded from `cdn.playwright.dev` each time. A stalled CDN download recently hung the job for ~49 minutes (stuck right after `Downloading Chrome for Testing … from https://cdn.playwright.dev/…`) before it was cancelled.

## Fix

Cache `~/.cache/ms-playwright`, keyed on the Playwright version resolved at runtime:

- **Resolve Playwright version** from `npx playwright --version` into a step output.
- **Cache** the browser directory with key `playwright-${{ runner.os }}-<version>`.
- **Install** conditionally: on a cache hit only the OS dependencies are (re)installed (these are not cacheable), on a miss the browser is downloaded with `--with-deps`.

### Why keyed on the resolved version

The browser binaries are tied to the Playwright version, and the two must match or Playwright cannot locate the executable. Deriving the cache key from the **installed** Playwright version means a Dependabot bump of `@playwright/test` changes the key and re-downloads the matching browser automatically – no manual version syncing, and no hardcoded version anywhere in CI.

This follows Playwright’s documented guidance to key any browser cache on the Playwright version. Note the trade-off: a cache **miss** (first run after a bump) still downloads from the CDN, so this speeds up repeat runs but is not immune to a hard CDN outage.
