### PR TITLE
ci(deps): update LDE packages fast, cool down third-party npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,20 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/'
+    # Check daily, but hold most updates for a cooldown so they don’t churn.
+    # @lde/* is excluded from the cooldown, so our own LDE packages land within a
+    # day of release while third-party packages wait out the delay (exclude always
+    # wins over the cooldown).
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
+    cooldown:
+      default-days: 7
+      exclude:
+        - '@lde/*'
     groups:
+      lde: # Our own LDE packages; bump together and fast (no cooldown).
+        patterns:
+          - '@lde/*'
       nx: # Grouped so they bump together; the Nx migrate workflow runs code migrations on the resulting PR.
         patterns:
           - 'nx'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,9 @@ updates:
         patterns:
           - '@vitest/*'
           - 'vitest'
+      all-other-npm: # Catch-all (listed last, so the specific groups above win): collapse
+        # every remaining npm update into one PR instead of a daily trickle of small PRs.
+        patterns:
+          - '*'
+        exclude-patterns:
+          - '@lde/*'


### PR DESCRIPTION
## What

Tune the npm Dependabot config so our own `@lde/*` packages flow in quickly while third-party updates stay low-churn.

- Switch the npm schedule from `weekly` to `daily` so `@lde/*` releases are picked up within a day.
- Add a 7-day `cooldown` for npm updates, with `@lde/*` in `exclude` so our packages skip the delay (`exclude` always wins over the cooldown) while third-party packages wait it out.
- Add an `lde` group so multiple `@lde/*` bumps arrive as a single PR.
- Add an `all-other-npm` catch-all group (`patterns: ['*']`, `exclude-patterns: ['@lde/*']`, listed last so the specific groups still win) so the remaining third-party updates coalesce into one PR rather than a daily trickle of small PRs under the daily schedule.

## Why

The distribution-probe feature (#1919) shipped pinned to `@lde/distribution-probe@0.1.3`. `0.1.4` – which fixes the Dataverse `Accept`-header handling (`IQSS/dataverse#12410`) that was causing false probe failures and doubled request volume – was published 5 days later and hadn’t been picked up, because the weekly schedule plus a pinned lockfile leaves in-range updates waiting.

A daily schedule alone would lower that lag but spread third-party PRs into a daily trickle (the `cooldown` is a per-dependency delay, not a weekly batch). The `all-other-npm` group restores low churn: each daily run yields at most the fast `@lde/*` PR plus a single grouped PR for everything else.

## Net effect per daily run

- `@lde/*` updates: one grouped PR, no cooldown, within ~a day of release.
- Everything else: held 7 days after release, then coalesced into one `all-other-npm` PR (with the existing tech groups – nx, comunica, etc. – still separate).

## Notes

- Config only takes effect once merged and Dependabot re-reads it; it won’t retroactively open the `0.1.4` PR instantly, so the manual bump is handled separately.
