### PR TITLE
fix(browser): bump Playwright to 1.60.0 to fix Node 24.16+ install hang in CI

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -38,9 +38,35 @@ jobs:
       # - run: npx nx-cloud record -- echo Hello World
       - run: npx nx affected -t lint test typecheck check build docker:build
 
+      # Only set up Playwright when a project that owns an e2e target is actually
+      # affected, so config-only PRs do not pay for (or flake on) a browser download
+      # they do not need.
+      - name: Check whether E2E tests are affected
+        id: e2e
+        run: |
+          if [ -n "$(npx nx show projects --affected -t e2e)" ]; then
+            echo "affected=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "affected=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # npx playwright install --with-deps is the install method Playwright recommends
+      # for CI (it also advises against caching browser binaries). The download stalls
+      # intermittently and has no timeout of its own, which used to wedge the job for
+      # hours, so bound each attempt and retry to fail fast and recover.
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        if: steps.e2e.outputs.affected == 'true'
         working-directory: apps/browser
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 300 npx playwright install --with-deps chromium; then
+              exit 0
+            fi
+            echo "::warning::Playwright install attempt ${attempt} failed or timed out after 300s; retrying"
+          done
+          echo "::error::Playwright install failed after 3 attempts"
+          exit 1
 
       - name: Run E2E tests
+        if: steps.e2e.outputs.affected == 'true'
         run: npx nx affected -t e2e

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -47,7 +47,7 @@
     "@eslint/js": "^10.0.1",
     "@flowbite-svelte-plugins/chart": "^0.2.4",
     "@inlang/paraglide-js": "^2.18.0",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "@sveltejs/adapter-node": "^5.5.4",
     "@sveltejs/kit": "^2.59.1",
     "@sveltejs/vite-plugin-svelte": "^7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "@eslint/js": "^10.0.1",
         "@flowbite-svelte-plugins/chart": "^0.2.4",
         "@inlang/paraglide-js": "^2.18.0",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "@sveltejs/adapter-node": "^5.5.4",
         "@sveltejs/kit": "^2.59.1",
         "@sveltejs/vite-plugin-svelte": "^7.1.0",
@@ -15459,13 +15459,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -28138,13 +28138,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -28157,9 +28157,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
## Problem

The QA job has been hanging for days on **Install Playwright browsers** – a step that normally takes ~20s but was wedging the job for hours (observed ~83 min before manual cancellation, reproduced across re-runs).

## Root cause (external)

A known upstream bug: **Playwright < 1.60 hangs during `playwright install` on Node 24.16+** – the download/extraction worker processes die silently and the parent hangs on stale IPC pipes (microsoft/playwright#40724, #37666). Fixed upstream in **Playwright 1.60.0** (microsoft/playwright#40747, merged 2026-05-09).

We pin `@playwright/test@^1.59.1` and the workflow uses `node-version: lts/*`. When the runner’s LTS rolled onto a Node 24.16+ release a few days ago, our pinned 1.59.1 started wedging. The Playwright CDN is healthy (sub-second latency probes), so this is not a network/outage issue.

## Fix

- **Bump `@playwright/test` to `^1.60.0`** (lockfile bumps `@playwright/test`, `playwright`, `playwright-core` to 1.60.0). This resolves the hang at its source while staying current on Node.

## Hardening (defense-in-depth)

- **Gate Playwright on affected.** Skip the install and E2E run unless a project owning an `e2e` target is affected, so config-only PRs bypass browser setup entirely.
- **Bound + retry the install.** A 300s-per-attempt `timeout` with up to 3 retries, so any future install stall fails fast and recovers instead of hanging for hours.

`npx playwright install --with-deps` is kept as-is (Playwright’s recommended CI method). No browser-binary caching is added – Playwright explicitly advises against it (restore time ≈ download time; Linux OS deps aren’t cacheable).

## Notes

- This repo doesn’t use the `@nx/playwright` plugin; the `e2e` target is a plain `nx:run-commands` running `playwright test`. Installing browsers is always Playwright’s responsibility, so the install step stays in the workflow.
- Because `qa.yml` is a `sharedGlobals` input, this PR marks all projects affected, so its own QA run exercises the new install path on Playwright 1.60.0 end-to-end.
