### PR TITLE
build(deps): bump the comunica group to 5.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2631,13 +2631,13 @@
       }
     },
     "node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-5.1.3.tgz",
-      "integrity": "sha512-vbdSYF/BKH+aiTJXLcR0YAMDxTrma6v8Bsfzxq0/srAe4TWlgw1iny5noMGUPiP5LauqiLgnIcDNgyaAoTz3dQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-5.2.3.tgz",
+      "integrity": "sha512-9zgeR4U8cdB10Mb9VSOuhzJGiufSmjb1N+CwVMQY65gOjXPmfXcybFjzGFKPFbmYOsB2mmL1aht/AXzODlJcaQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -2645,12 +2645,12 @@
       }
     },
     "node_modules/@comunica/actor-abstract-parse": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-5.1.3.tgz",
-      "integrity": "sha512-5oGYbEdWSBWwwN2TF15etay53yc1v59fGVnARxGD05J8HyQCw9syQT7ZgvaicVv/tmQ09PI2LnMKJbxsgj+eHA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-5.2.3.tgz",
+      "integrity": "sha512-/eEGBmJzbasYjjl+PVgCLQYNQXMt0Ni+sD9Xg+JQf+3oTa7MpfHSMZ6ZV++H3OufJaNid3gkUxZrufFm+k0giA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
+        "@comunica/core": "^5.2.3",
         "readable-stream": "^4.7.0"
       },
       "funding": {
@@ -2699,18 +2699,18 @@
       }
     },
     "node_modules/@comunica/actor-abstract-path": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-5.1.3.tgz",
-      "integrity": "sha512-YiaQwsFxWlnRt/O9f0MAJNkLBz2lv1e+rZuH1u25yWul06YJR5/VFv7FAf5bsvwoJMsO9TrYO3SaVp577infvQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-5.2.3.tgz",
+      "integrity": "sha512-E/+3d9hU0Ks7JDlyvNkoARKNmY/71cW22rBGJq0UxUfrNrK0SjHALREyOcGAOKNDdGcbOzbs6cbpDPXAK/N9DQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-string": "^2.0.1"
@@ -2721,122 +2721,122 @@
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-average": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-5.1.3.tgz",
-      "integrity": "sha512-r2tjjSlmVzzBAWMBWzNy8PDXlT7kdDDew4lgAyv9Veg89/JfTPVNOYvBrtyRktPtbUtiPvu6Ow/7qlsO1XVEZA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-5.2.3.tgz",
+      "integrity": "sha512-HS7ETQmtwIFTOkRP3mRD8PKvp3ZsSTXRpn76Poo17a9VdNhLMoP0vEBTdSH/4SXWiBtvyY7W30etsX+/VPRDdw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-count": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-5.1.3.tgz",
-      "integrity": "sha512-a/MiLt26IUW7WO+KOH7UfixTmSaSTf2NE2qSfVu5K0x9lG7DZywvz5uuJWgZmmD5UecpYK1iaLb+5xCrQMe2sg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-5.2.3.tgz",
+      "integrity": "sha512-Ne1LJOEhZyYmGj7xynagGUm5BoGow4sM3b0UaxaChKOdEdWI1kBdXdknatonL5jXEL168AcYNafxlGgSJwEU9w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-group-concat": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-5.1.3.tgz",
-      "integrity": "sha512-ZcG0XlE7OIGftsYBcv1iYCxyOBlLqPsKTHHI87tWkXRG6IAC1v0ZDuRZHvbd2e91hmmHtzYGJUhZmpEzG9jEyA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-5.2.3.tgz",
+      "integrity": "sha512-+JAaj+ZCAiaqsilN7/EqIFvjK3NFWnmksNOJyppNOgaSF3GwRVbyTsP6i9YOudHoZBAl+nPzyclApLKURpwkkw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-max": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-5.1.3.tgz",
-      "integrity": "sha512-xksCukc7oLMeIqRg377qi/voWUTR12v0UIkNNOt4nLFOcX9C9YbTWku+GBPT9P7EqCwaQ6XhSy72tLxBM0yb1Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-5.2.3.tgz",
+      "integrity": "sha512-fN602hX2gZuPFUjuQByriHz/FGY3+s5QobXoHSJbZF8EjtoecIUelKDr0czQBmyMsl1k4zUjc9JfkPGOFn9YCg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-min": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-5.1.3.tgz",
-      "integrity": "sha512-pCZnxsAekTBucQ2/8F0f4QVeDM4BYJ31gpuvrLCkXhA0E1AqBzb0IwRYI8Eo0cNuuxIU72J0Bb8apVLrtKrs0g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-5.2.3.tgz",
+      "integrity": "sha512-nnKlgNhpVYJ0GRvDprVsf/p8kKgd0sJBBFdwGSUvN1mvzuC8nXyDQOTun3EoUqBjaKjSGCevMBIyVyu4RQtKlQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-sample": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-5.1.3.tgz",
-      "integrity": "sha512-VichDq2FPjKPHlhwKB9rKohyF+eqjcmSwUHvXz4ILbWmH0A3kVUQdt03DMqCpUy5qSvfc8x1VuRNx8UYs29t7Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-5.2.3.tgz",
+      "integrity": "sha512-XKYvKOS3Byaye7P+IE1vs6VmE7d3IVZ2+Sh3wv0NCE8Du8jQrkHkIA7JJsIN/UPEP8DG4hSaH9IFGKgjJ26+Hg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-sum": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-5.1.3.tgz",
-      "integrity": "sha512-yA8wh43hUJx6QD+x7K3OCPvg0lolsEdy+ro6nXHeyGmeimxAlrClLMiSf63+CuvyS8iIdKW31CN+A4WCNbEPyA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-5.2.3.tgz",
+      "integrity": "sha512-emSKR/i4L9nQ4eBI5BXIyNz8vlBHLyyTD7BONOQnqQLY/jn0Y/AUqgGet0nGxI2X2+dUEaDDYVvvwhkbo5XrZw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-bindings-aggregator-factory-wildcard-count": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-5.1.3.tgz",
-      "integrity": "sha512-YZgs4sf4GD75F8s4+t04FGiiJyt/esYuiPhGYl4m9BzcnOo6eMyDb8AD2bMb6V6AczlrBoTfEusc7rsLhryLnA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-5.2.3.tgz",
+      "integrity": "sha512-KnvpJ1VjOAVp1HtmG7xOJpHnj2InWBPoq5CBidmo/AB9Ppq0q8ES3Rh38qKH+lIaumZze5cd5ZCpo85LOUqjLA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-string": "^2.0.1"
       }
     },
     "node_modules/@comunica/actor-context-preprocess-convert-shortcuts": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-5.1.3.tgz",
-      "integrity": "sha512-HnFsTUNls/HdZRK7xzj+PX0hylBnzIIU7HQFVEyqL2w1Nu5YFHAWgA3Tb1mDClE1kuHwMcL3+b1ZWWwZgp87lg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-5.2.3.tgz",
+      "integrity": "sha512-UwAUHluJYLlu7N9dAYpM0/aLzIzWOM5cBd6YNELQkuSIBkUxpofOtZ/zQvwuhgwbsOxPQFusT6IXjrIOPX9mLQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-context-preprocess": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/bus-context-preprocess": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3228,15 +3228,15 @@
       }
     },
     "node_modules/@comunica/actor-context-preprocess-set-defaults": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-5.1.3.tgz",
-      "integrity": "sha512-IYC4sqzdoW0SqIlH6l/idg5F9ZN4tTNpeIIKgCk/s/ubqAt3IWF5hefIxJp27pato+qCwQf3KKAGcRh9BdY71w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-5.2.3.tgz",
+      "integrity": "sha512-77RyL6xbmeltmtAfEBHz9FUtHlZ4dbXt3xK9wXXsK4pzDl42xbNUlFNiodlakyZxna40H/qAjbWzsiyJG1/4Aw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-context-preprocess": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-context-preprocess": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-data-factory": "^2.0.0"
       },
@@ -3246,15 +3246,15 @@
       }
     },
     "node_modules/@comunica/actor-context-preprocess-source-to-destination": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-5.1.3.tgz",
-      "integrity": "sha512-wY4WHiwIyv7MiAaaaY+J7aDLNJMjwhXOb6LHOn0CheCNnfagr2PZf10puFtYGuRXuMEMXvftmTM7CWOe170vlA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-5.2.3.tgz",
+      "integrity": "sha512-F17yPV2YzFtOWsfz9Ake7yHZHwnMdWqPm7xbHTIWpmN9aEbfcDmjcDWLTilFDNjMhIRQE/7b+HUXUuXDu/3IyQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-context-preprocess": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/bus-context-preprocess": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3262,13 +3262,13 @@
       }
     },
     "node_modules/@comunica/actor-dereference-fallback": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-5.1.3.tgz",
-      "integrity": "sha512-Vgx2rUJXme/HDQ9i5rXdoe1j4Ot6w1SFKTin+E3dwr9IW3QbbQ8+cLw6yWu1M8TIdsj86jKuFvKhmk1sV0+zzw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-5.2.3.tgz",
+      "integrity": "sha512-a87NJTCNP121zwhnyzyO/uDpM+uBvqeR35u5qMH2pihug1fAKMfDLcaQfxV9fKAUbG+bZAeaXLzH7wfF2fWR+A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-dereference": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-dereference": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3291,15 +3291,15 @@
       }
     },
     "node_modules/@comunica/actor-dereference-http": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-5.1.3.tgz",
-      "integrity": "sha512-DDWvSAc/ByIVUgKRkvTub/8a+Ay0u6a2u/gdDdTzU0twZFLfZ3rJDWwp0+297Zk+jndC+waN8xfqgRGnVoKu2Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-5.2.3.tgz",
+      "integrity": "sha512-DdNmvrQR51fdslmWOOMo58Cnlkq1gR7ucyWRZx0Feel3AMdf+8mGZwCL5AgrI7ZKeVNnHxHSOoH/PBhCoeI5hw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-dereference": "^5.1.3",
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-dereference": "^5.2.3",
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@jeswr/stream-to-string": "^2.0.0",
         "relative-to-absolute-iri": "^1.0.7"
       },
@@ -3309,14 +3309,14 @@
       }
     },
     "node_modules/@comunica/actor-dereference-rdf-parse": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-5.1.3.tgz",
-      "integrity": "sha512-1h6A/OBg++brmlObv6zAY+wwq/Q3PIwkrtgcNbmnZcHBTcTn6vTzTX7ZVmRoTp88V02e5wTsAZ45R3vDujEgDg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-5.2.3.tgz",
+      "integrity": "sha512-Vnmu69lbbO1OFod8bTGGKA6lBa/aTokw/Kzyo8eEvZykFl1JTaC/ppkMHzUhxmtmObv/6UoVvlBtI3Yp1mhJrQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-dereference": "^5.1.3",
-        "@comunica/bus-dereference-rdf": "^5.1.3",
-        "@comunica/bus-rdf-parse": "^5.1.3"
+        "@comunica/bus-dereference": "^5.2.3",
+        "@comunica/bus-dereference-rdf": "^5.2.3",
+        "@comunica/bus-rdf-parse": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3324,969 +3324,993 @@
       }
     },
     "node_modules/@comunica/actor-expression-evaluator-factory-default": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-5.1.3.tgz",
-      "integrity": "sha512-rG7MRKnkpUW4vHPyy4OR5MC0zP5XgZf2eSNFPRVn72fkvhffD+mqj37ek1e2VouufhCndEl6nDYLLCw51ThmrA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-5.2.3.tgz",
+      "integrity": "sha512-1qruJBABB0L42z6UlvrrUbX6hVHkIqzXwgGWwBgqMsb089nHzzwEt4aH9BltWI0HHA/Q40x4owS4JHlFiOJWVg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^5.1.3",
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-expression-evaluator-factory": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-bnode": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-5.1.3.tgz",
-      "integrity": "sha512-TbfPi9IZR3bdBToygwlsELvz0YIOv6IYn8EE13snmOXpCG4L80nAsmHSWe23DBLsdmjH6rF9lPKajs1grgluIg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-5.2.3.tgz",
+      "integrity": "sha512-6vqoL3QvSefjwA8rfElpOOVipB8VyE3npSSRXO/XiDr1Z4C7Sm5DoptR84bpaWOiuNvpNba3sLU9O61vyFu1SQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-data-factory": "^5.0.0",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-bound": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-5.1.3.tgz",
-      "integrity": "sha512-JU2JDa2FJqnokRRfiywlbKfzUuX5hxGEewdZJ1GVWThpFV6kow2xfoX71qRY5hh1tvyuJv3bqTUTdKAgzJcRag==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-5.2.3.tgz",
+      "integrity": "sha512-+GlgEPq8mqTC2MPPPgmiTWLBci5I6zAL+EaIM5jEaAMFDWSW5Qo8GpZgGasQgD+p9wElrCNPm0mj6XFxUE76Lw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-coalesce": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-5.1.3.tgz",
-      "integrity": "sha512-qX1osTdcqpIOO3eG9zGk43T8B/BWed+8X0p/BCWLpWB5eT/mvxCCQNiaowmIK/A6L2EmNfgo1bK/rXiHCHh3sQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-5.2.3.tgz",
+      "integrity": "sha512-NOmvfI3pBmlW9v5ERrIio6zTSahpBnTrRWryn/68BQIRlv+Rf6Fqjd2xgzWpfWR9eWkxrzLCarL2n6afNa48nQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-concat": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-5.1.3.tgz",
-      "integrity": "sha512-k7Ixv69XHkdWPDrETgKrbuk6pBQXUkBa2KQWh6bJO4yL1NRtR05Xe0sVmf1Ejd4r6fKG0dOGoFdDxP3iOzIMsg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-5.2.3.tgz",
+      "integrity": "sha512-B7XD9A+PtHsOvmFSAFcg1Q+NeVJJoaA91SGojAyvkEs/zOVP5bn1PjE/xH5PcL1XUSEONImD5dRrFOzDBH571A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-extensions": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-5.1.3.tgz",
-      "integrity": "sha512-ZHKReFE1+CR2rDXSMR07W/Niones4C1nFJHLFRl4UhUAyKKOQ+Re05SYRXpKCQuVvyuV3trAyv7ET2CwYJDrVA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-5.2.3.tgz",
+      "integrity": "sha512-OBO4V0nOCRPR/wvC63/X5lUUHBJ86hBfmI4lTgTLfjEwVTNjxeqIDxE3H4JhuoXQ5U/mzFakB+MeOIyXkJ3VMA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "rdf-data-factory": "^2.0.0"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-if": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-5.1.3.tgz",
-      "integrity": "sha512-RtXrrddDyp7ePM+elHaBQpIYP5AWHcnbZekqfIS5SpvgzXoxj52mO6w4hMK3SyfVPwvG6LTYBhxqPKho/mEpDg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-5.2.3.tgz",
+      "integrity": "sha512-6tG9rAqNX76mobQNHC9bj6I7kPGj3SdvCMTg9PmRRox86su7RBhT7Ig3jDFvvIG3/fX5IuV37C05L+pm+GJ48Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-in": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-5.1.3.tgz",
-      "integrity": "sha512-fBgsRozSBogLbAw0atUwULMYFn54xSfbrcuGt/fueLgK2CG389WVkqyZJ8cVz+/b428MELjm7yLBTdZBn5bH8g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-5.2.3.tgz",
+      "integrity": "sha512-EUmSFVmM/fwntDnex+TCGWvlA2vNpo0gsPvs2D91rKjrw//pZR4hDYT2EdfG0tb5E8WRN0dOdnUm+9H01WOITA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-logical-and": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-5.1.3.tgz",
-      "integrity": "sha512-p8ZoUBxddwh1q2vEaDOlLAunfev4XCHCusdzM40zegPuZrAJcNoZm8zHhSVWN0YKiYGmXKlXkTa870nQXQZ/sA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-5.2.3.tgz",
+      "integrity": "sha512-i0c4Q0OJIxpQzgzmInrGf1geQG4uVUEE000U9ovA22QVOUzaBE+NpM57MDnNZzvXr/I3TiAotqtUWANA9qBIMA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-logical-or": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-5.1.3.tgz",
-      "integrity": "sha512-xmQyoqd/kPuhuHl+f4OzTkp0NaULl6Ss/km8YEYMSlIcbHO3k5Hq++ZfjTl0KHNAJvkqpFD4ukdVkh6DyFzsWw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-5.2.3.tgz",
+      "integrity": "sha512-s1gGKE/pA3/cBl7GwPYtO4zUFOVvO9WJuX/+zpFpxUiO0hhrqgMo9P8eUaDijuuy1iexCewfznI7bWWSK5lw+Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-not-in": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-5.1.3.tgz",
-      "integrity": "sha512-XzIqRJ7tJYcbe8jhk0QGb1z6jf47DRGdIgQUkAD/PKvN89fVNekRPFgOtDado3udfck/+yXzBgap1qd1D30SAQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-5.2.3.tgz",
+      "integrity": "sha512-M+QnT3fLMtiYZYc8zuGuNTxWeZSH3RV36y2PFZkXN1+Ait6omgwOjcr6FEzAQPD0QzDfu7oNuCej0Vp54BOphQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-expression-same-term": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-5.1.3.tgz",
-      "integrity": "sha512-8T/+NF7OW2yrsd6bV8DHQpyR5nt06gel0ntLYul8l4rzKGrBgJrK/d7vuZZi5rXCuauK8DoOsgsTUWeRPQ9j2Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-5.2.3.tgz",
+      "integrity": "sha512-ZlosA74V5T0MMLhLYpbRVTYiFheZTAa2oiGNl/OCOMxm96mNnNDMnlTGUDGU+BIUhsoiy2cwveTorXUZseAm2A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-abs": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-5.1.3.tgz",
-      "integrity": "sha512-Y3ZNzAZfpueZY4QusCvB1GP+zYDcyHoHTrgKgvymyX4o1Nd/sfE0zzZkBYIU0O2DVBT9n1sc7p4yyMf/vEccUw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-5.2.3.tgz",
+      "integrity": "sha512-J5BX1N9l188NV4epgXyZNesVLSZEd1RONneXi34gSNIb2zTui+2J6XhcdrbVnZr/rlI647no0qpGsCDlp2x4SQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-addition": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-5.1.3.tgz",
-      "integrity": "sha512-qXDTFAirN7RKnYXiGOHB5bU8LpKoppIkU/uJ5pB+cUx65NLMEm0xwFCaEXuAQ/plF7z6hCQn4tOmCIiiIgn/cw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-5.2.3.tgz",
+      "integrity": "sha512-oX91XZJLo+YKeq26fMkFRwpTJLofm9G5Ip7ctDwYGHTJRwq5XEd3bL4faeOlEmTShRiAB3cbUokMirVHzn8lFw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
-        "bignumber.js": "^9.1.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "bignumber.js": "^11.0.0"
       }
     },
+    "node_modules/@comunica/actor-function-factory-term-addition/node_modules/bignumber.js": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-11.1.2.tgz",
+      "integrity": "sha512-9idDyC15Vpk+53w4OfxEu2PqHSKFQUffrH1oTvnkJ9fduTJ032tpuI2sxS04oCzocklokWUZmWVEkTEQdLmUOQ==",
+      "license": "MIT"
+    },
     "node_modules/@comunica/actor-function-factory-term-ceil": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-5.1.3.tgz",
-      "integrity": "sha512-qCB42PLfWZrHU88HWutcgaKJNybhqgvo6sLvk2bZNe9tRgQwxS0NPR2mZAlxQHf7DN3fJy9j6g81XCqsyCfk7w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-5.2.3.tgz",
+      "integrity": "sha512-3HId+H3bJwys+DADJz+j9QMm8y4NTPEZ7Sz6+Kkmx6ncZV5T5Md86dTOpU1xyP5NYBPB9/98NUBlOecH9CpXVQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-contains": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-5.1.3.tgz",
-      "integrity": "sha512-oddB//hRq4le3yZT7Mh7U2np6ZgePRUtlaTeKs+WKp4y7I5DYvsq+My6fsnQ6gvgwehKlFb4YGjxYhjmw+R5qg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-5.2.3.tgz",
+      "integrity": "sha512-t7/KSsnRUTCNlvVChVVi/L3IcmA7CDE+CryNHCygo5czrxGAt0GvAuHJ6JqAfhOdcjoGCdZ7MpWVbhPzGoE31Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-datatype": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-5.1.3.tgz",
-      "integrity": "sha512-kU317ilk071W53lx7hGAmmD4qFikTQO/tubXo2F0XtX5B+9bSBzexBb6AWzpUHq2oaxu0FCysXHmhJSAQTrLTw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-5.2.3.tgz",
+      "integrity": "sha512-tEidXD12PIFJ5qFHcw9A/8650tr0RnL9frt7WhZfnh5eqDumDNAugbFD1VNLouJ9Q/yIYFA4AQfGQUE/wItmjw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-day": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-5.1.3.tgz",
-      "integrity": "sha512-XcZlmxodsfszn/yzvQDjQXtWrzJIU1AWEC2fSNSMY5JKTmFEVpkVN9UsSP1tPOsvmniQ2EM6v4u2E5AnWoHf0Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-5.2.3.tgz",
+      "integrity": "sha512-D399Dke60415JRCFyuV2tglwRNjjc90I/HaFTagrViWerTwyHj7ew4+poJwcnqzITburp/k43GpB+7FTgTaNzQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-division": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-5.1.3.tgz",
-      "integrity": "sha512-5PV5dzdQTJbtKqt2TKzXwcFs+jLVMQpFtE05AGmBeeugOZcvpBC68TI6UGQMnCgUz66nE/RgOcz8hzI4M+EOZQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-5.2.3.tgz",
+      "integrity": "sha512-YMMwJPld3uJ6VYPcvAr+nNL00yfi68KunDwwawz8b1iJ1edcYgGBn039dP53y05FEPa2z91pLLUkJqDDzXVn0A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
-        "bignumber.js": "^9.1.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "bignumber.js": "^11.0.0"
       }
     },
+    "node_modules/@comunica/actor-function-factory-term-division/node_modules/bignumber.js": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-11.1.2.tgz",
+      "integrity": "sha512-9idDyC15Vpk+53w4OfxEu2PqHSKFQUffrH1oTvnkJ9fduTJ032tpuI2sxS04oCzocklokWUZmWVEkTEQdLmUOQ==",
+      "license": "MIT"
+    },
     "node_modules/@comunica/actor-function-factory-term-encode-for-uri": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-5.1.3.tgz",
-      "integrity": "sha512-bKv27rEfyWjgOwnNqxrJ5BBVbiL+/azDRPQD4lYtOnVezKJWSdbcF6VUehBhB+fOMf1MLincDUwvnW/UfbGSaQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-5.2.3.tgz",
+      "integrity": "sha512-ZTdT256QHCriLdGhEHKo8Id2UV1Bb64Zse01NETX4mG6Sozftxk4lTjswbrDIgwJiHhkqOGjpOwx6rlvOAa5Tw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-equality": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-5.1.3.tgz",
-      "integrity": "sha512-QJpVSjBvQ/yv9T4moT7/KvoGyKgCp9p4KsQJO1in8YaRKKU4qTzp49JXoSxOTjSts2NjD3MfEqb/aM6XkJ6zcA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-5.2.3.tgz",
+      "integrity": "sha512-3cHGE4i2kMnAAj1xO+68HxQOU0BB6uohDasCZp5q7GDsz+pjBbYJdnC2cekprNkwX6xT9THD82xa0+ro8bAQOA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-floor": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-5.1.3.tgz",
-      "integrity": "sha512-AjBhXK7/ts+TdgE6OKybBfKaJewgItmXegSvE7bkHvfD0RxNC9nQ68aSRiFajFbH0HBqPxQMu2aF4ORzQRPVyg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-5.2.3.tgz",
+      "integrity": "sha512-BhnBFknVSWdsxlmmJTeofdAdXvmc9r9coazdjtaRKncHhX8OFI/imxm/gaRkvto2WNpzturTrlDR8iNCwkRfEw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-greater-than": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-5.1.3.tgz",
-      "integrity": "sha512-y3OMO6SOsXkN03XdkLGQbwNuvy76lsLjcV2Hqx1A4Ev1OXcjgsePgoctVhp+OvwCpYsVIxVrGwEApeC7+d5RKw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-5.2.3.tgz",
+      "integrity": "sha512-9p/pO2c2e17e65KeOK0sSfjBK1EJmYvne9IolZrC7NYVxYlUv+wGa2H3yGacZ+0A7q5UfgXxGBfAAJmlTzisaQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-greater-than-equal": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-5.1.3.tgz",
-      "integrity": "sha512-cB5AZe4Lut2GtECirlJJmMsfJNzEtQTYSm1pZM/ojsi+K6ww2Ch5R45ALZxr37dpiAp0McdV/44YnaxrVOKf/Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-5.2.3.tgz",
+      "integrity": "sha512-bhhZU2eOvtW0DOvTUz3fCEUFV6zR6YrhLFKZqAmoYJI21umL6CySDSC6OuyiMGGFiqoAGC+3Wlc+rNV5PM/xqw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-has-lang": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-lang/-/actor-function-factory-term-has-lang-5.1.3.tgz",
-      "integrity": "sha512-jE9JUBw/MQnaClzD57ZIrjf6FUhZmEa3/QjpxvXjhh5Utf8zpFjTzw754dkDYkvoxyu36pwCUIGZ5bS9yX+OyQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-lang/-/actor-function-factory-term-has-lang-5.2.3.tgz",
+      "integrity": "sha512-NVHZD2nVqeiQDJCaLqlLa4dVwtWGyQmcrrcaJc+rej+alszJu0L+5J6zBO8SV3uJQGWlrQlM01mIkNb+vVZkXg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-has-langdir": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-langdir/-/actor-function-factory-term-has-langdir-5.1.3.tgz",
-      "integrity": "sha512-of+JP2AKtLMVg/FbVSey6ya6qmo+tzWc/c2C3QW1iCiQCeDwlU1Wl7u2tvR8kmMINoA26pxN+hEuB6SrWyg8VA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-has-langdir/-/actor-function-factory-term-has-langdir-5.2.3.tgz",
+      "integrity": "sha512-hig9Uux5aULHm69BxjVBomZwKj6O2FPVETq2QGgYcsb4TuQ1BzQgCLg+DvB88WTQ4Cw9ADn7yitITV/HH6vzTw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-hours": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-5.1.3.tgz",
-      "integrity": "sha512-8B79ORJBle3sDp2hYOvCJ/XF4vjH3q3DVP8oTVgsKjGrqfQyi+mN8tQQqVsctvVSRKv7x+OluyvMEOiEUQB/DQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-5.2.3.tgz",
+      "integrity": "sha512-+I9GECZWDB7iHEynaTMJWYp9YWp+Ng1ITH3Q4SoXymeA5N4sXkYMn43ImAee5nyPcJqDl/K8wl+SzlEvrIdHDw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-inequality": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-5.1.3.tgz",
-      "integrity": "sha512-gt0SjsUR5rnIyQ4AjEXNcetJ9ox6bk1iOyaZY9Ba3Or47qA8HrXXcrqwQBMB60jhw81Q8F2mIMvUHxq+CAsRQQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-5.2.3.tgz",
+      "integrity": "sha512-g+GRZlYBlKYPiBukNGWii7V7REo6arjZixK3VvIWMDMp1OKiXyBgw+TsSP0qL2oRp1QOeqZ+vn4xYbQt31VAgA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-iri": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-5.1.3.tgz",
-      "integrity": "sha512-k3HnbC7Y7JE/E0T2ZvINzqf2n6KMdIDvo696eBr/RjYH6GwfxA4pGLlWsbylOvwrnO6mreDQayMg381Duu4cpw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-5.2.3.tgz",
+      "integrity": "sha512-LK/W7/+QBfQe9gRaVkD0NpuIjBQpNS17r6FOXUVY+ltBQiEosJ7ruR0EoRq8OKKowSTj0SNBF9LzgFbBuRGvTA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "relative-to-absolute-iri": "^1.0.7"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-is-blank": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-5.1.3.tgz",
-      "integrity": "sha512-QsVwQFWx5jda5jmL3S9ciym4enMm0rzQ7Lq2/9CRcdDkMcxWXgYguTbVwKuHBrisOtVwE9q1esNrFf/OhXDjSQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-5.2.3.tgz",
+      "integrity": "sha512-YMg3ILzc/anvWMQdh57wX/d+S35y6GFGOhLe8VB0i1krVYh7WZ7/cXv0TdDU93Z+9lfhUP/mwNLCVeAikQBujw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-is-iri": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-5.1.3.tgz",
-      "integrity": "sha512-8qlSla8wMvHFwS5hpsnlEdWXl0d+ErsHPqUCPM85T5rofA/SUdGNLnbprnAKngfejDKjkaaXl1NDnHPtsPNCVw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-5.2.3.tgz",
+      "integrity": "sha512-vuQSOszkwraqlfME5fkYZ3mIq5VHmpqXsvWdqM+eggdmKV8QCrgLzOqYXigzp89Zi9Z0PZHNyEcNikb6tm35RA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-is-literal": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-5.1.3.tgz",
-      "integrity": "sha512-CxGEq0qkVfm3IAg9O+hnglrTLcB/fIGCzWEfQvioTdlZ97cXgEArcPgycECkX58jGStPZlsCR6u7vT0blYjLrA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-5.2.3.tgz",
+      "integrity": "sha512-cUyfzT+F+BdX416Sg+xjJaMxRBc9uXSnQMcu3VIWKzf/KsxIHcwkn0OJ+6wS5kIJ9sCGKQvg1d2+TqGOeG0c+w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-is-numeric": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-5.1.3.tgz",
-      "integrity": "sha512-yyVISxO6zdBBqm2Y/x5aMJtuCAscfmfG2ZlPa4kjiAWwGyhx791/7SgVATFsERwMugY6exRl0RuRLBb92kUTKA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-5.2.3.tgz",
+      "integrity": "sha512-VfCSqgusBPy1YcOGePhxqPDuTNTIh93BkWdH7Pf+pWvaD0ZXCYamWKzU9Vs3tzJWpLxX21C3S232und2hF/Lsw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-is-triple": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-5.1.3.tgz",
-      "integrity": "sha512-0T2lKIqowZMToed8SfhXG+k2nhERhrIZdBia6f7oahCdZcoz6IkYufrGwQ3f0JvHXiXChZCI3q/N3RLNK9/33w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-5.2.3.tgz",
+      "integrity": "sha512-oFMvktwb3nELeYF8GdS//T+4mIRK7T2jYNwiPrtdyCX7CbO1lVc9HpogAYrjAqVi7uUjo0Y7vqhywTEvMA5Wcg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-lang": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-5.1.3.tgz",
-      "integrity": "sha512-eEEtwaOHWfK/OYyFAKjI8xWg35ZZTrdookV/2aog5PP5+PmRenAC7krIPPInFksbhXLjjguWu6sRhdPohMRGRg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-5.2.3.tgz",
+      "integrity": "sha512-Gn6WwApJcRPhkY5gzzdAt3HIbp68PbfEeuaQJ6JT4IM5dn2F76RqFKrv1vc3k8wp8mytMBBIXPloLV/TXSYgbA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-langdir": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langdir/-/actor-function-factory-term-langdir-5.1.3.tgz",
-      "integrity": "sha512-I+6GavZW93bPMcNUOCVCc2dqOHKy4Pyq6wSEYDhrkrJ1LsdWsvMKxV84OB+4XXnpUpU7fP1gD5GgQdX/7GICtw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langdir/-/actor-function-factory-term-langdir-5.2.3.tgz",
+      "integrity": "sha512-8Kt2DYkShnCyR0Y9wJioQ0naQs/73yPHp+4cAGxXTKL/ScUvZElGzbzmmKx3gSbClFVKZaxKEbuw8YUhlGTXQQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-langmatches": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-5.1.3.tgz",
-      "integrity": "sha512-q57UgmRh3P416jCOVz9x8INRYhtEyDKzYjA40U5aMTeLF6cDYomSEERerQH4hDkgGlLPweNxeHP/+rrLhw5Twg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-5.2.3.tgz",
+      "integrity": "sha512-a0BC0ruzOFeqMj+D37Io9F+9IpeVpXf7ba81CQEHIn4Eogmw5hC3uIihbVz9n9ez1tTe35syS+x400TDoEVxaQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-lcase": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-5.1.3.tgz",
-      "integrity": "sha512-W5tL/AjcdLmBAhfqgvfVOh7Evx0HcfiHkKWhRQsOF3+juMC1yqL0sLVvXzDErGrJUJOgTvkr1QXP7UgmT+FsAw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-5.2.3.tgz",
+      "integrity": "sha512-HuWHt2udsrWUToRvjJrQ1x1jPXOlCCPKTGmih36tg2VLOnMKclxbNLaXF3tdk37Cz3f8HxDdhMd49psRpXyAgA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-lesser-than": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-5.1.3.tgz",
-      "integrity": "sha512-M0CC3CRcw0E/2NuRcHhT4MEOxvp8GQyNtSeqDQPJE4ri75C6bKfmMBFVToX2FVAcfJO6yaXomdE/cRO6Sc4r6Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-5.2.3.tgz",
+      "integrity": "sha512-4RBsGziZtNIC8VSerZBCauKU7GXpJwgW6x/BcU4jBNEnJpV3dPUmLUQYC4ml5BAJKJVI5zrDASdQEtB7+Fmo2w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-lesser-than-equal": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-5.1.3.tgz",
-      "integrity": "sha512-iaweBrllVC1YRjoyBeVWr0g1PiIAxUNKX2agP1sFeMmZv8MhW+63I7vflk9I66+t0qMNQpELmAJ7qrpGKrcNfg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-5.2.3.tgz",
+      "integrity": "sha512-e6NFM5Hjz1OMRjB8TL+eRHLuymytsJhBfI/DtZu9rMRv1IWyHHzbJzGdEsvyTnRMnrH5R3IwNociOAwixjmb7A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-md5": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-5.1.3.tgz",
-      "integrity": "sha512-xvdPLK1rWQQvjujsicV69nn11HwCepzLTQnMuhsL0KXQ6lexcDhORSjTtufuOoMQ8+AARb03S972bGEbXN9m1Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-5.2.3.tgz",
+      "integrity": "sha512-Vh6SAunNRAAr3XKXZXo12ZwXXsbq/7eKCY9O7ru9nEbbNTp86QeUpvkJ5KgwOG/dSNhLcJyM1CRGDJYD/DQG6A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@types/spark-md5": "^3.0.1",
         "spark-md5": "^3.0.1"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-minutes": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-5.1.3.tgz",
-      "integrity": "sha512-ZE79NTZ3TvbG9XD58JuItrX+XbvtAO89Sqpgboju9fPxiruF7x5pqyx/gLvpazOauZ6NOwWNOeVa5zGSdY3SHQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-5.2.3.tgz",
+      "integrity": "sha512-L4PrKkhwf86rzFT3E17xlbqcPnalZByGitk50l0Sh+Bpu3NYjmJ+FGpoUyVbeLhEyaP2DypbyYfCNHM62t8rPw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-month": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-5.1.3.tgz",
-      "integrity": "sha512-cRS9zhzpfBqPo2zP58/X1idHNWacFMQRHdIO45Gp05O4cak4nxDT2ckvVctoN0O+2Cd56zyySLNRtSvShBaipg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-5.2.3.tgz",
+      "integrity": "sha512-WZKkBz1grvZ8u3Bc+C7wOP4CelZip0M6/VMdckZQM5cSAnyW/0ckRL9l+6jKuqtbnqrQZ6vtDHhbBLQdpH1tIw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-multiplication": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-5.1.3.tgz",
-      "integrity": "sha512-57gI8xdXXdZwJq1b2ZUJrawjiD8fmXLLz+O2mSaMuEtt/YbOaUi1J7P3SAuNiUczZDB1/f4DK/0I0Z7kwZmhcQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-5.2.3.tgz",
+      "integrity": "sha512-EzStbRZXuQ6qOu2AdmNs0nld8hn80dyELvlKVp3gZa6mTcnSjgFJVHQvuxKJ+OPgvXL2QHjH9Y5jy7S6Wjx6bQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
-        "bignumber.js": "^9.1.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "bignumber.js": "^11.0.0"
       }
     },
+    "node_modules/@comunica/actor-function-factory-term-multiplication/node_modules/bignumber.js": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-11.1.2.tgz",
+      "integrity": "sha512-9idDyC15Vpk+53w4OfxEu2PqHSKFQUffrH1oTvnkJ9fduTJ032tpuI2sxS04oCzocklokWUZmWVEkTEQdLmUOQ==",
+      "license": "MIT"
+    },
     "node_modules/@comunica/actor-function-factory-term-not": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-5.1.3.tgz",
-      "integrity": "sha512-dloJ0O6YsCMUlt7OIm29258yTHvdmjW+JEnnK9OFn4FXcb9oEQjSotVz1wkfptyhKtSG1TKYFWWxy5nmN4qy6w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-5.2.3.tgz",
+      "integrity": "sha512-6HJ16o9gdgzGrK6ze3Y1MKArswlcOTnyMal5WwMZSmu+LxD5iArRjLI6kwDxjh5+WOKeF6cgrTuCYA7obevWMg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-now": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-5.1.3.tgz",
-      "integrity": "sha512-s7OchjNQc94Qyw8eCj2CFRx0hQtcuH2catFg0nx2hva3cn//mrLXuEeSqZS3E7ilMlOHvqmcjXhEINl6kihHOQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-5.2.3.tgz",
+      "integrity": "sha512-bQXfC/pr2PkVbMRy76HLXVAbG1n244QQAOc8ft+Wxc59NrCm+427DWEuCPWk/8N/o20mEw6fih0zZYPDfhRlDA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-object": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-5.1.3.tgz",
-      "integrity": "sha512-L7QNIja8tzpLt/MaNk7yysyCc4oDWyWzMVVwIawGAh95ceFcfjaYgk4mvm5dqH16kB0vBVZWlkdJ2UbXNJZhXw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-5.2.3.tgz",
+      "integrity": "sha512-IbW3BQkKqCNu7O24DpAIVk6KqiZBD5329tPj9vNQDp+g2iHXS88ajnBC1e8J9/7uhEegTLvVTDYAD68FC/dY3A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-predicate": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-5.1.3.tgz",
-      "integrity": "sha512-zId2EMoGVDfV6b4/6s9pj2qYxv5Sg2vQRcBxPcCRmNb6jENmjgcMxot67B6Qo+0gIj5Kn5Y7mF2PCvhIdrpaFg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-5.2.3.tgz",
+      "integrity": "sha512-jci4vVP4mtaYIQksbMV1fkJJ+1gpQjbPiSjgjK9CrdXyNZC1tgGa+31bn13CXV7gsVw4+mtyGAGtiB6Oba3H3w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-rand": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-5.1.3.tgz",
-      "integrity": "sha512-QDdxcxJZ7ru/ScETVbKwqQUa+pT/JczyegTUbe5/+EGDwgp+IfH6tR7kmjzTvNZNZVtEX/M6ZM4ufjjrVXpBNg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-5.2.3.tgz",
+      "integrity": "sha512-IvAgZkq95Zs4GzueH1yi7EW4wgsFJg2FF8VF4FHH/eMHToh2hNh+W/LktUCLVv+hv+VVDf7JVM6Y7zmffJPpFg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-regex": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-5.1.3.tgz",
-      "integrity": "sha512-7PFv5vgggOV4vtGy9pUqcOpigGuPJDZAjoTMplsV8Fb59XyMB5M86y0/zIqK9pP7fpgI3qJ/k2Vv+JqTQt5IqQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-5.2.3.tgz",
+      "integrity": "sha512-hhGUhVcOm8hyD2Nsa7Gc0YEONbS0p9FgcyZD/vrv6gJPp146g3o8xOX6BFmHSUqMqTSRPfF1gyuJ+8mxzRVZRA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-replace": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-5.1.3.tgz",
-      "integrity": "sha512-sXzHcXfofeKJ9tJJ/0JT4i97McwdBbFXcCR//u7EU+ZXam5DTCHG8r0jetcD652fCh8RGIL0OUHKpk4pWZYeNg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-5.2.3.tgz",
+      "integrity": "sha512-+wEb4iQqTU1/3atOPhDh3eH2/AJkJeFtBH0evNlcF4EhBindJSnIm0GTbtBuav9YA6u4sed9+riDgu3Ce/WumA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-function-factory-term-regex": "^5.1.3",
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/actor-function-factory-term-regex": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-round": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-5.1.3.tgz",
-      "integrity": "sha512-A90Izh7YLpaTCvS55R76LU/B5k+jISAAFjtiGM1RoNJ5gtk/hbJ+vZIfky8LxGhm7p6m9FvO2qB19KD3Mz6oKg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-5.2.3.tgz",
+      "integrity": "sha512-e1avFDjHJLm2vR1BeR+RISy+IwEsjNnooRaLZvCoe/t1ymtmapMuvzd77x46Jp79TGdLcDvOqQ3OcbHH8/PZCA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-seconds": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-5.1.3.tgz",
-      "integrity": "sha512-D6QbT7oDzQL3hXD/N26o4r0XjX3ncoWa08mhvFOD9GVyLoKypGfMSS8lwFxr+i4DLtyisPXxNCGKgVvZigD22g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-5.2.3.tgz",
+      "integrity": "sha512-7nQ59A4zFs/Nu6pm2gwk0e7uUyeV034XnS3WRgJn+KjG2w/TsFSv0SSdcCf2Dn3tar4gBkA0FcHBFDFsXp3/jw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-sha1": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-5.1.3.tgz",
-      "integrity": "sha512-InguNZZb/nf5wyb1YuwS7HV3BhWNSlL+7BqUtnjDVihSA2F0HDj2dyqfYyBPw82JEO8M0GJeZIB5KcQbuZGgnw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-5.2.3.tgz",
+      "integrity": "sha512-Brf2d2/Rh4LlbNHKKvfXXt/G4KTCfoY4BVhlZeXDBU6MidST1EycMz0BNRm8ypaoJUpoQsyVXVWwx0UpECTAPQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "hash.js": "^1.1.7"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-sha256": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-5.1.3.tgz",
-      "integrity": "sha512-5AbrMYi3+JLaniH2y8lIo7uZHaQ6chMOPbvelUh0Ww60TorP8u52O3ySAYDWaJAq3WkRBoPYL9RacfOnu2Kqmw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-5.2.3.tgz",
+      "integrity": "sha512-THYYNtAktmzD9/CNoV8P3mNX491fC4ZRJRZsC5TdKk/N9E7o7wAsNuMjc0C2iL9lgIOEXX0CTu50mhYCvmZQsw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "hash.js": "^1.1.7"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-sha384": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-5.1.3.tgz",
-      "integrity": "sha512-uUL0GJ29SMqH4QQrq8W0xg2gTl2YAzyYMy+Jw1Y+VFW7tfTeuMRglDur+St3SLzkmFFarMZOFjPXnCd6bhPi3A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-5.2.3.tgz",
+      "integrity": "sha512-4CRgRUPD2ZRekVJbKe8WbuRAfITueMz5xGc2vh5fNZ1rXwVCAZMKrivNWXFJ2vhG6PoYLhETfdqIVjX+fcx3hw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "hash.js": "^1.1.7"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-sha512": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-5.1.3.tgz",
-      "integrity": "sha512-S1nU5THkNTZXyha2R6Kw4vf8ov3kV3Y77O76i7d5u754eJdQTH7Zjr4js+BrBjbTOS5Lsim9VPYyTjc7PKBhbQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-5.2.3.tgz",
+      "integrity": "sha512-DhtC3OvBbgNbipJAMufdFUi5z9V99OHqSzrBt2635OV/1/jlypYCJlxStfmW23YoL92TGBRGfAw0jPuA9iUsbg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "hash.js": "^1.1.7"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-5.1.3.tgz",
-      "integrity": "sha512-ufP5prAmmp0J8rijADqsMjh5IG5j/K04KYODkFEMFJAsYBMjv5AecANRG4nlGkvP7lIpVpxVZ8EVE4xSDLacsA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-5.2.3.tgz",
+      "integrity": "sha512-Z56Bj49vrwHZESVkaH1NwOMd5A4YotSXcpn5Y/le18rF0oHhrvtyCOam8/oii6NIdEYMu549WZoA3AGL4WWNlQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-after": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-5.1.3.tgz",
-      "integrity": "sha512-z5yXU4kaK7MmkRxPYl6SqipT2Ho8nIgUTqieIdG9L4XcSaeFLqiMyogFDlZd4fXc5Dla/4zu5b6MFGqvzd85mw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-5.2.3.tgz",
+      "integrity": "sha512-4GSvMd2v5ziHs8kxGJmghYJBnMeieBJjzAjKX1IsX8osIpYbw91zZ7/rVYZHFQI5C05Wsww0LLOuu9G1GVJgnA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-before": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-5.1.3.tgz",
-      "integrity": "sha512-Gklto9pH8JcYYNpbMk5R47mdYppG2AP7/ZZRvjY47rsK1OoxSm5IdvtkB5MfzmGF3AXNRtCfPAtoxGjRKYpfIQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-5.2.3.tgz",
+      "integrity": "sha512-2bqaNg5Z/8gMhtPttLQTq60lfZE+l1QcqB8bBBQeyUEbia6nTQNnaSGaHsHMbhdD0JQ5wegCNerD68YzP45DeQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-dt": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-5.1.3.tgz",
-      "integrity": "sha512-EnWblVppmznNUjm/nuSKDoehL3HzEOY+xFY6BAj02TrUH6BUS/S6NwXIx+nxJTPUBlsLg4QHFZ6VsriwXvI4Wg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-5.2.3.tgz",
+      "integrity": "sha512-UqZhYuaQbBKIh3rgxDynEY43/jMT/Q/WKjI+HiKAwbsBJWcbzGYIP3zuAbAlOYS9fRgBCUFnsfNhbSxY3MFkOg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-ends": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-5.1.3.tgz",
-      "integrity": "sha512-X/EUa+AjEWEcS6JpDd7b3sY/Pbdwa9fjc5XEqUY48dGIa8zPJa8mLrhE+4MM1MxMJ6QoI0/9J2jjN1Sc6OSQUA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-5.2.3.tgz",
+      "integrity": "sha512-VKBNRWNJkTiQJUmgeEwc+6H/obgVfM7nR9LGi2trUTyl+R3jdM4GECf5VuO6hGb6nOWZ4ctBNUBg3esm24TJ6A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-lang": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-5.1.3.tgz",
-      "integrity": "sha512-S7AREjtcZebq7Hco09DMWbp5AnlrGKekDoqs8bQJHzpDc4a9aLYX1/3AboyoFP7GQWw6dJLfyszQ6I2NV/fdXw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-5.2.3.tgz",
+      "integrity": "sha512-r01Ivtcca1AwVdC8aVkJ2r2xblSWdtqFNVr6FxPSDGO+7lpSwxXSJC+sim0oEZv/ps2MUN4Hzk2ezP689Kj2bw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-langdir": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-langdir/-/actor-function-factory-term-str-langdir-5.1.3.tgz",
-      "integrity": "sha512-HHLwkxBARSRsVtyP6JzkwhcddbUW7/Ce5E5o041ZGbl3DLmQTMR+x/+6fB3Ao6HDaNHGhSvaT+lrFyK/zo5rKQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-langdir/-/actor-function-factory-term-str-langdir-5.2.3.tgz",
+      "integrity": "sha512-eE6/kHkF4C3z4GiOTYL6CrbtoOnpJjJHE0R9I49wne9BxBKc4/y+PamLQDOlLQKaGa6NveN7ZRO2vjl+VLLacg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-len": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-5.1.3.tgz",
-      "integrity": "sha512-pAF1MiemoGiJIXiOc72fx7BiBgqVxxjZORxlmaTnvlz/GgzH3B+VGGzHLuWhY8lQ79aW42oOc2PXTLYWHrGuOA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-5.2.3.tgz",
+      "integrity": "sha512-bxfm/l3pksJxysTioXP26meyu+S0XOqPhFpftDubH9zy2WG/FNPbyZ5quFRzl+DYu6zjskrX0IhEcvZSHvWsfA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-starts": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-5.1.3.tgz",
-      "integrity": "sha512-6LdV8WlMLc4hi4BZCq6a4gOB193v8AwYkj3Vc62Ba1+3pRd31XmWbHg5RsDKTXlbB+DYQpNz7DoW9wYiw3NdYg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-5.2.3.tgz",
+      "integrity": "sha512-YKPpEaK37RgtBJVyWsyKe02YwEBN5n2EAaSCp5YmtjGRqUgadgM+vL4ct1B/jUsof6hmkLkcj4VluPLwp0Rv6Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-str-uuid": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-5.1.3.tgz",
-      "integrity": "sha512-O/+9IuFRkmOrcIZmfNGp+XCT/17UvXnwGPWW/1lUVzZm60Jcf4wjQnI1aUmoLy9DCP6G3gE9/8gvSyP+gYrYoQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-5.2.3.tgz",
+      "integrity": "sha512-MxLR8UCG8W9sGJNCpe2rZIodjigPZlQpBePfr9VvYPjytnJ4lw3CibyxGvVQxo2tXwJ58umyi4Po1R/n0EucPA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@types/uuid": "^10.0.0",
         "uuid": "^11.0.0"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-sub-str": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-5.1.3.tgz",
-      "integrity": "sha512-jKzv1LmqD9+2HE3v3FA+3txuAP1ACgxVwHsDXN/9JwMZXpFyhfqhulz7hDlmYwm3TEPY7g5IqsQv9sAMc4dAQw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-5.2.3.tgz",
+      "integrity": "sha512-HyJfcw80ATurSVLplrZDePDSJubcVKTAxOaVwpH0qZQj8dM3PyayEjDQQL3zbX11S0EQeb2D2YUy4tH4sQxnhA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-subject": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-5.1.3.tgz",
-      "integrity": "sha512-DpGtUVGA9ewjssR7YNFDjbwjN2vMoG0Cmcsmg6traxpu9l3QK2M6y/s7hviHYN1NYghf0lUoDRNlG1f5CwdnPg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-5.2.3.tgz",
+      "integrity": "sha512-nIndDG6cuvkJyjkGOiV/8hwZ9jAUTYd/zIDPNCHQ4HwwX8zccD844YzkGsNZWrD4ytSqUvX5E4C5x5LFEWq8Gw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-subtraction": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-5.1.3.tgz",
-      "integrity": "sha512-krUL2hGggN2bTyoUyTgyo+JqvsDmID9nJtEQoGPRlH0iDS+EyWVW7AbFKCfuveqZKRLRLqLeZgNLWZLzA6krQQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-5.2.3.tgz",
+      "integrity": "sha512-3NaMrmuQdaPn3HR+JAeYFxI3vE6cM92iu9vVJ5mMZuDfpPXwRUoRIFZfNUw7WEcvP2UVRqPzFp5HvRxbBsSUNQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
-        "bignumber.js": "^9.1.2"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "bignumber.js": "^11.0.0"
       }
     },
+    "node_modules/@comunica/actor-function-factory-term-subtraction/node_modules/bignumber.js": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-11.1.2.tgz",
+      "integrity": "sha512-9idDyC15Vpk+53w4OfxEu2PqHSKFQUffrH1oTvnkJ9fduTJ032tpuI2sxS04oCzocklokWUZmWVEkTEQdLmUOQ==",
+      "license": "MIT"
+    },
     "node_modules/@comunica/actor-function-factory-term-timezone": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-5.1.3.tgz",
-      "integrity": "sha512-3UZQp+XaKX95wGDa6/Xh7FyaHIHEQyFbwGFNTR0XGyHAu2OLCzJZ2XL5nd+nb4q+anP+Vc5UrhGpexm/yONlyA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-5.2.3.tgz",
+      "integrity": "sha512-mDVGVx0OX1NiRkLQqg95qRaq0R6xwv8LMa018R6AiwW0DZZXcOdbhy7QXShM1QW/uZCi/oE+ByM2iZwO3m8DCg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-triple": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-5.1.3.tgz",
-      "integrity": "sha512-Zov320A/dBAoavJ+Zu3VTuIu7DW0zTM6r1GiqffvKYguPjNAm0bsXQOXSEOMkliEFrUUp3d0vqGmRZaiWtwf0Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-5.2.3.tgz",
+      "integrity": "sha512-BGc8sQoafDTNes41wqotd5KoDsTfKT7rrPqqwE1fN9woqSXKu8U8RZi268Mei2VSDejMsZwppZcgXYb7c+WMYQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-tz": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-5.1.3.tgz",
-      "integrity": "sha512-vmLB0AIx6KUVhzLj0xXyKs2UqmosRyLZvcgP6uA7CAhjxshoEtQ7JX3bmWbeM3Fx8W/Wb3eb1XopyUE39cHKOA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-5.2.3.tgz",
+      "integrity": "sha512-fPXxtqxqXgGvoCiYQtRsj62XCk/EkHAsZnfsrstooVRJevs4nvODEXDAQgyX8O3GKz+Px7eDU5t/wPafHdP6FA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-ucase": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-5.1.3.tgz",
-      "integrity": "sha512-3tXlj/IzwY5y4j4XGzXbn3p+OszccVEl1ijh+tjHfHrlTU/yJnPy0mIQQZrhTJzg6sizKRMYE0WYEHSabCQUCA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-5.2.3.tgz",
+      "integrity": "sha512-NnC9lO3rTQp69ZYMLkdGDDUpG4hDDQmrhaf2797AmwH6grS+erIYX0ZSoTZHO/vlPK1kvcfJq1TK3Yz+a3BZQg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-unary-minus": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-5.1.3.tgz",
-      "integrity": "sha512-PVhRKzvQf9Oxu698bmVTWvbNc3/2mZLD7IQ420ZKVIzZmPOR9d5Pd7FCapXS7I6ogoQ7Mc/63oeJhcHvSFuCTw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-5.2.3.tgz",
+      "integrity": "sha512-0MlqACFeDSl9nNfMKWR7jYwRMBmS8XMxSTf40VPvb4Z4+6q5wsvbOHMGmCESjr3PuWtxzlpZll6i+NjivCCYXA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-unary-plus": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-5.1.3.tgz",
-      "integrity": "sha512-8r4mOJhqc2Zrq5qfOmiK6ZAyzP0Fo8XH/icCDRagGkRCVb8bnI3dmC7HSFu7wnLwgSyKgd4NuLUfWTMF7zw7qw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-5.2.3.tgz",
+      "integrity": "sha512-3+D8e3KFKwQOcTBDsAPS6KW9wNzTAGbF3AVb4By81Mz0LIFeBoUWUKZ+2Sfg49fforHjv33Avs7Tw4CtAZrUKA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-uuid": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-5.1.3.tgz",
-      "integrity": "sha512-Mp76K770ZTvWaUoqOELdTX3tZZuFtHyFnGHy/aKw3DOOHDwvHAR6rssqdYV2VmVwZMDF6Rnzr0oZamGJ/RTsjQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-5.2.3.tgz",
+      "integrity": "sha512-HCS7Q2hXanEMfxE/ovRSLOEu+0SSDwUlYQTOB3HCf4Mi4UNkjtQ/0Q0LImQ9qtfcs/6D8OPVC1rJyOpotpHaQw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@types/uuid": "^10.0.0",
         "uuid": "^11.0.0"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-boolean": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-5.1.3.tgz",
-      "integrity": "sha512-k+BwCv+KqosWOZ2dSNU3aXb8XQb0A0i/HsvQ0C/PGRmq280QScpAh7SDiXwjE9hSZnffFjjWxugcoD2TLpdr0Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-5.2.3.tgz",
+      "integrity": "sha512-p/puRFYcgFEw6oXeL8nMrdUl/Kp2fmoc3vT+mlmqwmDFsB7DBnn6r7WzvXVYkNnTAYZCBr1op2e+yk0XpXtHqw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-date": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-5.1.3.tgz",
-      "integrity": "sha512-CSwyrdCzoXemL9+qkomkAu4vi1kXuZLuYgOhmPltXWcNAanY/QDYYwfNS5FukNTz3OR79yYC5NVI7RKQm+a+iQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-5.2.3.tgz",
+      "integrity": "sha512-k4mfJr3lwVOi0EEMrkjWEXIe8dznFffP7vaFTTh2B0XbOE210p2T83731Y1aiTEa31TwdAOR2dku3N40tTwnKw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-datetime": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-5.1.3.tgz",
-      "integrity": "sha512-O0TiaJBwqvaf7V+wOmpNkR0uno/dagEkTZAgUzzWDZeZc3iAnb+TqBDL4IqqROL6Il6/tmNSgmAeed3veKl7Iw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-5.2.3.tgz",
+      "integrity": "sha512-48Ecpp11HHiKKzErkYteYOouzt/XtYwp1zwfM/gpe+JbYv9RfUdfCECXvPHGluyA+fhJDqkUpEhGWOzwIxI7JA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-day-time-duration": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-5.1.3.tgz",
-      "integrity": "sha512-nEMSUF71lTcPdZtlatmnrC4PiASJboZz07k3EoY/k6pQNWiWaKNKYhnRAmRlCeblXFBA1Kf1lrgBJoa8F+aEUg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-5.2.3.tgz",
+      "integrity": "sha512-J+XHLC7s2+Xd2tMPMSjJ2wSCU3u/vnM+044kAor0w5EBiPML2cRmdZKyvSwIAy2c7aXuxdvrZOXwtwZiTqgD1w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-decimal": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-5.1.3.tgz",
-      "integrity": "sha512-Pqb/CIAx9+TG6Y76TPmfABAKXnefTnLi0s4lqCLPD1A2eMt7l9EaicmwVK5L/gAgojtC+99AMlzavY+3iekjpg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-5.2.3.tgz",
+      "integrity": "sha512-toM74B9LdOMYaeUXimtCJlZbccFwf2ccL8Rf32QuGfNpPGvZjZUB6arrhxIb3W743maRWUTntgujKI4vcRqNpA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-double": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-5.1.3.tgz",
-      "integrity": "sha512-3Fxg5Dj2uOY0qrTjyHlt+KnDu3NPm93NRIZVHPS6JJ+diaMJWJNZKr/83TwEWKUccsUFo/6BLEP7DZV6zoOqhw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-5.2.3.tgz",
+      "integrity": "sha512-XHIMhrp5eJkWyuWK0khQOVoGA5YtMOk/SY7PQZgsLR+VTXVjHpPu0CKhry/ST6xLKUsSekzXxm47TwAXLVPjbQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-duration": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-5.1.3.tgz",
-      "integrity": "sha512-Sa9IoZdZxvXnybIE+2nuy97Oz+0rZBq45FtLvDj5GV8wwUXUY3lGQj2VSn9V5Vk9SevlnK4/GmBoNn+QTOY3NQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-5.2.3.tgz",
+      "integrity": "sha512-Gtlor9JeyuTkw9KaEJVf/QgZ4/mkvlbFxDZ0wTQi89pl03ZS5v4JCeP7NICiyFfWQzSoeD/6hbCSK+rrJL5t4A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-float": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-5.1.3.tgz",
-      "integrity": "sha512-BwcOgtH+aMiU6o9a0pV0j1nAsPcg8+7QZgwIsxh5dYQkhbjZ/q9eaRimd3jZM4xskcM6WM0P/ioRSHRAmDz9Pg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-5.2.3.tgz",
+      "integrity": "sha512-qlnK7tjv74QZdmAepv0wjO45U5cOf20dKe7b/iepBEKw8V1JAsSY9jJlehpXYrBwHlW0tYw7iTYc22hVlZCVtQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-integer": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-5.1.3.tgz",
-      "integrity": "sha512-lRqIc3zZSeofzztaj9XLj4S5hRD/lVch9rJdaYThmVr3VbqN8kKAtYKBpR7535tj011M2uU7B2k0NIQ/AaUwEA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-5.2.3.tgz",
+      "integrity": "sha512-wa97A20obKuGtxWVzpAm2kj6MzxaNbeBf8bYgFZyN5+RUbmcBA2MhIvv0QooOKgvXu9T9vvoB84q7bXdLc6m3w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-string": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-5.1.3.tgz",
-      "integrity": "sha512-4PNK3UMR1FggzqYqQHDiufclMfsv4T+OZw34PFC18VL0si3S87yNGfZUhqnVNZXhbw+eWnO2QutpsHNtzXyxFg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-5.2.3.tgz",
+      "integrity": "sha512-MUe3xtDjqmamDDOKApZEYmzJiGac7lEGKoZwFDnJKJKJvkbcxw4L+o1QSAhrD/vE02LEl+86+i6G8QtJ8if30w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-time": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-5.1.3.tgz",
-      "integrity": "sha512-LCwccyXERS3e4dGYXSbB+LevhBTz0VXQrdUnVHRxR4iR8mVN5u+5PqoodXq02caIUszXzNCykOOXGI0nPoVfBQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-5.2.3.tgz",
+      "integrity": "sha512-djZi5eQj4uvF6ctKtY+tE+McW6WVA4Cc0LKHHmGjoAaAkMmoFbw2jnQNvAlIuFbpD/phGvZ398NTfP0jPLS9jQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-xsd-to-year-month-duration": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-5.1.3.tgz",
-      "integrity": "sha512-/oR43wwW8QNgJCmPLugLrwdFK+tohc62vht/t8hLUja+FIyC5O96WUmP7/HYbjTLfKcESnUjT5V2NG0HlumyVQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-5.2.3.tgz",
+      "integrity": "sha512-j+68WyVJyt56p5dVLcjjN+eQTuHh6nsoubG9jflZwr04dAsLhfMOiuceIJvwVomQ2f9T7pG7lazq2/tk9Gy3nQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-function-factory-term-year": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-5.1.3.tgz",
-      "integrity": "sha512-Qed6JWvT85Wbyn762xRfhBKA0kgVZ2OP0vfMHZhuCNJ8pHDlWAXWO2TbnE3tkbwtFJSYv//NzcAqs+iUvK2wWQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-5.2.3.tgz",
+      "integrity": "sha512-iL+ghG1CMG6Ud+l1wOvDnjg+LpACC7dugEwoB9jy9s11GnmchsQKt28o0bNU/qmVgi5eqpfANC5bsNM9yY6UGA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-hash-bindings-murmur": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-5.1.3.tgz",
-      "integrity": "sha512-QEnNB+hiwUhfeVHO0W4b8SkurM4McOS8mhz38pXklYPv81UQA36lNqmK6tcszuFm2uvyKJ/oEVeB7q9wTenKEw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-5.2.3.tgz",
+      "integrity": "sha512-SHYxt2r9Idv/OjN4Ssd0/P7/7ULay09UyvjgC/iY/LSROde4A22nOUkU5rD+jpR1hYyNmyClgfvf+HvB+ODXLw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-hash-bindings": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-hash-bindings": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@types/imurmurhash": "^0.1.4",
         "imurmurhash": "^0.1.4"
       },
@@ -4296,13 +4320,13 @@
       }
     },
     "node_modules/@comunica/actor-hash-quads-murmur": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-5.1.3.tgz",
-      "integrity": "sha512-y/WNiOqTLC5sachYA7XpkLwwH1WEWpyCzwmLscLiXHGKxn8cW1493IfW5J0rixy00DJcf4az/u9PRICAbNlWOA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-5.2.3.tgz",
+      "integrity": "sha512-4qUspwxQny7IOCB3+GLkwVUN93ahd9I5JA7AYQD947zELTwhB3pf71x4b0QaqFKuYYKZGfKMAOjUKBdpTa8lzQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-hash-quads": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-hash-quads": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@types/imurmurhash": "^0.1.4",
         "imurmurhash": "^0.1.4"
       },
@@ -4312,17 +4336,17 @@
       }
     },
     "node_modules/@comunica/actor-http-fetch": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-5.1.3.tgz",
-      "integrity": "sha512-PaU8cm/hFfmUc0zknfQ/WY29ffm3A+3g1nopGn90PCpaTwV4saB7MZAfHnCd9JB+YA5cuO0Z6JDwNr+T/ZiNeQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-5.2.3.tgz",
+      "integrity": "sha512-VeTCcDVZdz+8cjNeuFO28eIP/HnWkLZmy+sm4i/juXzvBY5gS6LavFj+c1g0F7Foyu0i74rdIay5zMHbbGkrUA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/bus-http-invalidate": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-time": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-time": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@types/http-cache-semantics": "^4.0.4",
         "http-cache-semantics": "^4.2.0",
         "undici": "^7.16.0"
@@ -4333,28 +4357,28 @@
       }
     },
     "node_modules/@comunica/actor-http-limit-rate": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-limit-rate/-/actor-http-limit-rate-5.1.3.tgz",
-      "integrity": "sha512-5mOuBTkKNjB6SG5KJFZpeOMnoYLAQ+/5/c96yjULSTGrwU9NewixfwN5OL5wpVq8VO70SjaLhcApciR5rrJHaQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-limit-rate/-/actor-http-limit-rate-5.2.3.tgz",
+      "integrity": "sha512-eH6bnC/yUd5TF69A9x+jbDF2e4nQZh75KuWdFdoedi+NlU4f9BBfwthYQ8Zf1jrv4uZdGJwt7MbqeSMOcIpXVw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/bus-http-invalidate": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-time": "^5.1.3"
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-time": "^5.2.3"
       }
     },
     "node_modules/@comunica/actor-http-proxy": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-5.1.3.tgz",
-      "integrity": "sha512-RDYgAdASVIXBaCLuvj8b4ILIBp8fyEAyRGJtOJ40U57eOUBW8ZBE1PwRwoIad//VGbGxELN6dxjYdmISwwOvLw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-5.2.3.tgz",
+      "integrity": "sha512-x32prW0HYDBcl+b183twO6+XcC5I0jy2R5DuXRB2L1t57FMz60BLzmbjehPMHLb8XGPNY3gx5cNaezfFpbaoUQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-time": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-time": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4362,27 +4386,80 @@
       }
     },
     "node_modules/@comunica/actor-http-retry": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-retry/-/actor-http-retry-5.1.3.tgz",
-      "integrity": "sha512-8ZXjjfHOzt/ddCIigid9mBuoAzi4agJ32a9vryn+7SH15wQrUQWcOr6FQUWtcFzbhBCnK2jaTOsjkCE5L7v9gQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-retry/-/actor-http-retry-5.2.3.tgz",
+      "integrity": "sha512-H6WTMFiA65PRw/UIYWcq9L38sjZHskEubtiyj+rFb1bv8scyjwQaiySVs2XnN6Yf94MOWSYfWawIvOaNlAffsQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/bus-http-invalidate": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-time": "^5.1.3"
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-time": "^5.2.3"
+      }
+    },
+    "node_modules/@comunica/actor-http-retry-body": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-retry-body/-/actor-http-retry-body-5.2.3.tgz",
+      "integrity": "sha512-xfpuIEFS5MkALRfHZ+Kx2KfAZR7A7Rob6cEgrTfCs3vcgjyAXO/Aj3Udal+5q/e0UGo+mz8PYt+nEGCoTsuJGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-time": "^5.2.3",
+        "readable-stream": "^4.7.0"
+      }
+    },
+    "node_modules/@comunica/actor-http-retry-body/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@comunica/actor-http-retry-body/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@comunica/actor-http-wayback": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-wayback/-/actor-http-wayback-5.1.3.tgz",
-      "integrity": "sha512-EkHg9vTEblerWEoVh470YoZWntGi0VoFSKss9DGCJxXHgGGfvIGyvG2wKcZ9Ck4+1azsfJhlyPVmkKQIan7CYg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-wayback/-/actor-http-wayback-5.2.3.tgz",
+      "integrity": "sha512-/8rwuEURC7cAZ/8MCsMV5Y3hTon0O3jvxLY5+7fvYmceGPhDaUctosWEiauaM1J8U1pNcIdY1OgqqyIcNHKusA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@jeswr/stream-to-string": "^2.0.0"
       },
       "funding": {
@@ -4391,22 +4468,22 @@
       }
     },
     "node_modules/@comunica/actor-init-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-5.1.3.tgz",
-      "integrity": "sha512-U9l5GuTuC5H2m+8LyUOj/UaGQw2nhXDuWvaOIp4XJSAp3jwIju6+vsbcjGrjbaLxvMjhHP6k03JUTtg37m5g3A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-5.2.3.tgz",
+      "integrity": "sha512-S6VZOlUxpvwPETWN4hWDPpgeNf5YyP2/6X62A5qv5zUIPwr01ZyL7kpm9jjnLE4dZQG2DVhbW4LEI9GqEJiJgw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-http-proxy": "^5.1.3",
-        "@comunica/bus-http-invalidate": "^5.1.3",
-        "@comunica/bus-init": "^5.1.3",
-        "@comunica/bus-query-process": "^5.1.3",
-        "@comunica/bus-query-result-serialize": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/logger-pretty": "^5.1.3",
-        "@comunica/runner": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/actor-http-proxy": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/bus-init": "^5.2.3",
+        "@comunica/bus-query-process": "^5.2.3",
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/logger-pretty": "^5.2.3",
+        "@comunica/runner": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*",
         "@types/yargs": "^17.0.24",
         "asynciterator": "^3.10.0",
@@ -4464,17 +4541,17 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-assign-sources-exhaustive": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-5.1.3.tgz",
-      "integrity": "sha512-Bs1sVDuQg4sLYnEITjqKb+zCKkbzxkCtuWu+tc/QTAc1ZeApNqiEvVNOhi3KnnWcNQu8Ul72ACJ9ShcSC266TA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-5.2.3.tgz",
+      "integrity": "sha512-j1+npLHR0vwd325DI4I27ogCNIRnMWcUVNwGIdn1LUQS3axMhwVuLEw7e+XpenQNnlIqsC9cPRps/98SyCedGA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4482,15 +4559,15 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-bgp-to-join": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-5.1.3.tgz",
-      "integrity": "sha512-L3ejXr0fVSWaMtfyFwiZcSITCaiFdzw5PEwSCg1c9QKVaa0QtMJ80V6yHya/xLDa3LmVV7t3m+7yFVGjZIYWzg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-5.2.3.tgz",
+      "integrity": "sha512-KOS4beFLxS/qDh43PEkbueOc+z546dWYzAJH3BOEbUxnc/sGQh95yIrOW46CmL4ebCuZePxoRuqZ7PHt0L2YcQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4498,15 +4575,15 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-construct-distinct": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-5.1.3.tgz",
-      "integrity": "sha512-ZMT5DY2xhg7BSi5AJLdu0kp6jT1SwrxarnlSptXt9wa4EUgYqEkfhOjZdOUMlZRzxZ71ohna4ESyBkta1twvzQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-5.2.3.tgz",
+      "integrity": "sha512-a7hj3llIYCKtrYHEagqq/NWAD1fw+9ZWPY+Htq4CdcSqOnAdNcnn3P3TW704gBZsNOqCFCxjU1vEC/6sQYHXmg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4514,15 +4591,33 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-describe-to-constructs-subject": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-5.1.3.tgz",
-      "integrity": "sha512-DbQHo4Hm/lKd9UK9TBgp/62UGXoCos85u3ZLIxtXMxoYBdlEOoosEeqpgYUu1YDCcN+pRCCqi1Ad9Fl1Od3XvA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-5.2.3.tgz",
+      "integrity": "sha512-NEBicKiWS+lsC3Eco7+MJ25bCgurHyoB0p5gExSSRSplNYPd1QUtE9y0v5PyONAM463bg07b6pMwdJC7dDnPQA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-distinct-terms-pushdown": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-distinct-terms-pushdown/-/actor-optimize-query-operation-distinct-terms-pushdown-5.2.3.tgz",
+      "integrity": "sha512-yelHnP4uaZaDc16+EXTVrSNfn02QTVmrgx6ZZYs6ejDljrNQqJBUehpvXzl9zd3B3j4vBfaa72BNE/XSN6kvFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4530,17 +4625,17 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-filter-pushdown": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-5.1.3.tgz",
-      "integrity": "sha512-xpPDHGX6HXgQEXlNIqi6ZytozVqh/MEcOIE8Ps8WjoE/AiA0v5ktPWu22pbPnjzrmCyjUv+A0L8ALgafR4gJhQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-5.2.3.tgz",
+      "integrity": "sha512-6DyGx3qRa3dS/yNhQaiEUqKRXrARaX7pvFC4LHl8nct89qhcqUMCkP3fgCIyC5Btc3sUiYaLlyie6ioiZfh9fQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-terms": "^2.0.0"
       },
@@ -4549,18 +4644,34 @@
         "url": "https://opencollective.com/comunica-association"
       }
     },
-    "node_modules/@comunica/actor-optimize-query-operation-group-sources": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-5.1.3.tgz",
-      "integrity": "sha512-633uZtt8kUdDazxp05Wlf1NOgSemWdyFKOCCkt9R/DNm2tyw4aODyD/0HFNF5XYTAPXSQxdLOLF6hji9enw0Hw==",
+    "node_modules/@comunica/actor-optimize-query-operation-group-file-sources": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-file-sources/-/actor-optimize-query-operation-group-file-sources-5.2.3.tgz",
+      "integrity": "sha512-GI5a8s0tKPByhT4yeX733sYI4ph9XFaInVqekG9iyRId4O2fwAND/J8ZKZ7yxQtUnAoeUnri5mUV0tRTmHnUzg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-group-sources": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-5.2.3.tgz",
+      "integrity": "sha512-qBo1P1HiKZDfq9KeCIRKmLjRqSzGYPnSKCloOcVTritwTBIKKpV/axpfgOoASpgMMB93qMELoiAVQfG6gECNzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4568,15 +4679,15 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-5.1.3.tgz",
-      "integrity": "sha512-fjkB8wZvZHw1JfChC0yAwb0KquZLHDOA/dg0Zbg+Vw/YwXjvB8QVVgw9DVpxFm8y/4XsvazzM/HPKlUd/7qE/A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-5.2.3.tgz",
+      "integrity": "sha512-Ccq8yfWp0XWd5D/McciSCSjcPIJ84aRjhAp4N1cumRSYJ4sjCcnQ3dkY5d0XEezvtCG2BUFV3abgvRnnYiwruA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4584,16 +4695,16 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-join-connected": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-5.1.3.tgz",
-      "integrity": "sha512-PfvfsP+jU2+7ikqgfe0C5nJKU1iMDwjWJPKu2hqavSDoGurpH8Xt36GT0qNpaWNEHCTsZTLVj/7Fi9O3XFtpNA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-5.2.3.tgz",
+      "integrity": "sha512-KGiEKNegvUf+Q/Cki9M5zeSr2JtsuU087RPuGwOyLAr2v76L7/Ll9Q4D1Qeq+tVEpkZGq1NjrrWO4DvmhZLapw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4601,17 +4712,17 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown/-/actor-optimize-query-operation-leftjoin-expression-pushdown-5.1.3.tgz",
-      "integrity": "sha512-CN1RU3v8KBU4GzWj77NeazQ0kNgOPB1Vh5M42qxgi0XecqxdPanvNeMjEhNmCOKcZ4oTdmIme8cmsVvoI2hNeQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown/-/actor-optimize-query-operation-leftjoin-expression-pushdown-5.2.3.tgz",
+      "integrity": "sha512-CesCgPEk1jwyZqEg9a3pQqflHM0YI9Hm97x93HJbT+tEjqXwxGVvPV/S4zQ5BVSIhHo8WBwdryx0M5mI6hG5eg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -4620,17 +4731,17 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-prune-empty-source-operations": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-5.1.3.tgz",
-      "integrity": "sha512-jI3/hjcqio8p9f8fHiPD0bCxg8kU5enpeB6WNY+N7edwHHHTzOB6ZKX95eu8CP6rjbTsb2LaW/xTRjz8WXP3bg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-5.2.3.tgz",
+      "integrity": "sha512-s6J7VpslGVGMidP4T2e7xgka9kakhio3apMYrF7hBUFfVIfbUkR6P0DIQWVzvBLRIO2OEfxfgl0hFbYARDCXWA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4638,20 +4749,20 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-query-source-identify": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-identify/-/actor-optimize-query-operation-query-source-identify-5.1.3.tgz",
-      "integrity": "sha512-Us6BIj/dK/ha0909qdQ/oOqO1vhVbMcoOXRo+7ioeUgK51RHREUsIcy3DA7AzCRA1QAS3UizdphrA60wMGalGA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-identify/-/actor-optimize-query-operation-query-source-identify-5.2.3.tgz",
+      "integrity": "sha512-TpueX8wdpwQp2Vy+2EGEVWgea9qW8YLVXbydHMYRNLX7UIGdu+iJKiWjrn/2uEDAr5+MUSpV+hTXpHtApc40sA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-context-preprocess": "^5.1.3",
-        "@comunica/bus-http-invalidate": "^5.1.3",
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/bus-query-source-identify": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-context-preprocess": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3",
         "lru-cache": "^11.2.2"
       },
       "funding": {
@@ -4660,27 +4771,27 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-query-source-identify/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-query-source-skolemize": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-skolemize/-/actor-optimize-query-operation-query-source-skolemize-5.1.3.tgz",
-      "integrity": "sha512-1UKyzyM6iaNETfjdRj15YEWQJYBwYQ8frHbwme443Gt6S5jAP4DSM2iRKanE8RVkXLN1GNawilLlhvlYS+9qrg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-query-source-skolemize/-/actor-optimize-query-operation-query-source-skolemize-5.2.3.tgz",
+      "integrity": "sha512-j9ouJ30S2uc8sEXvcfxxH3pMfIfVSmL/Xee7/Rc4cdGy27XwaKuMLXveDlybtpiPjnFer06EL/EoMxyNdRlR9w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@comunica/utils-data-factory": "^5.0.0",
-        "@comunica/utils-metadata": "^5.1.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-terms": "^2.0.0"
@@ -4691,16 +4802,16 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-rewrite-add": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-5.1.3.tgz",
-      "integrity": "sha512-DvcgxOF8s+jXQvrQ5JNx96HOHrNQy/BhNn34o4iCoSrmJUjECv59d6lNbUpyKhZA13U2/fYO9QNpexbn09C1DA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-5.2.3.tgz",
+      "integrity": "sha512-c9DYYzRHTEsD7Jy9R+8zchC2nZmV/3y2qKtwAxkHW30CdQSUijUBS2tHxUit5QSd/U2nQFG6qHViax3gZ7cdhA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*",
         "rdf-data-factory": "^2.0.0"
       },
@@ -4710,16 +4821,16 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-rewrite-copy": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-5.1.3.tgz",
-      "integrity": "sha512-Ypp64eG2TDkvWub1MLkGXhiciMdAMI42qmJTVNq4i13/8vfSWOi42/qAfGF2Y185rF5fh3Xv1Z8GtOe+swnMxw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-5.2.3.tgz",
+      "integrity": "sha512-19WBXW+lcpZhacRUCRzfd1UwPqE6auXf46x93xdU9QDIlLWiWFnd4L55pNLYZvvEYnyVc0+pzlwS0D6bcvF8kg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4727,16 +4838,16 @@
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-rewrite-move": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-5.1.3.tgz",
-      "integrity": "sha512-BV3sEh/cOCPWw0eq3R+iS5O+XDIMpd10J2GfrltPjPUo9yDE4yZbQW2JIIPrxBEmQJT5fIzO/IfiqxVwS+uLkQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-5.2.3.tgz",
+      "integrity": "sha512-aWQWF0vUg6nII1Bx6kfwLUtr1Nol+aRWr3JXIoVd68g051z4XZz46nrJgdB232+Ql2LKc35++Jyz8mSHeaHgHw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4744,16 +4855,16 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-ask": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-5.1.3.tgz",
-      "integrity": "sha512-qassrHOJzl7F7wyLIylCl2tOf0NRPzma7A7Km00c9IwHBBFTKFRgGI3TXbQfckNu8EXQVQBMe3ghPteqIJ/FnQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-5.2.3.tgz",
+      "integrity": "sha512-JpwU59vbWicl9Rnk0G+UrZu8HdLyAeTthtFX1V+DmotFNf50vzwJ39ICzIYa5Q0maXVDmdiEoi5MkWFXHBz8pQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4761,16 +4872,16 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-bgp-join": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-5.1.3.tgz",
-      "integrity": "sha512-22BiyoUVSwZA200rSEzQDLjWQNHOPeRQZziqMKnLlJN/Uk18RUL96SwbwpWmALoL3fJqktk4xl/tz9aRn1eWmg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-5.2.3.tgz",
+      "integrity": "sha512-A0y2aIjcfJDQyDF/GNy4WbQajo8Rf0c30CI7NNP/WP2/Gv28mjrcOpijQRrdWI50Hv/2vqeXcG5BFBRpMT5gRw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4778,17 +4889,17 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-construct": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-5.1.3.tgz",
-      "integrity": "sha512-Bt7dXh5L5y0p/I7QCfCzh3C0CX3EQ2bFNI+ONmyBUjPpynXbeEEIJMkoax6KJrGVuEXpgmRhorK4cIye2e72KA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-5.2.3.tgz",
+      "integrity": "sha512-d7ozBZyK03EZeOyRG7L71VqT5FjfZAH2ryoRCmkIKvEg6PHpv8NadPA5P4IKWmEW3B42WJFwbvylmF++xo2CNA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-terms": "^2.0.0"
@@ -4799,16 +4910,16 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-distinct-identity": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-5.1.3.tgz",
-      "integrity": "sha512-K6pdznqyMU2kKmeTkaGpw6AAM3TZscAD6fmBD0NXWL6EXRC6nPLVz1YxVGrMqmtDA722yTD74LnPq4oMgae5TQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-5.2.3.tgz",
+      "integrity": "sha512-k1vZeFZYQ1foGuhznKIkg37brwxapevLFKmKJ9CbG7Nb+7WW3Mw202NDw1awr+m/+CZ0QCZiLF6IUlgQOFfrcA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-string": "^2.0.1"
@@ -4819,19 +4930,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-extend": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-5.1.3.tgz",
-      "integrity": "sha512-Uu+T3L2M8QLap0w8jKUU+U5p3UjHsPG3Z4WVsg/vIeTxEF3wqQXmg0LpBgzCIBaHfuCTqzSyGwjZ4QZtxUvmig==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-5.2.3.tgz",
+      "integrity": "sha512-Cpmc0ISIyWX16sd7NXcNWSGzEOgGo8YMw08fimURG9oe+l2CGGkGDsj2AtngFyTVQvSOgEqbM5WyrG+qc70ouQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-expression-evaluator-factory": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4839,19 +4950,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-filter": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-5.1.3.tgz",
-      "integrity": "sha512-dR7oydhaamslDRUubtT5vJNe7VOFPOmT+of7eesn2GOV+VQXzps0RHxTaG85wrOOrM+JU6MVrRgE+Mtp6ZSQcA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-5.2.3.tgz",
+      "integrity": "sha512-NRnwAiF9ZfsNh0Rv1CBGIRMm/CvX5Dvy4iXTAzEMV9n/WWwRjrNrJjpN6vJUtGgFpF7A+Mu7GZxDf9qucKKvGw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-expression-evaluator-factory": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4859,16 +4970,16 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-from-quad": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-5.1.3.tgz",
-      "integrity": "sha512-n1a+UEqJ7QhYQswRmXSzJvYcqKticCmAJoJFDS6qqj1A4IptB2HlH2Xl5oWnKwwZKhzvP0OM2BvHp6aIy9Qdvg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-5.2.3.tgz",
+      "integrity": "sha512-peMws9f2ldijeJKf+Rnh3xXgwDBxvyd/wS3Mbfxu2fDFeXFQXB7AnNebFS2PTRF4K9uQqRrh/U7hoQtUcWGTGg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -4877,20 +4988,20 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-group": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-5.1.3.tgz",
-      "integrity": "sha512-fcIWFhR2yKHxFxJN/ECgNhpqTzeUfInhCoczxoMXlboaF80i1p5Q7WvUS74JTpd1NLtU3tjrHdNDIsG8ZaH3gQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-5.2.3.tgz",
+      "integrity": "sha512-EkLEoH3Eid4q2+3GnCTjClbwv0ROfhPuTe6EilSG9JO/Hrv4/Pj4WHtRQu6T1xzmCeXZbTZwTZ7LWBUnengm7g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-bindings-aggregator-factory": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-bindings-aggregator-factory": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -4900,18 +5011,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-join": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-5.1.3.tgz",
-      "integrity": "sha512-9BMLJLcc1GSEDo+vMj5pRBnBR8/CZ2aNka9wtFrzNOz0g176et1I8vx/embZ5e9NmHK0oQaZMVCKaXVzc9cXOg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-5.2.3.tgz",
+      "integrity": "sha512-XnBTOlED7+NimckkRXIb61pv3r4u9NbmAPvDkw/bBAcKnoKvvSW1eQYOjKWKKgTBnOboeCHONIGvn/M9pLWUBQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-metadata": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-data-factory": "^2.0.0"
@@ -4922,18 +5033,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-leftjoin": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-5.1.3.tgz",
-      "integrity": "sha512-xrUySlJ1/Gc32afciLJ+bQ/WdqeV5TNpFeE6yZiKIWN3GlWYVL1q/qHaABbEhkyN/9bdZLS6iB3O53SDByWoDg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-5.2.3.tgz",
+      "integrity": "sha512-M21jw/st6H/YpqS7Rn6Iyn/c5mdLJovMGGTLVUVz0EDXVofGktAnP6RGvDSlvcSm8Wzu/kypJGQPCy4qnf4rLg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4941,17 +5052,35 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-minus": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-5.1.3.tgz",
-      "integrity": "sha512-q6UA5eemPhdOFH9QUCUHB1nYuCyzrrqt5Rh3rmB0swDL9CcNs+bZES150oMe7GDq8JfKGRdebJEf0wycqJFHLQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-5.2.3.tgz",
+      "integrity": "sha512-8K0nq++Xkni+f2jIZUAFOyFFmi81Q4H3JaI6icFzA6Ml+6H2tSW27IxmwGVJFKDnNcQGYWeqMEFRJPHmpMi2YQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-nodes": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nodes/-/actor-query-operation-nodes-5.2.3.tgz",
+      "integrity": "sha512-TLzkQB3F4co+Xvnjcy7tLP4WXgHo2Bvy8NeFRd5VHQpXYYmwgv6wrd/NduIQBvHyLcHnlWBJRfD0ciVfflZ8nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4959,19 +5088,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-nop": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-5.1.3.tgz",
-      "integrity": "sha512-qsUBnqt/AM2T+Wb3SfSabg9rdq97Qwl8YIlQe0E/RqeoFXvEvfPwUEc6NYzoEXeAqDwwTcxNVsL3KiZNvb1XUw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-5.2.3.tgz",
+      "integrity": "sha512-lcq01cDhotaOb50WX7jBL0t+8OYZOqsDwN1xVbEf1AgDHz/InsRalUsuibpMPOunwM1iQcHx7fVMXd4SeCl/KA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -4981,19 +5110,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-orderby": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-5.1.3.tgz",
-      "integrity": "sha512-iC3G5KdGbIyKIfnsNqdwp2la2eMtDG+kujv8BE3Y4/q6eLzRvTVid/RaJQyQfg4ZQIPbbCEWc5W8UBKG0OUAYA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-5.2.3.tgz",
+      "integrity": "sha512-A9DVAicDITKXSkS4B2LaNga3hhSt8V67tNnJvSJhkGiE8MXKUYnPmht5uuoUU/4hQDgLGQEC5FZ7zMHMcszzEA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-term-comparator-factory": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-expression-evaluator-factory": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-term-comparator-factory": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -5002,19 +5131,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-alt": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-5.1.3.tgz",
-      "integrity": "sha512-1TnXdLxkipPGyG2a/yISU4eMjr2WzTkLoxijmoVK4jXGmcJD+mGBnhocsUJPnfg+wOATwBIlfdLg7uoS9sMAqA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-5.2.3.tgz",
+      "integrity": "sha512-hWijZHABPKFmnQoAxo2Uy9PEgMs5oHFs7rFGy4ShUzF0hYxWErUSKl3J3+RRi0gwkUGXgVv1azoOPeKPj0aBTA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.1.3",
-        "@comunica/actor-query-operation-union": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/actor-query-operation-union": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -5023,16 +5152,16 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-inv": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-5.1.3.tgz",
-      "integrity": "sha512-oGgJlytnxxacq359eu5gDGjwRPj2le/rG6u4p8bgIR/mBb8oD+v3Wbt9BVXcjskDk0/j2L0fvk1FH3MzWhPtfA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-5.2.3.tgz",
+      "integrity": "sha512-KxBTetLr2kKQ7Hwz1LDmMvwxpvQJqCFOYmgvnEgm6rsg+WGY7J3cLhhHx0Et0w26LAz2MB3qfyt+vFzyBrZ7kw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5040,16 +5169,16 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-link": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-5.1.3.tgz",
-      "integrity": "sha512-Qe3XAFvBiQJmdUhiK3bl6niS6ZpvXDqFRg/ypZjLPiK5vk5RVfqTRue7+eVLsc30kdOdSUFqh/TY4cUZFuArtQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-5.2.3.tgz",
+      "integrity": "sha512-ymkeLF/sjKhuD9bjFgJM91UgAnShNA/qjtyajc0INO+X0QI/VA75713W/HCMFNTrj27DoXhQc8WUnDCO7oOmnQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5057,17 +5186,17 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-nps": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-5.1.3.tgz",
-      "integrity": "sha512-zSX7dAudTFTJ2YTjhvkjSXIVhlSJyFAMwxQSP6Z014Sa8qQVrRFjHElCFZEIf1cwtxD4PIk0NpqWH/a3GAhkFA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-5.2.3.tgz",
+      "integrity": "sha512-4GwukJfxqPW14YabmVLajVtljMgrFPVMiOSP3zhj8e9KLzD+Evbr4eqc9dK2JZbYZYAKEmOZqHXPwx9SSNqegw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5075,19 +5204,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-one-or-more": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-5.1.3.tgz",
-      "integrity": "sha512-ZwfyEKtCvDFY1N5DeFSc7WZJIfUtIMyJkAqsDVP3zgqQW4cbsXcsuGXgr/P7P+TcPtn47cESspGGnX61BB4RlA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-5.2.3.tgz",
+      "integrity": "sha512-h1W0q1huLJJtiwVykazOjxEryJUKwsHfcYHKMkMtWpG880oNqIFASSio/sFaps4vxhubeaWVtQuoVr5EhDSYFg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -5096,18 +5225,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-seq": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-5.1.3.tgz",
-      "integrity": "sha512-iEoGvlHtLHnj5n9tWfFoePGglWft2cFmZyrxEHm8rZqLV/4vLk0LI6i38kc4a3HSAAwTRVPtbnx4140bXCfJfA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-5.2.3.tgz",
+      "integrity": "sha512-HMyL+387KaP+u4VCoPJmi2iVtxgSwy0DxXZSUuMZlwrn1rDxVojzIucBMZUH0XlhahHQzkpVQ8g+vgeZGJ7viw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5115,21 +5244,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-5.1.3.tgz",
-      "integrity": "sha512-r4kSzraaJc+X/NUz+bTKKu7hlYUc6r8MQkqUJlWlK9zTs8s858pX2UQ1pGwzvrw1Q89WzUeYjxH6hE7IgobWjg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-5.2.3.tgz",
+      "integrity": "sha512-iRi1gG7koIKzHMZT8Q6wGmPxMFMJcBY8kPAHeeP8FZYU/cVscqRr5di+Ne3oGBmstQpQGkhp02YO4pK707sWzw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
-        "asynciterator": "^3.10.0",
-        "rdf-string": "^2.0.1"
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "asynciterator": "^3.10.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5137,20 +5264,20 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-5.1.3.tgz",
-      "integrity": "sha512-T1pxhiz8HdMyjN1ZVBOnBS9ZX0W6wvwN3GdVVH+Xx5HKdh/H8hWA+mKKc/r8L+VloOWDo1c+PjrtIMus46aRSg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-5.2.3.tgz",
+      "integrity": "sha512-0a2fLpzuCm2r6c3sknjIhThU7hefL1izQ0/GyEpZaqaMU154ldvQMWOLJq/d2WQp8N3kYfNrEpCnXRSi6CTRtA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-path": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/actor-abstract-path": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -5159,18 +5286,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-project": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-5.1.3.tgz",
-      "integrity": "sha512-TlK6zHhrnoJc4PmSuxkY1oA62jMsNWgSnrJXvumgsLZO0XvP73bK8UDi7x4eCZReG1oTsBAwZF7BKJqgFJl22w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-5.2.3.tgz",
+      "integrity": "sha512-CfMEUuYOT/Y/T4aCYG0ZhSxPXi/6YDI2uOIYAlOjeud7Bb5n+3SxnvVd6r/rihiFWJLXykSeYsppWvVY5ElwWQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@comunica/utils-data-factory": "^5.0.0",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -5179,17 +5306,17 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-reduced-hash": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-5.1.3.tgz",
-      "integrity": "sha512-ZJh2GX94Lp+/+c8SJ9CKAtiziyFiwmR75kNgQoerq8DelLmx7pgmhiEn8bOYj2vEVHobwo1BiflMIFUOBIEiEg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-5.2.3.tgz",
+      "integrity": "sha512-gX23UrR5e/6zyO+MGuRru3OEr62Ty7S0iTxykI52YenGf+gsEGnkLQDBclOriMs7XNemJ+YHncsJ2v6HCSahhg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-hash-bindings": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-hash-bindings": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "lru-cache": "^11.2.2"
       },
@@ -5199,9 +5326,9 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-reduced-hash/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -5463,16 +5590,16 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-slice": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-5.1.3.tgz",
-      "integrity": "sha512-IGirpu0mB/jzmRTRNb695ORi7XgmQtJ7871hkIZjmuUTUqaZO2nssKj7gAvsliq0Vh9fEL+e7Td1NSOPCgJLtw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-5.2.3.tgz",
+      "integrity": "sha512-taXSk/xTXKHoWxQXv1J6XwKPrRNUShIjGuLi10MmfKqje3adNSrVDr9dKEaIUK0iKxdJFP6ZHXgRjdqiYb99Dw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5480,18 +5607,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-source": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-source/-/actor-query-operation-source-5.1.3.tgz",
-      "integrity": "sha512-NQJW48VhoamebHzdxBXj07YkBTEoxEwp0cj9o62NeP6qJP1J+P/Ij29APhYwMAV+3Tc2DcUw82Ljq2yf/gLCqQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-source/-/actor-query-operation-source-5.2.3.tgz",
+      "integrity": "sha512-3jsxiAqZXMwHJObQ36sYrh+3vnOeimGlil3jo30C2uAGRiD5M3+bNb+SHp74VXEgOeeMG9gwB33W44qolYqS7Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-metadata": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5499,18 +5626,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-union": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-5.1.3.tgz",
-      "integrity": "sha512-HQLDkQkmO5fmvQauH+niQJ9q0KGnHH+6UBn9VGQA28ptpGtn5D+xX+yYcRBaNxF5Y3t/0Se0RG/0PashhwCj4A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-5.2.3.tgz",
+      "integrity": "sha512-HzaQ/KK4/3XPJ9Dc40Ngn7FWvzAyH+iWpVl9cvOwGgI92ndICzDtbHNgC7ZXJ34pRqwU/Oc5O09FUqP6T2VnzQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-metadata": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -5519,18 +5646,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-clear": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-5.1.3.tgz",
-      "integrity": "sha512-dwR6nn0kKXWcAAFNIKl4WpoMJtPweP4kwo8a9qTu4JaYqk7RGRgrJi8ufzHTifFVzqlLafs811PWe52h25YzyA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-5.2.3.tgz",
+      "integrity": "sha512-4MqGN+8kTj5cCsLppQRbdbqjRW66ST2ELGHPN9HScI8gEHjh+xKDgY/poKVPvgxUYOylpNkMRN0e4nF6O0lhmQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-update-quads": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -5539,16 +5666,16 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-compositeupdate": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-5.1.3.tgz",
-      "integrity": "sha512-LuIsU2TXaCWKNdUNQDGphgKfni+O/8PNwdR773YE67vpIEY8hC7uorrvh0FGn0hWr7aAGhZGJyGkb0Oy2XMkSA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-5.2.3.tgz",
+      "integrity": "sha512-LXwD13/O/LQ1MIsxpnVj4Exk/tHdtw16kmwydWH61Wpd0a6glStygKdyuumNBMoKtefS8VF9tC57zDy67X7TXA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5556,17 +5683,17 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-create": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-5.1.3.tgz",
-      "integrity": "sha512-I3ct5yxqQQWzxMUcdAcF41tGBCkoRBNRQYaF6JY7eZ4TRfmjdky+pXjnXK33vkJYRJyJ1Wy8kx+fNGGzvEQ3uQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-5.2.3.tgz",
+      "integrity": "sha512-vn1sZBNUih4L5vKUQpa+cS0yNjElnA9MtlCq5Xr80GM911i7DKUvwdqdBuGMWlivQQKQUsRaOWnF+WrlZXSlzQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-update-quads": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5574,21 +5701,21 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-deleteinsert": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-5.1.3.tgz",
-      "integrity": "sha512-s2PD+xOJCtBbnSJf9YPCBf5wVkXp2S2oudY6SkFsN8oUTc6wxet0aowzuKTivB9ykob72AAZYKazOime0LTsDQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-5.2.3.tgz",
+      "integrity": "sha512-9pLqGUPeCQsv6rfotaf9ly5Y6Oft4CforMHnL5wmAZUGkm73m0aBdX8Q+9M1tNop3w++J9eK6tovcbXWPBFtBA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-query-operation-construct": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-update-quads": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/actor-query-operation-construct": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -5598,18 +5725,18 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-drop": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-5.1.3.tgz",
-      "integrity": "sha512-CO3o2FGhI+seZCKeXM2hpbZ7m47wT21qRBJ872P8aEf/7MJP2Ta92EVNgwIzcYHc4GuE2yaJE1YdRtYgPtASkg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-5.2.3.tgz",
+      "integrity": "sha512-oGyD4MmHjVJ84bZNhgorIGkcUsQxe4GV0qZSSVbQE0sGrSXD7xHaRRphVE+O31qKnQ5VWznge8vJ637HZZMIQA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-update-quads": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -5618,19 +5745,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-update-load": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-5.1.3.tgz",
-      "integrity": "sha512-fI7/xx2A0EO/vInE5eNDhYvjPA3fC5AekNiMtpUr/hpA8GoSSspkng3qCuq8eJZkkKJMelA3qiSH9Gvg5DxkmQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-5.2.3.tgz",
+      "integrity": "sha512-ryXy+fd53bOnd9bcPjQxo8amyQHwTiQr2o0/uLbeaYppimsfH5nf+FKDWWP9mkewNCUueOnFzqSI6i/plPheJQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-query-source-identify": "^5.1.3",
-        "@comunica/bus-rdf-update-quads": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5638,19 +5765,19 @@
       }
     },
     "node_modules/@comunica/actor-query-operation-values": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-5.1.3.tgz",
-      "integrity": "sha512-Eu19fMgyvQei9IM7C+f1N74XngZUR0/urg5umvN521XccebegzgSw+Wci+PBtFrU3mlESFm/599J3WUw9OEijA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-5.2.3.tgz",
+      "integrity": "sha512-kOuH8JQ8PeeKFWe8ni2LbA5KD4PAP1weq/vYwanpBk7/sJVjVI2ieQMF8pHUri0uh8RnmTZT7y4t+QbzxpVuSg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -5659,14 +5786,14 @@
       }
     },
     "node_modules/@comunica/actor-query-parse-graphql": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-5.1.3.tgz",
-      "integrity": "sha512-8qZZ2z/l+tqqZqP0ESJMybLwkloiPS+qeQcvbrGTtBZ+KAxQjZzxcOx7eUfQL06hxe/bqtcHV0b0OGRT+XbT1Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-5.2.3.tgz",
+      "integrity": "sha512-fCo2Lk7k2avs3yhmLqKhnCjnf6ER6UA72LAW6t8hosEiReX+wdpxkpQLcDEktLj+3FZJm0YRONrrQ6IgBUh5nQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-parse": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-query-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "graphql-to-sparql": "^6.0.0"
       },
       "funding": {
@@ -5675,15 +5802,15 @@
       }
     },
     "node_modules/@comunica/actor-query-parse-sparql": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-5.1.3.tgz",
-      "integrity": "sha512-4yHDWglryUd1alDBu7OW2lKH2tirxE26Z6RtcNPCNA9NNz55gufPJtB1eBwnoq/anNgzAvlwnaZohmDDnLKrGg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-5.2.3.tgz",
+      "integrity": "sha512-zRhPm9D9Yj8/2aMKCeDWPLq6Wdo4nmNBs5EC3QYDtxdHOlTCtwdfYyJabJ2J77IZ/PY2dZJXGI4veujjSk/UOA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-parse": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-query-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@traqula/algebra-sparql-1-2": "^1.0.1",
         "@traqula/parser-sparql-1-2": "^1.0.1",
         "@traqula/rules-sparql-1-2": "^1.0.1"
@@ -5694,14 +5821,14 @@
       }
     },
     "node_modules/@comunica/actor-query-process-explain-logical": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-logical/-/actor-query-process-explain-logical-5.1.3.tgz",
-      "integrity": "sha512-LFXhzoSGVwSXcaYwRD/EN5QhGxtyEVwdQd1hJNtxyalN5qGOt1i69y/fJLI/RQV4Vc4yfVxhdgfpqgEeGUy1+g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-logical/-/actor-query-process-explain-logical-5.2.3.tgz",
+      "integrity": "sha512-wYB4KybDLx3enOMi6AJ1xhoBcLhGOMQD68VOLfNWV0cWc4EflM04W1+uaGIrjZPIcTV6m4k3CC/DiFHBb6u49Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-process": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-query-process": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5709,14 +5836,14 @@
       }
     },
     "node_modules/@comunica/actor-query-process-explain-parsed": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-parsed/-/actor-query-process-explain-parsed-5.1.3.tgz",
-      "integrity": "sha512-836hDnrxSgMohK2zaDhRWTqPWgJXm3KX19QaE+oR4PSoh+fUk84dDYGL6q9Mwgwcg7lihHfbKkHYtdQ0Ye52rg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-parsed/-/actor-query-process-explain-parsed-5.2.3.tgz",
+      "integrity": "sha512-mDyjNBBDIWuxnV90f38Ka3vP5pH/OK6/wI5HgENuFweNe79QSyaKt1j7TXn30ZhhZ1OsBR6VxVq+oSLSfXHuaA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-process": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-query-process": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5724,16 +5851,16 @@
       }
     },
     "node_modules/@comunica/actor-query-process-explain-physical": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-physical/-/actor-query-process-explain-physical-5.1.3.tgz",
-      "integrity": "sha512-9KEhPFUALAkyfnUghNMubfP9zcVJ4t8e410CljCAyTxdu4iZNQ1Au+7Ny53wNkF1ZYfUwbxxT7tgr+7NYMKdAA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-physical/-/actor-query-process-explain-physical-5.2.3.tgz",
+      "integrity": "sha512-PQ8H/kEe0Nc1eRBJWJJSBT7LZhWxa/pHTyejzppVL/GoN884VKeOzYImEEQaQx8Sa69CcoQjuoxxv6IMhE+RAA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-process": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/bus-query-process": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*",
         "rdf-string": "^2.0.1"
       },
@@ -5743,17 +5870,17 @@
       }
     },
     "node_modules/@comunica/actor-query-process-explain-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-query/-/actor-query-process-explain-query-5.1.3.tgz",
-      "integrity": "sha512-ZPAaV3WT5R2lBnOEcNj/NQHeyFippHrQgVegfTTVNe5cTx9eQf/Kn5C/ZLOpISXjGwPiNVBlfmjI/LkIwl6CTg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-explain-query/-/actor-query-process-explain-query-5.2.3.tgz",
+      "integrity": "sha512-j/wV/yQ3S3sgOgW+8Bh5t7mbakBgOFXfUrjYr/f22p9OxqJU1JT3ruNqe6C4qJYhjZTtlGsSzOQ2PJUXymbzjA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-process": "^5.1.3",
-        "@comunica/bus-query-serialize": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-query-process": "^5.2.3",
+        "@comunica/bus-query-serialize": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -5762,23 +5889,23 @@
       }
     },
     "node_modules/@comunica/actor-query-process-sequential": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-5.1.3.tgz",
-      "integrity": "sha512-5u8mtXzKiG7Nfy50jfMWBDsAlYSMjr962NV+eBfuddE4+ZP+zql0AJRhRtJWx2HW5rinwuuHmRYtJdHeVGLIQQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-5.2.3.tgz",
+      "integrity": "sha512-pFtjUhtqkVQRh24q7GmCrZT9kZ/P+A7alzI2AbVqurRNPUuTSQoGzkpzqE6Od/IYvPqRGp4bgZSXy4Ew56GocQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-context-preprocess": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-optimize-query-operation": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-query-parse": "^5.1.3",
-        "@comunica/bus-query-process": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-context-preprocess": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-optimize-query-operation": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-query-parse": "^5.2.3",
+        "@comunica/bus-query-process": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -5787,14 +5914,14 @@
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-json": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-5.1.3.tgz",
-      "integrity": "sha512-PbFpwsDbXUtVQC5m17eXc+9r+9tRiOjs4O6IbBvaS8AVDFKc4PRdGVz47HAM4FQ5uJoIai1Rzho79CKvZuRXcw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-5.2.3.tgz",
+      "integrity": "sha512-50GXNieH7RKLBz1W6vImKwu4yxrKVPLgtOdBNZthByCNI1sar9Hfkx77bEnlUNqXlC7Sbu6VLV5XeFn3tpf3uw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-result-serialize": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "asynciterator": "^3.10.0",
         "rdf-string": "^2.0.1",
         "readable-stream": "^4.7.0"
@@ -5845,15 +5972,15 @@
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-rdf": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-5.1.3.tgz",
-      "integrity": "sha512-53+khlxRA9Ji8oTHjooPgdzA9fcKQRJUQ2aj14L/c7dc9X9R8bURjJZ+4J1ur0kDm0OSi4NVL5qLgS6/+NMhCA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-5.2.3.tgz",
+      "integrity": "sha512-pTsy+C9wNZBdFkOlYM8BgyXRge4CNJl3tLiCfIJ0M8oTcXHmB/vDnj+eQ1F7O0CbIptvos9jgit8Y1yDsfMNHg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-result-serialize": "^5.1.3",
-        "@comunica/bus-rdf-serialize": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/bus-rdf-serialize": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5861,14 +5988,14 @@
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-simple": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-5.1.3.tgz",
-      "integrity": "sha512-OyPToQhjnkxiLkDFwetknKoz8gQj49yVCwdtGANJ7MYkMNpUlarBF73WKjnTCw4so2enGvH2ADBn4Vy3YeQK5A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-5.2.3.tgz",
+      "integrity": "sha512-Vd7crOOyCtV8JZ9HllcQoSEBCplRySyTYwihLOysGv/0FtXCwL/W/zo3lQTHqgdIGgK9uBmdBEUXz98F2GLGkA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-result-serialize": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-string": "^2.0.1",
@@ -5920,14 +6047,14 @@
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-sparql-csv": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-5.1.3.tgz",
-      "integrity": "sha512-hu5WYAwg2IG9AfSZ9OUzdeo9eABCfpx1c+dcnn2EwHdM1TQAe23gr1s51Cj0lzX0QahksbfyR/r13elhHNvomA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-5.2.3.tgz",
+      "integrity": "sha512-ejC6KJCL3pvsOddJVsjw8z0SYS0tH47ih7qRPHNi7BpnGDaY2NGixEZGERRCVdapowri/KH9KGyzlxMZxGmXtw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-result-serialize": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "readable-stream": "^4.7.0"
       },
@@ -5977,16 +6104,16 @@
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-sparql-json": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-5.1.3.tgz",
-      "integrity": "sha512-+4RrVkf+L0xDWyvHhydqWGWFUzaecYnS3P1gM2Aapb55IG/uvG2N03HQRfcrfr2DCPOgOyFzomX/+p/fU4EGEw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-5.2.3.tgz",
+      "integrity": "sha512-T6dZl6avIMiRKV24LU/MrqvoA/+d+CwRzwtPCe7fvp5ebVU2cXi1ij/5uUu8969BbEA7XGytqF0JpVS+e4lzqw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/bus-http-invalidate": "^5.1.3",
-        "@comunica/bus-query-result-serialize": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "readable-stream": "^4.7.0"
@@ -6037,14 +6164,14 @@
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-sparql-tsv": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-5.1.3.tgz",
-      "integrity": "sha512-/4f0y2svSvMUJk4ZSCldFIa7vgzOZeY663BUkRU0FB5EPeoKDJXq5igxL1rUSWLERhURpFa7aitNbP/wmKlFQw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-5.2.3.tgz",
+      "integrity": "sha512-cfGpAWXIVADYdf+V/nj/WuU329lAChyi3FZXcqa9ofFV9uOwDEb4yUkWkQm5DktWybo21BvB3zGpNEHaiG5GkA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-result-serialize": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-string-ttl": "^2.0.1",
         "readable-stream": "^4.7.0"
@@ -6095,14 +6222,14 @@
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-sparql-xml": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-5.1.3.tgz",
-      "integrity": "sha512-ZhDWW16tM+XmDWmyZfGYugsir7a8Q6q+sHSw6P1QHgd3Dj0s4x4Ud1P+fHcX8kQx4Br3SXmFtbsZ2oBeJt3zgQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-5.2.3.tgz",
+      "integrity": "sha512-mMSY6VLcu9XtIDd361PCbFBYlzehuKMOmmX31D+dNHW/8PLsaaevegAfVNjbo6CMqJY0G0FJNSdzYW192y8V2A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-result-serialize": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "readable-stream": "^4.7.0"
@@ -6153,17 +6280,17 @@
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-stats": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-5.1.3.tgz",
-      "integrity": "sha512-Z7JoaYxc/uOK1J1QZIRYZjpZDySuZuHbxJM1K25aOXXSay79kr96+ZnlaXtne41kZfLszhkUTWJ8eJO1Vo8Wdg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-5.2.3.tgz",
+      "integrity": "sha512-KsxnYIPtQa+3CCWE3aGi7Ck7YhC0MNVwkroueCR3wG9YVICn1VI4RiXNmw5RpH+4m78EbWHwHCEEhO7mUXggMA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/bus-http-invalidate": "^5.1.3",
-        "@comunica/bus-query-result-serialize": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "asynciterator": "^3.10.0",
         "readable-stream": "^4.7.0"
       },
@@ -6213,15 +6340,15 @@
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-table": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-5.1.3.tgz",
-      "integrity": "sha512-I/wMesFuxpfRcohBQid6kjcmZB+vRQHq96s5L5jJMCPG1mn3nlGehCNcupjYhPsH8YgfhWe3BXtVOfAI8fXxQA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-5.2.3.tgz",
+      "integrity": "sha512-uH+NSuf0P2O/nRDDd0lxYqwRqDd67NnPKR4TSOA8LquFxJgRTSBpuoR9OtBa8HWUlkqnIoi+OtqseHNjeH5+GA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-result-serialize": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-string": "^2.0.1",
         "rdf-terms": "^2.0.0",
@@ -6273,15 +6400,15 @@
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-tree": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-5.1.3.tgz",
-      "integrity": "sha512-nEerT7fxbn7bZh+CXW0/NddeXgp5jcriiSYx3PAztEj9jHFCRBs4Bv3yH5iXCCpsUlwXX8yhhQxjNkj9l+AEOQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-5.2.3.tgz",
+      "integrity": "sha512-vJIE8uFLos7P9QtHM7hhNJhQA9zsp/5exMn+S72YNf+sEzVR1mSfrPl45v26tSOr7ZhuvJE4DcbFP/N+k5EoJQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-result-serialize": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-query-result-serialize": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "readable-stream": "^4.7.0",
         "sparqljson-to-tree": "^3.0.1"
       },
@@ -6331,13 +6458,13 @@
       }
     },
     "node_modules/@comunica/actor-query-serialize-sparql": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-serialize-sparql/-/actor-query-serialize-sparql-5.1.3.tgz",
-      "integrity": "sha512-RbAP8vkply/q/+m04VibBRLtpG8G0kjOK8Nt49yuQeXRuy5WSiFYJJtFM0SjxDwdWbG4DAL+A9W5zFrhLuQZZA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-serialize-sparql/-/actor-query-serialize-sparql-5.2.3.tgz",
+      "integrity": "sha512-ql8YkbekuvT5MTSX/LrLgEYiI5Imp2hgvzJs/j4B3uCjQdwZ/Wf19Be5oPIlUn9iPK+FNvJqBhBgXN5aqoRHbg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-serialize": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-query-serialize": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@traqula/algebra-sparql-1-2": "^1.0.1",
         "@traqula/core": "^1.0.0",
         "@traqula/generator-sparql-1-2": "^1.0.1"
@@ -6348,16 +6475,16 @@
       }
     },
     "node_modules/@comunica/actor-query-source-dereference-link-force-sparql": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-dereference-link-force-sparql/-/actor-query-source-dereference-link-force-sparql-5.1.3.tgz",
-      "integrity": "sha512-GD1smY0eGFpxodhAHgF1uJbM+JaANxF3IWmMSHgKd8aJeQLCnShVdk1H6w+5wHzOGrJH3kb4pqo9WYSbvKl79Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-dereference-link-force-sparql/-/actor-query-source-dereference-link-force-sparql-5.2.3.tgz",
+      "integrity": "sha512-hstSLoLPsubm5+LbvGFGIoAHRje20OArBmTnHyjQZj8YA+HM/qFZ/yP2pQwTkevCfxy17olA6g2tkbxefZ0TxQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-source-dereference-link": "^5.1.3",
-        "@comunica/bus-query-source-identify-hypermedia": "^5.1.3",
-        "@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-query-source-dereference-link": "^5.2.3",
+        "@comunica/bus-query-source-identify-hypermedia": "^5.2.3",
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "readable-stream": "^4.7.0"
       },
       "funding": {
@@ -6406,21 +6533,21 @@
       }
     },
     "node_modules/@comunica/actor-query-source-dereference-link-hypermedia": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-dereference-link-hypermedia/-/actor-query-source-dereference-link-hypermedia-5.1.3.tgz",
-      "integrity": "sha512-8C9M7yd1W8s3aVJvSua3AuKKYW2TWy/vk2HF5/Ph13TtZ+nTnxZNmC1VsgUIpaKasw7En1/PStp8xOV90YYgmg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-dereference-link-hypermedia/-/actor-query-source-dereference-link-hypermedia-5.2.3.tgz",
+      "integrity": "sha512-6Yy4/8wA1wV26g0YGFYqU/cYvLfB5iLjqhb2WtzM1TI7Wp9sdvWmnVqxZnpnNPmeZa6x0LTMbrOj5SYXYSLS1g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-dereference": "^5.1.3",
-        "@comunica/bus-dereference-rdf": "^5.1.3",
-        "@comunica/bus-query-source-dereference-link": "^5.1.3",
-        "@comunica/bus-query-source-identify-hypermedia": "^5.1.3",
-        "@comunica/bus-rdf-metadata": "^5.1.3",
-        "@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-dereference": "^5.2.3",
+        "@comunica/bus-dereference-rdf": "^5.2.3",
+        "@comunica/bus-query-source-dereference-link": "^5.2.3",
+        "@comunica/bus-query-source-identify-hypermedia": "^5.2.3",
+        "@comunica/bus-rdf-metadata": "^5.2.3",
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "readable-stream": "^4.7.0"
       },
       "funding": {
@@ -6468,24 +6595,44 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@comunica/actor-query-source-identify-hypermedia": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia/-/actor-query-source-identify-hypermedia-5.1.3.tgz",
-      "integrity": "sha512-kQ8+u2ug+MALmm6StYaI95DevwiTXt3QunG0VUOXvZ2/5hPIxnsmijTniUKXIB9anGR0NH8cZuomJRzFdvoXpQ==",
+    "node_modules/@comunica/actor-query-source-identify-compositefile": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-compositefile/-/actor-query-source-identify-compositefile-5.2.3.tgz",
+      "integrity": "sha512-H0kuvNr5Bi9kMZWUjFWmoRZkoch+ZXcI0pi2Tm64BuycL0foxTF30ZRENjgG4i2JgGosqInLysUdoiNfy+ALYA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-source-dereference-link": "^5.1.3",
-        "@comunica/bus-query-source-identify": "^5.1.3",
-        "@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^5.1.3",
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
+        "@comunica/actor-query-source-identify-rdfjs": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "rdf-stores": "^2.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-query-source-identify-hypermedia": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia/-/actor-query-source-identify-hypermedia-5.2.3.tgz",
+      "integrity": "sha512-V8+Onflq1iOCUaTAVx+hV0ZaY/9YlPqCqJXm0k6H9LK56XfqTXaTjGJhhJzJjbuRdMjPjqHe+v8AfqzwyFWnFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-source-dereference-link": "^5.2.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^5.2.3",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "lru-cache": "^11.2.2"
@@ -6496,19 +6643,19 @@
       }
     },
     "node_modules/@comunica/actor-query-source-identify-hypermedia-none": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-none/-/actor-query-source-identify-hypermedia-none-5.1.3.tgz",
-      "integrity": "sha512-W+hP4Wnibb1zr4Y2XbpTs0sdjfkhWTjZOWNVV9dPAra5Ypaxjtje2LQQoupon4oJE4lIWLGIykHer2HuF+9tgg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-none/-/actor-query-source-identify-hypermedia-none-5.2.3.tgz",
+      "integrity": "sha512-4CIXXt3GA1wWENoasQxU0vZOI6qpS0oyfueE3tUp3XbIEX4jJUyiTE5dR73cWZW7g0vdXsX5EkLheD21k8yrLw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-query-source-identify-rdfjs": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-source-identify-hypermedia": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "rdf-store-stream": "^3.0.0"
+        "@comunica/actor-query-source-identify-rdfjs": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-source-identify-hypermedia": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@rdfjs/types": "*",
+        "rdf-stores": "^2.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6516,24 +6663,24 @@
       }
     },
     "node_modules/@comunica/actor-query-source-identify-hypermedia-qpf": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-qpf/-/actor-query-source-identify-hypermedia-qpf-5.1.3.tgz",
-      "integrity": "sha512-yT1+okZnkG9AfBWGOUAkIJsj2qHoATka5u7+/ALmigq6WThh9G86f36tBXg4aCwiw2BmPQrNcBwDFSPk+vGFDw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-qpf/-/actor-query-source-identify-hypermedia-qpf-5.2.3.tgz",
+      "integrity": "sha512-cjzNmjjYdE8PI4dOLwqmma2YM38voA24MPIaShhmY8A32Z3rwsgntTVLDyDye8aQQxb74Bl0T0Ra0Dzy1cNKpg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^5.1.3",
-        "@comunica/bus-dereference-rdf": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-source-identify": "^5.1.3",
-        "@comunica/bus-query-source-identify-hypermedia": "^5.1.3",
-        "@comunica/bus-rdf-metadata": "^5.1.3",
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^5.2.3",
+        "@comunica/bus-dereference-rdf": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/bus-query-source-identify-hypermedia": "^5.2.3",
+        "@comunica/bus-rdf-metadata": "^5.2.3",
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-string": "^2.0.1",
@@ -6546,22 +6693,22 @@
       }
     },
     "node_modules/@comunica/actor-query-source-identify-hypermedia-sparql": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-sparql/-/actor-query-source-identify-hypermedia-sparql-5.1.3.tgz",
-      "integrity": "sha512-guNj+Hs2E45T6og+8HjIPYvLyYVX9WWuuQf038LfQlO/4w2WzewH/8VKqmc+jr8Kqml/ehTU7d/AOflkYIZWVg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-hypermedia-sparql/-/actor-query-source-identify-hypermedia-sparql-5.2.3.tgz",
+      "integrity": "sha512-dBfvYIEID7ga6ddbb9z+/tl8VrwptUhfR0JgAjA0CiyB9/KzBK3qmThLnWzJKiIbZ5UjyRlmPr/pVFR3Y9GmMA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-serialize": "^5.1.3",
-        "@comunica/bus-query-source-identify-hypermedia": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-serialize": "^5.2.3",
+        "@comunica/bus-query-source-identify-hypermedia": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "fetch-sparql-endpoint": "^7.1.0",
@@ -6574,37 +6721,37 @@
       }
     },
     "node_modules/@comunica/actor-query-source-identify-hypermedia-sparql/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/@comunica/actor-query-source-identify-hypermedia/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/@comunica/actor-query-source-identify-rdfjs": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-5.1.3.tgz",
-      "integrity": "sha512-LgB3va2e8Cw4/ia5luPirf5NTLdaeToVVp8O9uU6gAEzXgqpDWrLO0l6bvO9CQXJB/wIF5lTr/w0S/yWaUFDVw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-5.2.3.tgz",
+      "integrity": "sha512-eX3ZyBU32L1B8iXPf/jerHqnD73ooxKW0ThXRQClLuSEJZCQ1Zo0GZ0tQv4tVg4XnK+f3u2K1QfUOAmwTMLbMg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-source-identify": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-terms": "^2.0.0"
@@ -6615,15 +6762,15 @@
       }
     },
     "node_modules/@comunica/actor-query-source-identify-serialized": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-serialized/-/actor-query-source-identify-serialized-5.1.3.tgz",
-      "integrity": "sha512-/GaopV3GGiNbTwJ4aS5tu4ZXDu2pvYVcLRhh4XouA6SACFynJQYd5XwkrcZU0L8zM+GMLy8wbMcYKcSQYCrsIw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-source-identify-serialized/-/actor-query-source-identify-serialized-5.2.3.tgz",
+      "integrity": "sha512-oAtjI8fzslds06Lo3jdKBmgHfxmZ/hbUDaSIcdR/RaqzVh0UoTRZj5eHXzBQ3Mew2Od5/rqy5XD4oTdsoRhw7A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-query-source-identify": "^5.1.3",
-        "@comunica/bus-rdf-parse": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-query-source-identify": "^5.2.3",
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-store-stream": "^3.0.0",
         "readable-stream": "^4.7.0"
@@ -6674,13 +6821,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-entries-sort-cardinality": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-5.1.3.tgz",
-      "integrity": "sha512-XLYyk/gap6cD1wDN1KsbaA18J+iMzPdWBH2r7WxmCLy08UY2pigxl8EU5BT08s5XxYPWLDEUL/U+qy2IGzeKRg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-5.2.3.tgz",
+      "integrity": "sha512-zt03Wl/clFxdMGvBeoPSVhlaRV8R/j1ZbDagYCvq+AczsJcVlxuAyMVnKRjdmnBaW5thbnGkXKwBgCZaSlDaTQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -6688,15 +6835,15 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-entries-sort-selectivity": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-selectivity/-/actor-rdf-join-entries-sort-selectivity-5.1.3.tgz",
-      "integrity": "sha512-U82yb1QT37dF7gebEYmtIWygbvxxgmcETsQl0QS+t7oHEPs5wKrq++Y62Tha67MGztr+2mVFaZYobGS34Ef/Xw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-selectivity/-/actor-rdf-join-entries-sort-selectivity-5.2.3.tgz",
+      "integrity": "sha512-oO/buzYYczMG3PC6aH04TBCqgjF3lG/4bF0DxxwHKa+7z2BfoJNhil1xmzI0NVWcg3ULhfeyFDjirxQ5+DtqDw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-        "@comunica/bus-rdf-join-selectivity": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/bus-rdf-join-selectivity": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -6704,17 +6851,17 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-hash": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-5.1.3.tgz",
-      "integrity": "sha512-NjA8dF4JLf0RxR0fDxvlC5wDna47NUdkjCOecZxolqa4XScZMcSu3Sa0P+POirrj57Tkp8P0C4qcjJ8kjOZQ7A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-5.2.3.tgz",
+      "integrity": "sha512-bOrLb92YCUTCAck1Fbri/wxHYJNPjbgtuXXQoUbS5jolaaYfvjw0m3gVdsFTNXHWzwnwzGzpf7AbK//fAIBUTQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-hash-bindings": "^5.1.3",
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-bindings-index": "^5.1.3",
+        "@comunica/bus-hash-bindings": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-bindings-index": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
         "asynciterator": "^3.10.0",
         "asyncjoin": "^1.2.4",
@@ -6726,22 +6873,22 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-bind": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-5.1.3.tgz",
-      "integrity": "sha512-m8HRDNcAxtbBnNVxZIoTGIXyIpJKxl3IuVoAEFifB5tXC0YBUc/M457X+IWBAB0MzBYxoj+Gw372Mn/u/fyJcg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-5.2.3.tgz",
+      "integrity": "sha512-k/R3/Z027Ra/wFP1zmpArhtbLFVnvExoLfrPBz8ggUvQnF/d0fi6r+GY8qs3CZi9+PlGSISJ7/rcxx+b2VyUNw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -6750,20 +6897,20 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-bind-source": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-5.1.3.tgz",
-      "integrity": "sha512-SDjKNoyCTti30M08EtWet8uIRFd7bMv057bu5Kk+7kUEJq699KLmalIAqvQxeS9Zx4lmbCCPLPcQqwKjc9HbPg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-5.2.3.tgz",
+      "integrity": "sha512-7s+uRuhvB0q5rAsbgQjkHZz6Mcdu0/1GYYfsSVw2e33RQvNPWMviHZNb8DV5rJ7szOTLbtPO9UT1JOKYgQeYVg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@comunica/utils-iterator": "^5.0.0",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -6772,17 +6919,17 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-empty": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-5.1.3.tgz",
-      "integrity": "sha512-UuqK4yDiFmUetJU4hMac7j0ZfCU+sGlPcTzEbwf1tgUrdDU1vlXaoSsRTsN4hbsPsUtjC1rQt3ZojVITl8hEfA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-5.2.3.tgz",
+      "integrity": "sha512-UDgeb995HKoBMHVtAopnncKwMS1UwEkYRaJ+NtHlaPzVFJ9nyC73nQ+KJZNRGcTv3PE0r87nyIeLhvlr5+S92Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -6792,19 +6939,19 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-smallest": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-5.1.3.tgz",
-      "integrity": "sha512-jZNq6mDzU4+GKY3ccYdmYJdeKzXvpHQiRcZlWCNifGAH3CC3k72Tvfh1GVChVE06Ek9EMCT/OU5QtlgjPRCLwg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-5.2.3.tgz",
+      "integrity": "sha512-rLmr+9roj2llyZnmy0xz2ls/FfmfO/RHUQchXJuiLSGURjpoE0jDT/CREbyRFEJCPI7BFHg9Jko3H+Vzhh7N0g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -6812,21 +6959,21 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-5.1.3.tgz",
-      "integrity": "sha512-gbXAm7Wdtcn0ed2q4L70XPhEsr1+fiCGnIgRU0ap5eqhgoFGATw4G2VK2lQ9ueJ/ZCAE3QSnVMMnPn5PLxGNBQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-5.2.3.tgz",
+      "integrity": "sha512-wD2XpYeOfNAYIjeX8eqNQDvFYWCjEO0x7YKI5oxoxJHrLYCgMTaqXyC0f563f9smINIwBdylQE/tRJXu3Tcl5A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "asynciterator": "^3.10.0"
       },
       "funding": {
@@ -6835,14 +6982,14 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-nestedloop": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-5.1.3.tgz",
-      "integrity": "sha512-8NNxv7FMIWdkJcWZim8muhUNFDGH+kz0ye38XhVhhCwie10bOu67ON+j+R5WuvuFbb5Z8CKvM+5xl6ieHgsW/g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-5.2.3.tgz",
+      "integrity": "sha512-9PN+wkmoMzHv792VEGJa1nKDEmnfwMun76WQo25EEimchHkqdbz5nLKKbo4ecNmkx7aJ4B7us0QrZ0/lILmMDg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
         "asyncjoin": "^1.2.4"
       },
       "funding": {
@@ -6851,19 +6998,19 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-none": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-5.1.3.tgz",
-      "integrity": "sha512-tkpT8vz2cjMA/jzNoWqtZxdKDby1JAb6jKfLW/bsMVq6H2/80OXB5bF1t120IR7+eFR/f7mde6D3Xqf7IX898w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-5.2.3.tgz",
+      "integrity": "sha512-93jA81M6iJd9Ut89pusfwCLAXZNjmCs+/e18V3wiW9YvDAKQNbTS+wxh1/fGy5WTTWEtQvbf65NgC5mvDBi8dQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -6873,14 +7020,14 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-single": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-5.1.3.tgz",
-      "integrity": "sha512-k27OLJ0Bg2aoCW/zBxAvmZNjk+kqibx843wAaQdOY1qxlsf3XK59HOROYeHAk+ydnYP6lWwMjuDco2jTI9Uvzw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-5.2.3.tgz",
+      "integrity": "sha512-4i/Z5PXa7EFdztHAQAA0zXVIQppTEpBscZ/RSw5sDx9baRLSazAU9k3SuXkr+06aUefW8xNJt2zJXwKgTBGC8w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3"
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -6888,15 +7035,15 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-symmetrichash": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-5.1.3.tgz",
-      "integrity": "sha512-U41j1sziGCIM04kejE8Vf/w3bf+fXI+xPc/JAEfikFZcq3GufGHp6+6x4/WI/mI+D2/0vI3w0PxngZ+1EAuFkw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-5.2.3.tgz",
+      "integrity": "sha512-rA6hwJ7OfL8O8pJwsQsYy28tFnqkoUpqqBB5vFfUBaZLepYhwkZD4oLvJsa9EcWumDaJsrV0GACEHr9jnfVfEQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-hash-bindings": "^5.1.3",
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
+        "@comunica/bus-hash-bindings": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
         "asyncjoin": "^1.2.4"
       },
       "funding": {
@@ -6905,17 +7052,17 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-minus-hash": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-5.1.3.tgz",
-      "integrity": "sha512-vFcWRkqjalJUJm5mTKP/VAYK0hP01mwf5fF23qeXeSW3tjP7ePn34+NA0N+Igf/XPQVtRmd+b92woFuHm6ydfw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-5.2.3.tgz",
+      "integrity": "sha512-4v1tPTyPe0/nsbmaBf3TdpCBR37/O69JyeEcr6n1S87yyWOkktlOm2SbHJ6m8+TFRYkMSWr2aZ01P4s0glpkDA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-bindings-index": "^5.1.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-bindings-index": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
         "@rdfjs/types": "*",
         "rdf-string": "^2.0.1"
@@ -6926,22 +7073,22 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-optional-bind": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-5.1.3.tgz",
-      "integrity": "sha512-1PJHdLjCNa4mQjaNVZKO2BovL9abB2wfa0ch1AQlMIA1uCpX3jj3iLXMB1GIDNe6aeArkuyL+cKUHQH6RqXLBg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-5.2.3.tgz",
+      "integrity": "sha512-5T1D0+t5Ghs/mNC4HXeDXbfhzL6sG4aYuihTB8E/PRowaEQITDuyw4LKUj6wc3xPojNP1niFWdokULFsXUfvPw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-rdf-join-inner-multi-bind": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3"
+        "@comunica/actor-rdf-join-inner-multi-bind": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -6949,17 +7096,17 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-optional-hash": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-5.1.3.tgz",
-      "integrity": "sha512-XgJzTvWAPh3qwsmK8BxGvezB+IRsYGS9jwvIcQeXnZ6Q+8Br9S9wRtZk5fU22t6B0Ra1bIuLrH3PVMAlJHFTJg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-5.2.3.tgz",
+      "integrity": "sha512-RqW28QO62yw3RYmQkT+pWcEVcQhKF1HFjwhcLwdhi6zP8ENRtQSlBaUW0wUAhdyT46YH5/tlOJYnVyDut5c9NA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-bindings-index": "^5.1.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-bindings-index": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
         "asynciterator": "^3.10.0",
         "rdf-string": "^2.0.1"
@@ -6970,14 +7117,14 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-optional-nestedloop": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-5.1.3.tgz",
-      "integrity": "sha512-prsgzCT+JqKUXN0Xg7NxPEUfzR9XCPz/Xbk+QCjJr2sKmObU+TQQx2X6nDudx5tGVCr1JhrYSG7UUJkVoLf8Kw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-5.2.3.tgz",
+      "integrity": "sha512-hd5XEUa+i7jTXk35A0a/rD+8+pCnK0pGKFCIQFq/fTZNqCK0waKhyok5AMOhRSVngwPiJ01I3aqO3INTwoLY+A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
         "asyncjoin": "^1.2.4"
       },
       "funding": {
@@ -6986,15 +7133,15 @@
       }
     },
     "node_modules/@comunica/actor-rdf-join-selectivity-variable-counting": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-5.1.3.tgz",
-      "integrity": "sha512-LViPdsDoPQNycgs82yjXP/CFUn+B/UmCOLF40EwzJ54KvMqlVkQH+eSXAMOZ+VAVUyDFf4haRNi6YQjAfWBC1w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-5.2.3.tgz",
+      "integrity": "sha512-/4McTKrrhNBcvIxCta3G30btrDartN+U6JQFOSb0HBdUTGz5PnzQRWCgQo9iVlEjK68pZ3AZRXYQFlfoU5Spqw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join-selectivity": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-accuracy": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/bus-rdf-join-selectivity": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-accuracy": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7002,14 +7149,14 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-accumulate-cardinality": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-5.1.3.tgz",
-      "integrity": "sha512-Vwby9Ye6uvxZraX0+GGkQzRNIQyj4eC2x0odZAd9UIfKek1yxz7f23y4Dh/UgOt8NwLa8XKcTzEFSH7m5DeiDg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-5.2.3.tgz",
+      "integrity": "sha512-ZW3EvYKI+JgU28ORyxG0hjfRgR/fya6bXf4tVJW4kwMCJpqPeCBP9sZp2DyMN5gUJgyEF9OCjsFivOXRhE7qSA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7017,13 +7164,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-accumulate-pagesize": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-5.1.3.tgz",
-      "integrity": "sha512-+UdaqRlyOHkkSoKd+W1xSCf7IrMVlHoeDov6y1tzzYbnFLnyjEVx+0XW6f8S6FTyQ8uYZOMISqgEEh0CXfKHXg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-5.2.3.tgz",
+      "integrity": "sha512-yWWBeqviOxQ1E0m55PrYZu0UccUvCLkzKuc77nh0Ok6sr2fmScr5UDZGT5guhtK9mdPooiza/5wX185CZLwPzg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7031,13 +7178,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-accumulate-requesttime": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-5.1.3.tgz",
-      "integrity": "sha512-O4a/oBTu3E58mfZ5oCxXibanBHsCX0db0B0eeWJtuWswQN1vRlj66xpjGNcC+wSz4i04KjmDkAyZTyisj8nIwA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-5.2.3.tgz",
+      "integrity": "sha512-aW+DBzRaWc4FuSM8gE8NpcNsLsJP8oee5jadx7/rNZO18e1Lq69G8m2QivD8dBNUZObMKNB5f1tqn5b5jSED1A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-accumulate": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-metadata-accumulate": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7045,13 +7192,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-all": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-5.1.3.tgz",
-      "integrity": "sha512-SiwMp96+pe726PUau785pceIhmmUh35p2lUWmGFAafTtLzMvdb/4yw0vU8J9XGEFmz/njzYT1PfgwM1K0CUqYQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-5.2.3.tgz",
+      "integrity": "sha512-1nkNXxVYGNe92/gYquPBLtaaHFee2ij+anIEgxfr0oqqIs3GmHxsf5viU4PEhJo+wnwMK0yLfaEIxXtaYRIH8Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-rdf-metadata": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "readable-stream": "^4.7.0"
       },
       "funding": {
@@ -7100,13 +7247,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-allow-http-methods": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-5.1.3.tgz",
-      "integrity": "sha512-fMB7iG4LYt2cTGmZ44o1Z6lZyN/4zF8xqomqEJrr28wA9Gqbso12ZODj0QphJGY6t3VPeoX6Fpmjhc/seMgqHA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-5.2.3.tgz",
+      "integrity": "sha512-EpHBeWdy3N610O9ktU4HhpfOaq8aae40e0W05RyFI4df2C9zPkkmYM1bnglw863ti5KdCsjIMizlcfiHQOkAXg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7114,13 +7261,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-hydra-controls": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-5.1.3.tgz",
-      "integrity": "sha512-wdB9AcfQL/bl7KRxW9cT911wJadeRwDvkeNut8k5SRAq//ahXSkO2MdIglGiS9pgr8BTUwtF4tKEvQsGc6yCkw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-5.2.3.tgz",
+      "integrity": "sha512-/GZJIknF8x1CpZ/qI4+Og82XV+HAvFWhvSfn3Sag3bdppZcM/KxwrOJZ9W5amZ8Rf1Ss/U2USl+kKMEz13Ce9g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*",
         "@types/uritemplate": "^0.3.4",
         "uritemplate": "0.3.4"
@@ -7131,13 +7278,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-hydra-count": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-5.1.3.tgz",
-      "integrity": "sha512-75pBxALDnQmTUCmDvbT6ctZyNvMJEUmc1SHBcGCkpeobX1k8gl2+1jrbOta+mG2Hp/dfk1e9h+ZqfUk34cF5OQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-5.2.3.tgz",
+      "integrity": "sha512-88sk4QHsFrQX9AaX9NzltTuHOYPd8pT9mIbpksM8XN+qHxFFBRfm883PtZzlyKAapM3kR7QFb3GZrPrpnle2lg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7145,13 +7292,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-hydra-pagesize": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-5.1.3.tgz",
-      "integrity": "sha512-v066/WKTGVtE2if0Qf22N11Cvy9koMpmDvRd+JL3H4J9P/0SIELM2Qg6a62DD570K3AMBlwtAwA9iKyJEu//ng==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-5.2.3.tgz",
+      "integrity": "sha512-EaQDoU6LvYejDDo+rrlrBcGYAQx++AiBo+0CZ467M6YRuPFXikXgdWx82F+XgO7q9W7gJAINK6mpid9x9hreug==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7159,13 +7306,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-5.1.3.tgz",
-      "integrity": "sha512-rCUY07vdDKpdY9B2cmCoZFFdPXY1zZ5NNRf151JEUPzeHO6MIHe0MFlW+3pXF0a5c+gBqUc7nv2TMTuSFY6P5A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-5.2.3.tgz",
+      "integrity": "sha512-TVX5K6x+38vHfY91FRSF4S3E+qLAGh4KtYCcFpLnDmz+E2dM7qTnnQ8dF9xLdrUD2aaBOoyUZOXtKT+JJDYxIg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7173,13 +7320,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-post-accepted": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-post-accepted/-/actor-rdf-metadata-extract-post-accepted-5.1.3.tgz",
-      "integrity": "sha512-ReDpvtoKhi0MUqX3JtBbv/55IsuzQh2h58h7iXhMudwpYhmP3SblIuvp8YiqItNz+k0GpAygtwogeArVgI59Ww==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-post-accepted/-/actor-rdf-metadata-extract-post-accepted-5.2.3.tgz",
+      "integrity": "sha512-HXTWMUgsEiMGX+Oth8N/HK7Rsn7ryv/6LTodz2I/NFO6sKOtUh+cp1MwTpYsrYXMdrl29O1FszqJ2MGl2f90yA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7187,13 +7334,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-put-accepted": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-5.1.3.tgz",
-      "integrity": "sha512-iqP5VBGJgsaqOmrx4Rciwh89kyDc4sID+Gml81WX+qNK7xvn8cZxnKNM2JISNRK7Q4kP7xzObMwn20T/7LAUhg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-5.2.3.tgz",
+      "integrity": "sha512-DZU+CZswuVDMA3P1uznApT0SukXXMKCYq/jlcdZwWp2giNqG3JoiYgpFNmhZ/1mYo1+Hu6GcrBU1Ij8+gIjz9w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7201,13 +7348,27 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-request-time": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-5.1.3.tgz",
-      "integrity": "sha512-urfSfwy0Z2IM6SvsJWtg5bi4DuCEU0A9JNR/2d4LLZh0srjPREk2SS7av0cX1Vkq85FBOG5cTjgbSlM0trP93g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-5.2.3.tgz",
+      "integrity": "sha512-9XrOHQsu/if9YOWu1ushjr8QosebVMZE+4KpjHMjWNV3uuk6hyuiSDyqISe1A8jXVfEmmZTyTjy1kAi2hdWZZg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/core": "^5.2.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/comunica-association"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-server-software": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-server-software/-/actor-rdf-metadata-extract-server-software-5.2.3.tgz",
+      "integrity": "sha512-eemra/IPnZ0rBc8/8cqqEjYCw48Y0rbGrxH3M3v8HVQEs+2JWhehoAs6/RGywEp4+nwr1dj5uxsMWCSJ5op5FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7215,13 +7376,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-sparql-service": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-5.1.3.tgz",
-      "integrity": "sha512-gUKb///+/rTpq4iKZCHP4LiPSkk3ywCHxzFYWKisWEmi79HRh9PVsRhETIT3/6vNP8nC03EJP5/k3OD+uqLq/Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-5.2.3.tgz",
+      "integrity": "sha512-E/We5+9CeS5zMpnqIr/SYoL90crVe2g1/kYolsRU5D0r6zMNx+ry98GOatWqClfBP5cy/IfKGAIQZ6SStrKaCw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*",
         "relative-to-absolute-iri": "^1.0.7"
       },
@@ -7231,26 +7392,26 @@
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-void": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-void/-/actor-rdf-metadata-extract-void-5.1.3.tgz",
-      "integrity": "sha512-GSVasBKtKOEfsD7RYp3BfR3x+gGXbjt+ZZDQTwON8cZgWyZkU7DhxJ0DLKrJJgte/LbJWdufObHj6tel1TNmOw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-void/-/actor-rdf-metadata-extract-void-5.2.3.tgz",
+      "integrity": "sha512-bpuDdqfmEel+sn4jvNw4vhLPx6330bNR/umbJKzS9b3sQyuplNACMtSRYngGlX7lbgZhnFylUAYYW92hZtzoUg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-primary-topic": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-5.1.3.tgz",
-      "integrity": "sha512-AV2RTwp4Innv0JL3aOfFhPunbdtETkBpKtGh6dMed/JyoQnnIvV/RJo+k7jSF/weGygZxJlH0PwULEpyKQDdPw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-5.2.3.tgz",
+      "integrity": "sha512-jAh4tv+6lLX+2JJpzdNAFYb9vFnbFEl1AIKLSkEnAXQuok8Sa56ZqfTEIBrn+xFAwu0wj4frHVXHbxNwpzvXqA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-metadata": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-rdf-metadata": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*",
         "readable-stream": "^4.7.0"
       },
@@ -7300,15 +7461,15 @@
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-5.1.3.tgz",
-      "integrity": "sha512-YfyXKpJtcX3RHhpdr68wtHbDTREtanUGB+KrQLHRzkCIbQyQ76CmWcBZVZnrsxIb2Lv/kSWJjwhoAdw0qYGkwQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-5.2.3.tgz",
+      "integrity": "sha512-OwTATauDXLCFT1BALiF5XLbEm3V/SqKSYlO2TmJWnVyEKYs/smYOSfD+Vlh4Zy86goq7iSHPgJhnzL8EWlkj9g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^5.1.3",
-        "@comunica/bus-rdf-parse-html": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/bus-rdf-parse-html": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "htmlparser2": "^10.0.0",
         "readable-stream": "^4.7.0"
@@ -7319,15 +7480,15 @@
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html-microdata": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-5.1.3.tgz",
-      "integrity": "sha512-A+9vfMgp5aAArWgKZcJxeRpolNn6OL9EU5IGFB9AhfOiMWKqgaxBIFrrn+Bd2S4yi5AE4XA0BDSCKw9hjOD/Ng==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-5.2.3.tgz",
+      "integrity": "sha512-XJOiNfb47AbYKZSv/mjCoDEd745JSiBTjwm/bHEO7tQuUgDCJPSSLVyNjfVEulsQKpqacF9ZGWQ8+iZyuGm2uA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-rdf-parse-html": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "microdata-rdf-streaming-parser": "^3.0.0"
       },
       "funding": {
@@ -7336,15 +7497,15 @@
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-5.1.3.tgz",
-      "integrity": "sha512-YT8DRCrVz6gSD7Nz8NI3/KHSnrI+uJKhUHvF7l1GPR0HCxXVRxd3Ck9L/iAgsXv9Ilv6oXLOPum5U0kG9N4Fkg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-5.2.3.tgz",
+      "integrity": "sha512-8NnVJX/f1sv9WzHwMjFgfuhi2m1NLPa7eo/0N/4YpZWu4F6O1V62NC8NCZV5tKOYFKhFMmgdv9R9kW1qDOMhGQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse-html": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-rdf-parse-html": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "rdfa-streaming-parser": "^3.0.2"
       },
       "funding": {
@@ -7353,16 +7514,16 @@
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html-script": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-5.1.3.tgz",
-      "integrity": "sha512-lq9xJMMntoD8EDcQl+idsvhON9gdk5gVID8ltMIo6t31n3OFOUiWowow5zRsVBwj+JVsKimR/X0hz/yl+2tuPQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-5.2.3.tgz",
+      "integrity": "sha512-rftfcqzi9qxGXpgGu0F7dWYToxG4YsXiCVtuXGggzo/0oIQNkiz+/m90l3JRLh1IkFyfZ9XBvbz0zjdCYFtN8w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^5.1.3",
-        "@comunica/bus-rdf-parse-html": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/bus-rdf-parse-html": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "readable-stream": "^4.7.0",
         "relative-to-absolute-iri": "^1.0.7"
@@ -7453,17 +7614,17 @@
       }
     },
     "node_modules/@comunica/actor-rdf-parse-jsonld": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-5.1.3.tgz",
-      "integrity": "sha512-5s+EK1JiwzntFLqB4J1DNAbhjtM1v5sdK4c078Q3QuBv3+IUzXzSyAqfloCGyRo8ZMaNck3XM8kXbst5/3vzgg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-5.2.3.tgz",
+      "integrity": "sha512-eqUhugeUDqH0fvlqL5LvH0OVVCk2U6PT/oHKeqSs9fGnbcFGRXQLo5Bua7+w4Yp+YIA0kMkfFGLa0dFgh4MvAw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/bus-http-invalidate": "^5.1.3",
-        "@comunica/bus-rdf-parse": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@jeswr/stream-to-string": "^2.0.0",
         "jsonld-context-parser": "^2.2.2",
         "jsonld-streaming-parser": "^5.0.0",
@@ -7484,25 +7645,25 @@
       }
     },
     "node_modules/@comunica/actor-rdf-parse-n3": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-5.1.3.tgz",
-      "integrity": "sha512-OJZGclYq299rI0LfeHBu+2nabXUoSXnilJRUBUdOruvSsCBT3Y85cmGxzP4iFE25WSuS1cvdH48tbZItvXXsgQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-5.2.3.tgz",
+      "integrity": "sha512-r0JhUmD0sIljM3StVn9u0cuOqMUkms7uCLX2ouym+stsFfarJmLeXejEfsK5sNfZvg/jdmGTFZWXIvbb4eTe3g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "n3": "^2.0.0"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-rdfxml": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-5.1.3.tgz",
-      "integrity": "sha512-6oHHEk85KmwQ7ildTO0yVlulNoXXXdDuCQW5a3o9E9gxJoHg52pdswbuuMO7+VybzxPcrZPUvKpwEuIPRQ2bMQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-5.2.3.tgz",
+      "integrity": "sha512-7/0smzkWOoI06tQ2WbDJe0AoT4ZFceRJtjHlN/vfAVrOoAG74nQIEt4ktHyo4+bhxAzePn0s/fAdpeDmWnju0Q==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
         "rdfxml-streaming-parser": "^3.2.0"
       },
       "funding": {
@@ -7511,13 +7672,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-parse-shaclc": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-5.1.3.tgz",
-      "integrity": "sha512-dWZnxwKgb2cGKEcWA7adIUeijDSfA3rXqAiSi6I3NZUZmJDvmj5Ze+D1DB6/RO7lxm5iHRTCKECElJiwyqgbpw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-5.2.3.tgz",
+      "integrity": "sha512-Kw9x55+4yIjEhbOfDWKadTDz0AYzN9qJsE4jomptPnZsbrfWpWRu9A7T768onMjzWR5S8kkV2x8vSoE3AAczVA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@jeswr/stream-to-string": "^2.0.0",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
@@ -7570,14 +7731,14 @@
       }
     },
     "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-5.1.3.tgz",
-      "integrity": "sha512-eGioGo58dMjt/FzBPjNFeRf9wDspDHTFt6ZWXSxdeJjHuuvFQvnZEJq/3d4Oe9unHzImCRUEOcLApKbZfFbxVw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-5.2.3.tgz",
+      "integrity": "sha512-cEHFeBOYLmFr1Vacv6xfqyX5aQFppu53CQndGIciTEjAvKD2hCU0lBCdvbSySn8SBOd3tZ0obGowXVGfRQsdCA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-parse": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "rdfa-streaming-parser": "^3.0.2"
       },
       "funding": {
@@ -7586,13 +7747,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-next": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-5.1.3.tgz",
-      "integrity": "sha512-64xtAg8J6LoSgSpnttCmBMvLInxGtn3Mq1w0h/dIzalTZ+LX+xmaBsaYdkNmo0K6JmVot35/M1rNVHbkJmHr9w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-5.2.3.tgz",
+      "integrity": "sha512-o5sC2uPDUk1uEA7JBjfO+eKwq4Rgo0mGlabQG/ZMykl5YT8zUOmexaUSabwkvVq5ncHv89toG1Bpr1qPPs7a/w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia-links": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7600,14 +7761,14 @@
       }
     },
     "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-5.1.3.tgz",
-      "integrity": "sha512-zJWMRyoW8Q3cOcQoMZtDaWBJoTkuAaqkvcP6V8SfK8yqG+ARH0JMJoWwbcYHi7hi/xbxAEJgWaZmlgzpz5jxrw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-5.2.3.tgz",
+      "integrity": "sha512-1NB4T28oePE3rtTtDc0DPNuQW36XpUzmkBXXCav+eipGHk/W63D/+l04XaWbTz1pqrFHqYmu0z4OiktUdo297A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7615,13 +7776,13 @@
       }
     },
     "node_modules/@comunica/actor-rdf-serialize-jsonld": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-5.1.3.tgz",
-      "integrity": "sha512-QqfsVclU5rF28cNkO1EZoOm+zT/70s3y2ljnDx2v9zLvImE4iwdLwMYe4ueXPqXRdmwI85/qqsLkNcMtMKEMtg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-5.2.3.tgz",
+      "integrity": "sha512-9kvmEryMpFryQtsH1zx2rhuwcTcwPB9C8Un5xMxXPMX+T73aN8qelU4Kou5pEX5EUvGfBfBXhXAHum5I2gEYTw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-serialize": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-rdf-serialize": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "jsonld-streaming-serializer": "^4.0.0"
       },
       "funding": {
@@ -7630,23 +7791,23 @@
       }
     },
     "node_modules/@comunica/actor-rdf-serialize-n3": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-5.1.3.tgz",
-      "integrity": "sha512-tH9lNJZLTSsk9CqANHeV+W4kTI2k3wGbcSa0H5D72rI7CbjDcQf97YDAcbdnpvbavS66TB3mibjV9ekeMqVOfg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-5.2.3.tgz",
+      "integrity": "sha512-yQjbaLWSE6RjZzv6TFTfQKP+BMxBrW1uwE6QT4yG8uF+d5CdQiZqplvvmmpf5rQknM462jDHk3mvUXIrS0Fcyw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-serialize": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
+        "@comunica/bus-rdf-serialize": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
         "n3": "^2.0.0"
       }
     },
     "node_modules/@comunica/actor-rdf-serialize-shaclc": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-5.1.3.tgz",
-      "integrity": "sha512-KgcgtfzWl8HMgXP7B+DcycV6Neiv/GWfnt2tZ0rUY81xkf2Pb6HjYAprK9nhkUEnz6hWPBGCU8SGF77+dJakLA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-5.2.3.tgz",
+      "integrity": "sha512-yyObuvQuvPPnLvXETNMzEe9POF9ikIQgalhr9RtxEU6ZoG995YgLKqECNF69yuWkrB6dLs2BO5Vhs2RLM53rgg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-serialize": "^5.1.3",
+        "@comunica/bus-rdf-serialize": "^5.2.3",
         "arrayify-stream": "^2.0.1",
         "readable-stream": "^4.7.0",
         "shaclc-write": "^1.6.0"
@@ -7697,16 +7858,16 @@
       }
     },
     "node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-5.1.3.tgz",
-      "integrity": "sha512-1AabrIU2pntk5zycY2ISX4YC+K9d21ZwLaTVO5c29zzzK2YSnFBXFt2Rm2lLZ+dl127kEC67O+UYfxXw8K01xw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-5.2.3.tgz",
+      "integrity": "sha512-9IIF+i/tdEZ0Tnf0+ORGwqliakM55ew4WlmXh+LXb1zgxuKROwbDBZEMv569XuobY8jeWiY0lllPAKgfKftD0A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/bus-rdf-update-hypermedia": "^5.1.3",
-        "@comunica/bus-rdf-update-quads": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-rdf-update-hypermedia": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-string-ttl": "^2.0.1",
@@ -7758,17 +7919,17 @@
       }
     },
     "node_modules/@comunica/actor-rdf-update-hypermedia-put-ldp": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-5.1.3.tgz",
-      "integrity": "sha512-nTgEDGwyb5WRGrHSB/mXyEmx6fggX6/lpXLf3kiqz8DTEDvFyswPVii/8CWDRynuKFaBvA3iuEIk6VAaBKS7AQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-5.2.3.tgz",
+      "integrity": "sha512-RuKsmqP1rEob3pRA1kaxe0jVyGJjYo+kIJfoBOKvzITcWzCRp2bJqL/z0MsSjPCGMG1e9Hn6LWMwbAmAbI560g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/bus-rdf-serialize": "^5.1.3",
-        "@comunica/bus-rdf-update-hypermedia": "^5.1.3",
-        "@comunica/bus-rdf-update-quads": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-rdf-serialize": "^5.2.3",
+        "@comunica/bus-rdf-update-hypermedia": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -7778,17 +7939,17 @@
       }
     },
     "node_modules/@comunica/actor-rdf-update-hypermedia-sparql": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-5.1.3.tgz",
-      "integrity": "sha512-5OA9HzNRDroIGx94KEL/jhzvErNpmlaKrJieC+MOfKtTzlEmCCfcugIAZXwt4Neaaqw2ER3mFsdUEa4PRNMBPQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-5.2.3.tgz",
+      "integrity": "sha512-SSLVD4Mi1D0PYloBurHDAOAIP9NSMx3Fb94qUC9rkzqnFszLldvzQHnPZZXQWGT9fL3toiNnPMsjTZf0YTUsgA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-http": "^5.1.3",
-        "@comunica/bus-rdf-update-hypermedia": "^5.1.3",
-        "@comunica/bus-rdf-update-quads": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-http": "^5.2.3",
+        "@comunica/bus-rdf-update-hypermedia": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@jeswr/stream-to-string": "^2.0.0",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
@@ -7801,21 +7962,21 @@
       }
     },
     "node_modules/@comunica/actor-rdf-update-quads-hypermedia": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-5.1.3.tgz",
-      "integrity": "sha512-dKIRysQrv0fH7835WzxfXYgjP6U+PF/QPtEjuaueyB0tY/H6AcrScCkg8AcahKR1UPm6qNXtkkwPVxPDYROepw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-5.2.3.tgz",
+      "integrity": "sha512-nQpRMtj5TkYSmrdWzX75ZTWOsRT3CGTMjQBiW3ZiYzT09vQ8uoZsO+feL/y3k94LtOjNqcBXAnOYv/MJAn3xww==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-dereference": "^5.1.3",
-        "@comunica/bus-dereference-rdf": "^5.1.3",
-        "@comunica/bus-http-invalidate": "^5.1.3",
-        "@comunica/bus-rdf-metadata": "^5.1.3",
-        "@comunica/bus-rdf-metadata-extract": "^5.1.3",
-        "@comunica/bus-rdf-update-hypermedia": "^5.1.3",
-        "@comunica/bus-rdf-update-quads": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-dereference": "^5.2.3",
+        "@comunica/bus-dereference-rdf": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/bus-rdf-metadata": "^5.2.3",
+        "@comunica/bus-rdf-metadata-extract": "^5.2.3",
+        "@comunica/bus-rdf-update-hypermedia": "^5.2.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "lru-cache": "^11.2.2"
       },
       "funding": {
@@ -7824,25 +7985,25 @@
       }
     },
     "node_modules/@comunica/actor-rdf-update-quads-hypermedia/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
     },
     "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-5.1.3.tgz",
-      "integrity": "sha512-MTbUNNkJsj8HZRYNm6CicPSpqKydeZTwdFJbu/jame0PEk1Hu+UixbSO6a/xKqQ+E/pAS7NZygqJDscXy+UTTA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-5.2.3.tgz",
+      "integrity": "sha512-EOgxs96QZCA4Ksb85P9GhMcV0ToPuKOTmPNtVJw0UwXxRRN6AhhhIlMWyTK4Jw3SxTFm4OtUes+eRioCTcMdwQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-query-operation": "^5.1.3",
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-query-operation": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "event-emitter-promisify": "^1.1.0",
@@ -7854,45 +8015,45 @@
       }
     },
     "node_modules/@comunica/actor-term-comparator-factory-expression-evaluator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-5.1.3.tgz",
-      "integrity": "sha512-0kwd4QpPClN0VUJZ34iiOBYlCkzPFi90NwL254lNalHT8cBrXfGImoE80jfPwpvRYYYjuHNwqIT3ck4wPCTi9g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-5.2.3.tgz",
+      "integrity": "sha512-hpsO5FyC/3cv/yxmNA0PXFEmjZkUEWZwW/Dijl1HQXK0KzrNDffpIKEt8Y6704h7oWnPjaGAxlzoi+e7gwztqg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-expression-evaluator-factory-default": "^5.1.3",
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/bus-term-comparator-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/actor-expression-evaluator-factory-default": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/bus-term-comparator-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/utils-bindings-factory": "^5.2.3",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/bus-bindings-aggregator-factory": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-5.1.3.tgz",
-      "integrity": "sha512-COtwhyFPgirx2OpC1m7wObZzcNIWTNGEt7Z01Bx69i3kvsvsHkJwznLhnFzOq71sR7DoyVDZlQ3kwqgo5u/hCA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-5.2.3.tgz",
+      "integrity": "sha512-qURcsSJeijscCPmLLZdKKQ/33sks3gEFr3JoXM97B8ZS4ZnhmE4JSiSHKE4cYN+osXHXVFRHQuHDd1cIlxjO0w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-expression-evaluator-factory": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3",
+        "@comunica/bus-expression-evaluator-factory": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-expression-evaluator": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-string": "^2.0.1"
       }
     },
     "node_modules/@comunica/bus-context-preprocess": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-5.1.3.tgz",
-      "integrity": "sha512-y5LkWP2FklsJViOnzNClNl6LaDuyI3T0Y+rWnH9Kbw5/fzAGI01adAM7Tu6UlwAMshV2MnDsnuM2llFvGbi2KQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-5.2.3.tgz",
+      "integrity": "sha512-LtoQGPHjT+OJb5E9+0ykpDyaWlyi9nbhQjH5xlZyvdl3xVoFiA+uzpbOug9LWS2WIPwzlfFWhLHl+iuFCIwc7w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -7900,16 +8061,16 @@
       }
     },
     "node_modules/@comunica/bus-dereference": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-5.1.3.tgz",
-      "integrity": "sha512-BeR3K0zzpg883tDO22PdjXBt1nVsS4Qz/rzvZ7TtfMMcPySVgTScOpmQAHWhV569aSi+ytU5dWEgzW58OIc/Xg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-5.2.3.tgz",
+      "integrity": "sha512-SYnWwawpckTWHSIFd6jo+EhfUXouqVTp3mioIwa/xvT7nywI6G0IGaw511imSb88VhSOh+fqQOJC+BHq1oQYQA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^5.1.3",
-        "@comunica/actor-abstract-parse": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/actor-abstract-mediatyped": "^5.2.3",
+        "@comunica/actor-abstract-parse": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "readable-stream": "^4.7.0"
       },
       "funding": {
@@ -7918,14 +8079,14 @@
       }
     },
     "node_modules/@comunica/bus-dereference-rdf": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-5.1.3.tgz",
-      "integrity": "sha512-Rqfyf3/NaUxSl31o59zDfQLJrQ+erHbuks/lHG9TBgEzGOattwv0k9IK5MJS2xboIyrajOGff6cn7XidyGtw+g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-5.2.3.tgz",
+      "integrity": "sha512-AidyUMAdGb99chRELC5WP7hEhys3+/RE8ABwIspwdlUi+WgnMvK/hjQMT6LQnjHRYI/kx5w9mniYq2feEHXkbg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-dereference": "^5.1.3",
-        "@comunica/bus-rdf-parse": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-dereference": "^5.2.3",
+        "@comunica/bus-rdf-parse": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -7974,40 +8135,40 @@
       }
     },
     "node_modules/@comunica/bus-expression-evaluator-factory": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-5.1.3.tgz",
-      "integrity": "sha512-Zq+iWYjOQ5WE5UnGzT6sd3ZR4plwTUgsbbSIKv2YkMAd6czoaT2WNtNcJL19GVcdhtKMG0eVOlYCfsu0RCq2/g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-5.2.3.tgz",
+      "integrity": "sha512-46jPNOXLx1bIvHSRdPk8kIW7TJAqTdZIucgcSn6z1aJyXMSsDYUZPTClX5eSZciUufKASyPicMebvP7p47++JA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       }
     },
     "node_modules/@comunica/bus-function-factory": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-function-factory/-/bus-function-factory-5.1.3.tgz",
-      "integrity": "sha512-PhPIYnQXSPxi/vYjOToyjBHPFukXhg/1/q3zh0z0QHikUZaT8uhW36kBWYmc2t3wwtyzUw9FDG7VCDqXhOsC0g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-function-factory/-/bus-function-factory-5.2.3.tgz",
+      "integrity": "sha512-DlRHH5ktOTb22J0vlMumBfIkFkg3eN3mfB+mRrt+pbLabI417/arkEFSSvZKrXjLUL39zbBqhv8gbo5jM8vk4A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-expression-evaluator": "^5.1.3"
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-expression-evaluator": "^5.2.3"
       }
     },
     "node_modules/@comunica/bus-hash-bindings": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-5.1.3.tgz",
-      "integrity": "sha512-bE5RkrwGpfjXEp8pxF3dbHopG4hyni+QB4D5sTfz5Wk4iMsfG0Mq/Og4zLY9tfz4KvPxtVE8b1w0BtNrySdTIA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-5.2.3.tgz",
+      "integrity": "sha512-dbGrxkKwO8e4qyDjQ8og/ZCJj9sJv3jS7hqmyaGCVU5RSMdXGNTo6mtHW0k1zTvzQ2XT5ZqrroCDzqT6xgQt6A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8016,12 +8177,12 @@
       }
     },
     "node_modules/@comunica/bus-hash-quads": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-quads/-/bus-hash-quads-5.1.3.tgz",
-      "integrity": "sha512-8bBUQSL1GO1d8+xEw1lU3OW17Y0W00hsmc6R6hgxym6zcIbQMnK/p+UnTAUo/3mn6e3mxVD2GEKh9PUYfZKVQA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-quads/-/bus-hash-quads-5.2.3.tgz",
+      "integrity": "sha512-qCKphc2ZqPbFtKrBO6rftq3M9wJhFhQLSCHS4RDQAYy03NT2Te01MyxJK9RjxQx/xtYsy5DPPLH/dYPrOAAFCQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
+        "@comunica/core": "^5.2.3",
         "rdf-data-factory": "^2.0.0"
       },
       "funding": {
@@ -8030,13 +8191,13 @@
       }
     },
     "node_modules/@comunica/bus-http": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-5.1.3.tgz",
-      "integrity": "sha512-UQAYlWHCIneRafcSy2yCJyGoZwtDYr5qdpF71SXE8Jwm8rFyjQLTSC4JKK3F02WxuJ7fMkMXZhg/anaT580QCg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-5.2.3.tgz",
+      "integrity": "sha512-1xQVWj0UEScLYc2ah0LiiLdNPEG8yjcyuHl3kyDy+TLjifhNMoMjhv2vFRdB28s8B6Y05K6Zz6Jl7tnoWxNMwQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@jeswr/stream-to-string": "^2.0.0",
         "is-stream": "^2.0.1",
         "readable-from-web": "^1.0.0",
@@ -8048,12 +8209,12 @@
       }
     },
     "node_modules/@comunica/bus-http-invalidate": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-5.1.3.tgz",
-      "integrity": "sha512-A97g7OA9QVNn5j4mhOEoy8QORR1ILvctTRVwUNV6faIezKYifiZBack5aXotv7lNZGFA/dSdArcbXJKkEq6Tvw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-5.2.3.tgz",
+      "integrity": "sha512-i14H83kyZ+ryDsqKizF8wE6RgqJDbo6/VK18wR3AI9WQ/RcZ7C/TQfn03DTp2z/ehHf6BfO/mlTv6WsOOYOw9A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8061,12 +8222,12 @@
       }
     },
     "node_modules/@comunica/bus-init": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-5.1.3.tgz",
-      "integrity": "sha512-x8MQhPIZgQWmbG/5YCPIhMe0lhX2bTuwTAVX8EF8PlnnG3tkXOlV9fR8DOASvWhTVEiZJy/582UM0ZNGe9Di3w==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-5.2.3.tgz",
+      "integrity": "sha512-I2eP9JiK5WVv5vUY9QbHAbXD7NRTBP66CkW8MJ5KKswNPdsFBPJaeXW/ekcEKEm4aUsj/80zIO/eE4M0vzo2KA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
+        "@comunica/core": "^5.2.3",
         "readable-stream": "^4.7.0"
       },
       "funding": {
@@ -8115,13 +8276,13 @@
       }
     },
     "node_modules/@comunica/bus-merge-bindings-context": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-5.1.3.tgz",
-      "integrity": "sha512-AH0QhlhTHPJSD0IG5qIinHO3R05fVz8Z7GpBQJN9O43BzDZIwuSdJ1bVOcRITEPoSEhGeTTUGLzKGvz9xgbkyg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-5.2.3.tgz",
+      "integrity": "sha512-X9H6amot0QX3a4X+T0B7urCvtPmNE5vkqVNKx5AJU+j0N1UhbZuaNBhn8pJ7n1bmAGKowBc+bAX1pOQNXWF3EQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8129,14 +8290,14 @@
       }
     },
     "node_modules/@comunica/bus-optimize-query-operation": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-5.1.3.tgz",
-      "integrity": "sha512-vyenOYrNZ0e6eg4R3u6tVquc5m4Cb22WneujZhRto9MgQJaPYFAK7WiL4BM9uZSEmFGtHd8qErvu5J0pys9lvg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-5.2.3.tgz",
+      "integrity": "sha512-hl8zVCgEO0yn+fyXdM9ZrQrl4PuiBzGgNH5Vda8/iIzSScOIQzTLIEUFFZv5nr4oiTSOLxyL1ZHFQ49Ij269Zw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8144,16 +8305,16 @@
       }
     },
     "node_modules/@comunica/bus-query-operation": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-5.1.3.tgz",
-      "integrity": "sha512-040bKjCxHeFiGu89QUB7Hi92q1ziV1PG5Fsb6c35LAZvvoWYb/bu9tOntTKKmkleUN4uhxsxeqCw61SsOp49Pw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-5.2.3.tgz",
+      "integrity": "sha512-B5vh4Nz699vxh04hYmlpelKDSQ0UATcsSGwFYbccVsQBIulBAdET1y8ODFPZachZyTdPXj8ehyHyYhYY+MzrNw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-metadata": "^5.1.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8162,13 +8323,13 @@
       }
     },
     "node_modules/@comunica/bus-query-parse": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-5.1.3.tgz",
-      "integrity": "sha512-vsHQyuVcL7U9HStLBf4WMt77CYKD6QC5oXmOclx6/dKyGc+bCw0Cl5Ltb2yipbAosTwM9rqEbICfNnGADazgkQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-5.2.3.tgz",
+      "integrity": "sha512-zC45bBWFhuJ+PLZwx1n131MOKnZChl4o/GPQkK4xyUQL6AslGKA9xdJRxsHosxUB/NFClv1DcWGWPgB0nt5uZg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8177,14 +8338,14 @@
       }
     },
     "node_modules/@comunica/bus-query-process": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-process/-/bus-query-process-5.1.3.tgz",
-      "integrity": "sha512-36WthzjsEuNQkgr5l0J04EeT1y+chV0IQr/kKpAVypux2yf/o3qc3GdwRVfILHMxb+uD52EqOYDuJHWnQbY3Ag==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-process/-/bus-query-process-5.2.3.tgz",
+      "integrity": "sha512-qI2MplEOz3tYhRU9yY6iQUBaXTLVpLPX4OaEuUVGmPaAE7o9QIrgRSyMaCd/+jnka9pVElqVVN03mmr0AK/uiw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8192,14 +8353,14 @@
       }
     },
     "node_modules/@comunica/bus-query-result-serialize": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-5.1.3.tgz",
-      "integrity": "sha512-NQ1Qe0/rQjSDJOuDA2GpDnIZjejM1Tp1savFVVtqRZs7BxVWfCpQ4aCdiZ20eLDgE9MK1HspKlUfV1c1amGtSA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-5.2.3.tgz",
+      "integrity": "sha512-xNoRjHgf9rqWDJKWMKjNOfntfDwlhUCcbAiwC7CObkrF13vKga5W5NjeNVHVCQxTofk7Pqp0YzagJgNlisNkzw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/actor-abstract-mediatyped": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8207,13 +8368,13 @@
       }
     },
     "node_modules/@comunica/bus-query-serialize": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-serialize/-/bus-query-serialize-5.1.3.tgz",
-      "integrity": "sha512-n3atX87lj49UqpXNSJ/o+FIf0ZUgKvLasIf7SoigW13xcb/z4GyVACa78RLGYP577qJINs9RGkMvcxZk1VjQYg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-serialize/-/bus-query-serialize-5.2.3.tgz",
+      "integrity": "sha512-vpK3m9oPj0XkmCcWy4iSHZgIlNSG9wvZan7qazTjFNMAz/KDyYzbV2uSDtCqkvoxjaNOhr8PATdRdDDofiFz0w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8222,13 +8383,13 @@
       }
     },
     "node_modules/@comunica/bus-query-source-dereference-link": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-source-dereference-link/-/bus-query-source-dereference-link-5.1.3.tgz",
-      "integrity": "sha512-u9/wqYbk46QCb/MNX3hoEe/LLKjSYXqVYD3zSGq3mtnlxYlpOZMoZSLu6JttZKP4nPKXOwVj61XZK8XjkKb6KA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-source-dereference-link/-/bus-query-source-dereference-link-5.2.3.tgz",
+      "integrity": "sha512-F2Dxrk2i8JrHFeHIIG9HIALZQXxFPb1ZtJapLrCovRdFgmpDcpYZklfz9iIK9n/IYj0Ig572CoZvsJgEoB1BUQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8236,17 +8397,17 @@
       }
     },
     "node_modules/@comunica/bus-query-source-identify": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify/-/bus-query-source-identify-5.1.3.tgz",
-      "integrity": "sha512-3lqmDg4ftBpgFuHRa6OltSEOLqMfq9YLDZN9VQuOqoNP+tMqLw0HruHqYD2LJCS3nH7hS2m+pXfnkXNh2vYCKw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify/-/bus-query-source-identify-5.2.3.tgz",
+      "integrity": "sha512-S8sr2nFLzPbT7I4XhjJpBlW/jMDuvM4t3uuya8bUo2+bSgSJE3obDdpMNtK3mj0BD05IQZyP0DINzuG8VNFdww==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
-        "@comunica/utils-metadata": "^5.1.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0",
         "rdf-string": "^2.0.1",
@@ -8258,13 +8419,13 @@
       }
     },
     "node_modules/@comunica/bus-query-source-identify-hypermedia": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify-hypermedia/-/bus-query-source-identify-hypermedia-5.1.3.tgz",
-      "integrity": "sha512-VpDMqXCwl3Kfa9QjpP6pR++A1Ser9QV7FlMFUvSlgD09XDBPr2T8auS3Q/5kBYmcjwh5s1woXy2nm053WzZDwA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-source-identify-hypermedia/-/bus-query-source-identify-hypermedia-5.2.3.tgz",
+      "integrity": "sha512-WMHEAOGbfPwpl7uhbG49dP+RhOXekm37tmBlEAgmuvqt9fjU5zV4Z/aPp5CyQN+IAV8S/X6nQ4I12qakBa/FWw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8273,19 +8434,19 @@
       }
     },
     "node_modules/@comunica/bus-rdf-join": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-5.1.3.tgz",
-      "integrity": "sha512-z4IfUfRHosSAWRGwNIc3hIhYU5JsdSF4SNIoA+vgGDlB/P9Rn1Bo/KCoKq35BLOXAp6Xo7mkNQCiN9u88L5RPg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-5.2.3.tgz",
+      "integrity": "sha512-SG7A+4mGCaLJrudnaZBGiWXUxTIcA9SJSUXHm72S5RScOOW/LWd7XbXNcJEOqtjU1ySARLPacN4f8TXa7PUieg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join-entries-sort": "^5.1.3",
-        "@comunica/bus-rdf-join-selectivity": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-rdf-join-entries-sort": "^5.2.3",
+        "@comunica/bus-rdf-join-selectivity": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@comunica/utils-iterator": "^5.0.0",
-        "@comunica/utils-metadata": "^5.1.3",
+        "@comunica/utils-metadata": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8294,13 +8455,13 @@
       }
     },
     "node_modules/@comunica/bus-rdf-join-entries-sort": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-5.1.3.tgz",
-      "integrity": "sha512-+JRQ+PX5p124BiCapPBmDzH0bbML1NUYyzhV0xpizKU5KFwv++sZBpTetHR4PUhz3UnGsz4H+U7MQbkgmno+ig==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-5.2.3.tgz",
+      "integrity": "sha512-0yso5PT72CG1i6UJhF8d1bpCbrDunon7eFx/oNzniiDUDsfZSxFT7wXeXl0r8L0aHmsTRwLx+24BCrDNzTZv6A==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8308,14 +8469,14 @@
       }
     },
     "node_modules/@comunica/bus-rdf-join-selectivity": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-5.1.3.tgz",
-      "integrity": "sha512-MFr0iazkZtWFiTBKFTt9ZqKXdUic9dUg4cLdsoiMzV+hyK3il5xcICzLVTkTbGyJe9dJjjvc3ZvWbmS4GYxcsA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-5.2.3.tgz",
+      "integrity": "sha512-na18v7Y6YbaxtHpAte1I9my9dzqqDJ37iPJpfsLL/4QXFCJgaux3hklQf51UZQ7JosPb3dOHml+l9dqXT5AVBA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-accuracy": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-accuracy": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8323,12 +8484,12 @@
       }
     },
     "node_modules/@comunica/bus-rdf-metadata": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-5.1.3.tgz",
-      "integrity": "sha512-MC2cQtjT+ZTKfyJbgfY41cAmZ+4/xmWm+i5E7Ip7Ldipc2IRNrBRvYmAu4FRmhj6+J4Ps/JH7iOR/QczCG+Rng==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-5.2.3.tgz",
+      "integrity": "sha512-kYC6onDA4Wtm9cpPO6GGE4sS5VT6wZCzFC2O9a4QZu6ZlOqCubGt/pxytTPpuN0DbS2quornugJFG9gMGofffw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8337,13 +8498,13 @@
       }
     },
     "node_modules/@comunica/bus-rdf-metadata-accumulate": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-5.1.3.tgz",
-      "integrity": "sha512-1sz/pkwFXYWL5M/BfDddpnGr8o/b0mG2HHOwF9ujb3RKHj54Qj3PiGfAAbOXd6yKgpOaHeKpCKuxfdCZYqr1vw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-5.2.3.tgz",
+      "integrity": "sha512-oQrP8ZpPVOUMitApWibSxWV/t561q/iYr+Q4Xl71HtDasyERyUayBvVxZA/YdtTqoV6anOshCcNH1w+1xkoOGQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8351,12 +8512,12 @@
       }
     },
     "node_modules/@comunica/bus-rdf-metadata-extract": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-5.1.3.tgz",
-      "integrity": "sha512-lGDVcgcBdP6mCjDrKJjAwR4p11wbCTgIl+dqYwfTBVVUOrKX72UNOpq0cBLKdq+j5Y+FZC4fzYuVgvXpo38jTg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-5.2.3.tgz",
+      "integrity": "sha512-Bqed20/4/QyDGb0M9JDcKTIIjZQwfP1vYN7/zkE6IHsr8l3zllfNoCBMIpJvq1s4sRlpDsMLfsgoq/M8kqkDwg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8365,14 +8526,14 @@
       }
     },
     "node_modules/@comunica/bus-rdf-parse": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-5.1.3.tgz",
-      "integrity": "sha512-K0tt2+5sbjnndYvuwsZGqNecm/IbywGqqUquRlyVvW3pzMEPOG3IMmYleeUSZqkJJ4gwdm5cBHA0Hykro30UeA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-5.2.3.tgz",
+      "integrity": "sha512-7227U+KefLev3zr7Nq/g3IDCSS+Qvvt7tN4MLF8QZICZBdDviTE1ctafQr2rGOUW+FL5PKpqtOoO+vAiw1DS4w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^5.1.3",
-        "@comunica/actor-abstract-parse": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/actor-abstract-mediatyped": "^5.2.3",
+        "@comunica/actor-abstract-parse": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8381,12 +8542,12 @@
       }
     },
     "node_modules/@comunica/bus-rdf-parse-html": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-5.1.3.tgz",
-      "integrity": "sha512-iIPVdLVzQt25SclAPjPbEgq4ZWupkQSnq6LO0rxAxto7p9Md6dGy/Vm3r28KvicK9qOorQiyW3TGqWB+PhFupQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-5.2.3.tgz",
+      "integrity": "sha512-ceOamxkmIMY2xVz8FXkBOiD9jrVf+FmZhpxL6k69YjseouK1CTUXKnejuC36ge7I13XuS+veNp/WOgfh0ZSoag==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8395,13 +8556,13 @@
       }
     },
     "node_modules/@comunica/bus-rdf-resolve-hypermedia-links": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-5.1.3.tgz",
-      "integrity": "sha512-QH6p1G205mKGCJtqcp9OSKw2A/th6zmpHi+IlSZd4jT7RcFhs5dVpywPvW7ZlCsuR6X9vBmzVIVhd/hsppGUsw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-5.2.3.tgz",
+      "integrity": "sha512-+r4VA3rZsIH8nM2lxAMDilxAFZIoI3Km/B1xbQprM83e/jWt1w66eZHfXXtfmsXiZ7SwLWA/RFzZNK3TFFt3fw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8409,13 +8570,13 @@
       }
     },
     "node_modules/@comunica/bus-rdf-resolve-hypermedia-links-queue": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-5.1.3.tgz",
-      "integrity": "sha512-wEQU06dAb38BgK+1OTnmsTNaZctz79cEgxd/DZnke/FykxoqRM5wEqgE2dI/j3tzV+8XGbe5IS94iS2F0dvmew==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-5.2.3.tgz",
+      "integrity": "sha512-7BJOxLjTLmhr+4B9INw35lp+hhU9Fkde2/qCba0rx6ObuYEoidX20AHcCc2wBxDnSjLi9ZCfrP/jSK92pwuGnA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8423,13 +8584,13 @@
       }
     },
     "node_modules/@comunica/bus-rdf-serialize": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-5.1.3.tgz",
-      "integrity": "sha512-wKOsPFYw9QM6fw0kBzup0HvUDkx6Y2SZGV0jFx9va3T2OuwkXD/UPHL61M+JZ82qHzQndS8cMaUE5VJjqWnJDg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-5.2.3.tgz",
+      "integrity": "sha512-KuChOoTvm+CqD2CLtD1sc2MzXnWP0BZAvelj3AzoUwhZEQyD7BOgeED1MZ42tA3rFY87QhQL4DoOkx73GytiWg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/actor-abstract-mediatyped": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8438,13 +8599,13 @@
       }
     },
     "node_modules/@comunica/bus-rdf-update-hypermedia": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-5.1.3.tgz",
-      "integrity": "sha512-6axnYhDYSB6zjhLttCCbsXuN9V8ufAZv9UpZTjXchWqFyHOOI/Za2/n6i/UHGNgJ2OuuUlnQNSRLFXQ9i38lMw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-5.2.3.tgz",
+      "integrity": "sha512-NelT4+uEaJXq1CGIFk94enMS0AME6+cAfdlXJ+G9LzRpohVLil/G+r56eL5Oy/jgitkLcYz5mFALwCon2jBf2g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-update-quads": "^5.1.3",
-        "@comunica/core": "^5.1.3"
+        "@comunica/bus-rdf-update-quads": "^5.2.3",
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8452,15 +8613,15 @@
       }
     },
     "node_modules/@comunica/bus-rdf-update-quads": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-5.1.3.tgz",
-      "integrity": "sha512-jZMw/JgZYHU6e/p9/8QCxNdDhLvqI2KtHlWSBpaL0tTjtbsdWNTaxcBAmbbcxXRL877C8yWA0g89NzuTI+pS0g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-5.2.3.tgz",
+      "integrity": "sha512-tMc2hibV0r25KAp9Z0l6ZvTzG1uIpwF+dBfrzgd8crURXN15g6xYtFp2iDdUWeCgNAO9np/RTHeUcalLyLNqTg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-optimize-query-operation-query-source-skolemize": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/actor-optimize-query-operation-query-source-skolemize": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -8470,22 +8631,22 @@
       }
     },
     "node_modules/@comunica/bus-term-comparator-factory": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-5.1.3.tgz",
-      "integrity": "sha512-BMQlV/H5593DZMdvskpvn0d8vh3NKS+Xhe+vEbugoF19sk5a9cOmfA7fZZmPIVfIh4Zlo6itQfZwdHdKjvMzng==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-5.2.3.tgz",
+      "integrity": "sha512-l6WN/oDogrCGLBpZdB3Aq+Fgpauxf0IgajT9B7dJCrknwcoZU3nbO7sEA2V93ADS4Q/ClM/Wtb7qdAecKBHPow==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*"
       }
     },
     "node_modules/@comunica/config-query-sparql": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-5.0.0.tgz",
-      "integrity": "sha512-vS6Ik0Lbm9InWPrqnLeOFM7M2SKj+KLqGVwmOaX6N/+3TjOdOhGQJRLZCGXkiwYUDg/Jn3Z++9bQIR9/Bhj4GA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-5.2.1.tgz",
+      "integrity": "sha512-zCfogBq5IK+GrgX/mBEltzdVDWLOBnyzpUXBLQdd6LTgfjRVYjAQjbZEAtUZ36mh6EDG5QGUbE4SnedQFvRMVg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -8493,14 +8654,14 @@
       }
     },
     "node_modules/@comunica/context-entries": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-5.1.3.tgz",
-      "integrity": "sha512-7LMYo7l/3a3BLOYfaMXR6Jh/QIIcz77a1rEMXPxtLE6io+m/4l72EZG6WGeUbyHFablt0fzaeBA/6afufrVNqg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-5.2.3.tgz",
+      "integrity": "sha512-HGImR7IN70Dh/3k7PqyLPWsc8AddenrzH3Ns6oFuru6GdzbokdPaoe/G08818u3GAXimrMAKcM22xNPEMrEFsQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*",
         "jsonld-context-parser": "^2.2.2"
       },
@@ -8510,12 +8671,12 @@
       }
     },
     "node_modules/@comunica/core": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-5.1.3.tgz",
-      "integrity": "sha512-j0m+iJ3jAs06BeDlAIqqLj3rAf0vbj/oONIMPzzPE13aVvtd4q1NlhV4sGUQCwqD9IKi/16HpliMie618dQ/iw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-5.2.3.tgz",
+      "integrity": "sha512-+ZpuwERjRAMRCdkxBJbUHSdHpZAxU3fHGW7tA6JpJbYryneEIU7IFlEDgP/NbfmdD5O5HfO2/0GbThiMMWgOFQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/types": "^5.1.3",
+        "@comunica/types": "^5.2.3",
         "immutable": "^5.1.3"
       },
       "engines": {
@@ -8527,12 +8688,12 @@
       }
     },
     "node_modules/@comunica/logger-pretty": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-5.1.3.tgz",
-      "integrity": "sha512-HrZPwAtFqZ/t9m/rFT4W1+dySBAQ4mZs2kowoInjY7sm26ivbF+SqUKPryQFzYB4QsQnrQstSnlo6168a6xHMA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-5.2.3.tgz",
+      "integrity": "sha512-MgNZ8MWP9GHsHbA7a9ZZ2tdSnUr/1adbisbZh9UdvvIyXdGP0mdqjhHlDq/KobBfRr9HS7AC662OD8pMl0L2pw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/types": "^5.1.3",
+        "@comunica/types": "^5.2.3",
         "object-inspect": "^1.12.2",
         "process": "^0.11.10"
       },
@@ -8542,12 +8703,12 @@
       }
     },
     "node_modules/@comunica/logger-void": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-5.1.3.tgz",
-      "integrity": "sha512-HQvRB0tMWabPfHBDCjeUC7DnXsBdtbrnU7RUQdfpJ9rtehtxf5spi/ba+vbWxEtfsb+eXHAurlSEHU2mNK1m2Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-5.2.3.tgz",
+      "integrity": "sha512-lUgcEmvIpmJr9+D3ideshcc+18pcrd8hbajjjcrv0g/0jkSF6ijHkhKVHC3wT24WIQ8K0/BFkN3JHq7kZ8HXHw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/types": "^5.1.3"
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8555,12 +8716,12 @@
       }
     },
     "node_modules/@comunica/mediator-all": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-5.1.3.tgz",
-      "integrity": "sha512-A/oV5mngV5JEN757NRR7UZhfNkJKaC2iyqbwoavdtHtLOlgQe4BYSsyD2QM9gSswm4DwfUZvi5CwGr3ppON7vw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-5.2.3.tgz",
+      "integrity": "sha512-VA+IytwflTunuPs1x9i3BRTUyrIP4iXOPlY4h2ZpsQmoLa07QAcs7tEIpLBY3owkyEbcdEAZPF9qqBYjChZ7dg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8568,13 +8729,13 @@
       }
     },
     "node_modules/@comunica/mediator-combine-pipeline": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-5.1.3.tgz",
-      "integrity": "sha512-OR9z0Bkep/22ARDf2P/ZxAMgQ/lCarSp6XNE2DmjsenQR+N2+75LqSSqwvZZWNiaSukB/wsm2FnA7+i+O/Dttg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-5.2.3.tgz",
+      "integrity": "sha512-Tu5fkk1wO9mqYhLo8P8gqw6ZM+QlrG5YcemSNNxpyOWYBaZUzllppa3c01B4TczAcNteg1sIavf4DF3w7wo4fg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8582,12 +8743,12 @@
       }
     },
     "node_modules/@comunica/mediator-combine-union": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-5.1.3.tgz",
-      "integrity": "sha512-hvSIR6Ddu456bauJULrnXeFiobGXuqABYhGFdEPlXoyl4DKVew3TbIR843JcVttefS5dMT4IRqulMKBWNw+CWw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-5.2.3.tgz",
+      "integrity": "sha512-KeTyRBT9ZLn151eV1UQgDruYoXWKl1jr28q/Rfo9+M6xHXU93ySQCjv9Y0ckaDPKTXNQVo2Q95tI49R3XD+vww==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8595,16 +8756,16 @@
       }
     },
     "node_modules/@comunica/mediator-join-coefficients-fixed": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-5.1.3.tgz",
-      "integrity": "sha512-3VBBQQwnu/oKQQiu+XGbUS8SwLeAfXUoWY09fnEYwKUHIcxi8+i8jvicOzXnWVs3D5hscX8ViAR+aEJzc8TOUQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-5.2.3.tgz",
+      "integrity": "sha512-JsUJRkLGaqqnCjDV0F4AV3VMuEC6bsbwCaI3kGIr4UnBlnFu7lzwZcl6VwGivTGizRcMQ6cBeKJcGb3VK5AE6g==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-rdf-join": "^5.1.3",
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/mediatortype-join-coefficients": "^5.1.3",
-        "@comunica/types": "^5.1.3"
+        "@comunica/bus-rdf-join": "^5.2.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/mediatortype-join-coefficients": "^5.2.3",
+        "@comunica/types": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8612,12 +8773,12 @@
       }
     },
     "node_modules/@comunica/mediator-number": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-5.1.3.tgz",
-      "integrity": "sha512-w2yHLjI5ROdAw5L5rN/iWgH0Unc5D79QeFFl6FfmpPZirbP9W1nSXHZT4HP71hk4m8EEZN70gSzCcu5+QBGgpQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-5.2.3.tgz",
+      "integrity": "sha512-QgMjmHdsOFPepgFOa6pX5pbGgYrxGPTRZ5cy0Az0eNxit034a4lUKdCH4+ShFID3kUXrLZ6FdjUbHxdDNTh7Ww==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8625,12 +8786,12 @@
       }
     },
     "node_modules/@comunica/mediator-race": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-5.1.3.tgz",
-      "integrity": "sha512-MbODudHH8poLfUVpWaNarajF/1f9m2MTEtECweE26hit/9TzRDj55/Af2tYpiD4B/TFZQuFheWZ7fzL169Hq9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-5.2.3.tgz",
+      "integrity": "sha512-lN6OO7eG5n/pivpXriK4P6g0G25Gzg3lz2eCI9n7m52g7SqcOYFwY8r68sAxLGuT1KM1KXLJwm1ie2ymp6VWCQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8638,12 +8799,12 @@
       }
     },
     "node_modules/@comunica/mediatortype-accuracy": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-5.1.3.tgz",
-      "integrity": "sha512-n5rcZMlyeueyy4dxfHuV0QbjAh6Cc1gBM7hxx3GzSzijmhpTHiGayIdUgN6kdiLHMqmDk2ZHDYHTF4ZRtJR15A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-5.2.3.tgz",
+      "integrity": "sha512-JWEAvml7xt0d/G8pp4/5iPHVBTnIggItpJ8qDtWjUf3Rdl/IWOYpMgfXo8oGNHrQ6CYevdJ7vSI4Xf3xpF7gAg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8651,12 +8812,12 @@
       }
     },
     "node_modules/@comunica/mediatortype-join-coefficients": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-5.1.3.tgz",
-      "integrity": "sha512-y7l+kFO5qML8ul0DoPCT08ENIpceBHcVABvIvMl1J1gkySkAK2STQn3YZPt2fNtDxHFLUbDJTulr3K/JU+7eKA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-5.2.3.tgz",
+      "integrity": "sha512-FE000HZeHgQ5/WpB39qci2HGUZ6wuoFDGkZjNGCD2hUQU6SuubWyoolxvIjXUqClqCQJVJNu7qW4eaK4MNZhzw==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
+        "@comunica/core": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -8665,12 +8826,12 @@
       }
     },
     "node_modules/@comunica/mediatortype-time": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-5.1.3.tgz",
-      "integrity": "sha512-qvvekxezMO+r8lonfTY+Yo7CNm5oABfg420M9ZgPlTDECd53GGhwjWLQqp4lk285ZOCrEkOYiy7AW1LZysLvIQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-5.2.3.tgz",
+      "integrity": "sha512-LPZjj/s/9R4jGDj8U5c8txyxfFTqqVeQ0ociQPRVtQSK0qUHJGsUHYqTUQqu2e9MCW6qFIlSInZ6a/7IOQmUEQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3"
+        "@comunica/core": "^5.2.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8678,264 +8839,270 @@
       }
     },
     "node_modules/@comunica/query-sparql": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/query-sparql/-/query-sparql-5.1.3.tgz",
-      "integrity": "sha512-vKleNL3i4d/QJwy6gfz1orblRY9wyOK8MlP9Dou7YbsdqAxMD6SsSE2Yn6++Adza9q8exVVL2vFBZ4mTAgIVig==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/query-sparql/-/query-sparql-5.2.3.tgz",
+      "integrity": "sha512-AJ30NI9TKf3k0d7LKCbNOsVBS5IK+HS+UJjkkKyzzk1JtdfRg9sWltC9m8sKxwpeKCI2SMemX64FIQN9qpc6nA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/actor-bindings-aggregator-factory-average": "^5.1.3",
-        "@comunica/actor-bindings-aggregator-factory-count": "^5.1.3",
-        "@comunica/actor-bindings-aggregator-factory-group-concat": "^5.1.3",
-        "@comunica/actor-bindings-aggregator-factory-max": "^5.1.3",
-        "@comunica/actor-bindings-aggregator-factory-min": "^5.1.3",
-        "@comunica/actor-bindings-aggregator-factory-sample": "^5.1.3",
-        "@comunica/actor-bindings-aggregator-factory-sum": "^5.1.3",
-        "@comunica/actor-bindings-aggregator-factory-wildcard-count": "^5.1.3",
-        "@comunica/actor-context-preprocess-convert-shortcuts": "^5.1.3",
-        "@comunica/actor-context-preprocess-set-defaults": "^5.1.3",
-        "@comunica/actor-context-preprocess-source-to-destination": "^5.1.3",
-        "@comunica/actor-dereference-fallback": "^5.1.3",
-        "@comunica/actor-dereference-http": "^5.1.3",
-        "@comunica/actor-dereference-rdf-parse": "^5.1.3",
-        "@comunica/actor-expression-evaluator-factory-default": "^5.1.3",
-        "@comunica/actor-function-factory-expression-bnode": "^5.1.3",
-        "@comunica/actor-function-factory-expression-bound": "^5.1.3",
-        "@comunica/actor-function-factory-expression-coalesce": "^5.1.3",
-        "@comunica/actor-function-factory-expression-concat": "^5.1.3",
-        "@comunica/actor-function-factory-expression-extensions": "^5.1.3",
-        "@comunica/actor-function-factory-expression-if": "^5.1.3",
-        "@comunica/actor-function-factory-expression-in": "^5.1.3",
-        "@comunica/actor-function-factory-expression-logical-and": "^5.1.3",
-        "@comunica/actor-function-factory-expression-logical-or": "^5.1.3",
-        "@comunica/actor-function-factory-expression-not-in": "^5.1.3",
-        "@comunica/actor-function-factory-expression-same-term": "^5.1.3",
-        "@comunica/actor-function-factory-term-abs": "^5.1.3",
-        "@comunica/actor-function-factory-term-addition": "^5.1.3",
-        "@comunica/actor-function-factory-term-ceil": "^5.1.3",
-        "@comunica/actor-function-factory-term-contains": "^5.1.3",
-        "@comunica/actor-function-factory-term-datatype": "^5.1.3",
-        "@comunica/actor-function-factory-term-day": "^5.1.3",
-        "@comunica/actor-function-factory-term-division": "^5.1.3",
-        "@comunica/actor-function-factory-term-encode-for-uri": "^5.1.3",
-        "@comunica/actor-function-factory-term-equality": "^5.1.3",
-        "@comunica/actor-function-factory-term-floor": "^5.1.3",
-        "@comunica/actor-function-factory-term-greater-than": "^5.1.3",
-        "@comunica/actor-function-factory-term-greater-than-equal": "^5.1.3",
-        "@comunica/actor-function-factory-term-has-lang": "^5.1.3",
-        "@comunica/actor-function-factory-term-has-langdir": "^5.1.3",
-        "@comunica/actor-function-factory-term-hours": "^5.1.3",
-        "@comunica/actor-function-factory-term-inequality": "^5.1.3",
-        "@comunica/actor-function-factory-term-iri": "^5.1.3",
-        "@comunica/actor-function-factory-term-is-blank": "^5.1.3",
-        "@comunica/actor-function-factory-term-is-iri": "^5.1.3",
-        "@comunica/actor-function-factory-term-is-literal": "^5.1.3",
-        "@comunica/actor-function-factory-term-is-numeric": "^5.1.3",
-        "@comunica/actor-function-factory-term-is-triple": "^5.1.3",
-        "@comunica/actor-function-factory-term-lang": "^5.1.3",
-        "@comunica/actor-function-factory-term-langdir": "^5.1.3",
-        "@comunica/actor-function-factory-term-langmatches": "^5.1.3",
-        "@comunica/actor-function-factory-term-lcase": "^5.1.3",
-        "@comunica/actor-function-factory-term-lesser-than": "^5.1.3",
-        "@comunica/actor-function-factory-term-lesser-than-equal": "^5.1.3",
-        "@comunica/actor-function-factory-term-md5": "^5.1.3",
-        "@comunica/actor-function-factory-term-minutes": "^5.1.3",
-        "@comunica/actor-function-factory-term-month": "^5.1.3",
-        "@comunica/actor-function-factory-term-multiplication": "^5.1.3",
-        "@comunica/actor-function-factory-term-not": "^5.1.3",
-        "@comunica/actor-function-factory-term-now": "^5.1.3",
-        "@comunica/actor-function-factory-term-object": "^5.1.3",
-        "@comunica/actor-function-factory-term-predicate": "^5.1.3",
-        "@comunica/actor-function-factory-term-rand": "^5.1.3",
-        "@comunica/actor-function-factory-term-regex": "^5.1.3",
-        "@comunica/actor-function-factory-term-replace": "^5.1.3",
-        "@comunica/actor-function-factory-term-round": "^5.1.3",
-        "@comunica/actor-function-factory-term-seconds": "^5.1.3",
-        "@comunica/actor-function-factory-term-sha1": "^5.1.3",
-        "@comunica/actor-function-factory-term-sha256": "^5.1.3",
-        "@comunica/actor-function-factory-term-sha384": "^5.1.3",
-        "@comunica/actor-function-factory-term-sha512": "^5.1.3",
-        "@comunica/actor-function-factory-term-str": "^5.1.3",
-        "@comunica/actor-function-factory-term-str-after": "^5.1.3",
-        "@comunica/actor-function-factory-term-str-before": "^5.1.3",
-        "@comunica/actor-function-factory-term-str-dt": "^5.1.3",
-        "@comunica/actor-function-factory-term-str-ends": "^5.1.3",
-        "@comunica/actor-function-factory-term-str-lang": "^5.1.3",
-        "@comunica/actor-function-factory-term-str-langdir": "^5.1.3",
-        "@comunica/actor-function-factory-term-str-len": "^5.1.3",
-        "@comunica/actor-function-factory-term-str-starts": "^5.1.3",
-        "@comunica/actor-function-factory-term-str-uuid": "^5.1.3",
-        "@comunica/actor-function-factory-term-sub-str": "^5.1.3",
-        "@comunica/actor-function-factory-term-subject": "^5.1.3",
-        "@comunica/actor-function-factory-term-subtraction": "^5.1.3",
-        "@comunica/actor-function-factory-term-timezone": "^5.1.3",
-        "@comunica/actor-function-factory-term-triple": "^5.1.3",
-        "@comunica/actor-function-factory-term-tz": "^5.1.3",
-        "@comunica/actor-function-factory-term-ucase": "^5.1.3",
-        "@comunica/actor-function-factory-term-unary-minus": "^5.1.3",
-        "@comunica/actor-function-factory-term-unary-plus": "^5.1.3",
-        "@comunica/actor-function-factory-term-uuid": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-boolean": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-date": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-datetime": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-day-time-duration": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-decimal": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-double": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-duration": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-float": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-integer": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-string": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-time": "^5.1.3",
-        "@comunica/actor-function-factory-term-xsd-to-year-month-duration": "^5.1.3",
-        "@comunica/actor-function-factory-term-year": "^5.1.3",
-        "@comunica/actor-hash-bindings-murmur": "^5.1.3",
-        "@comunica/actor-hash-quads-murmur": "^5.1.3",
-        "@comunica/actor-http-fetch": "^5.1.3",
-        "@comunica/actor-http-limit-rate": "^5.1.3",
-        "@comunica/actor-http-proxy": "^5.1.3",
-        "@comunica/actor-http-retry": "^5.1.3",
-        "@comunica/actor-http-wayback": "^5.1.3",
-        "@comunica/actor-init-query": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-assign-sources-exhaustive": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-bgp-to-join": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-construct-distinct": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-describe-to-constructs-subject": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-filter-pushdown": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-group-sources": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-join-bgp": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-join-connected": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-prune-empty-source-operations": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-query-source-identify": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-query-source-skolemize": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-rewrite-add": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-rewrite-copy": "^5.1.3",
-        "@comunica/actor-optimize-query-operation-rewrite-move": "^5.1.3",
-        "@comunica/actor-query-operation-ask": "^5.1.3",
-        "@comunica/actor-query-operation-bgp-join": "^5.1.3",
-        "@comunica/actor-query-operation-construct": "^5.1.3",
-        "@comunica/actor-query-operation-distinct-identity": "^5.1.3",
-        "@comunica/actor-query-operation-extend": "^5.1.3",
-        "@comunica/actor-query-operation-filter": "^5.1.3",
-        "@comunica/actor-query-operation-from-quad": "^5.1.3",
-        "@comunica/actor-query-operation-group": "^5.1.3",
-        "@comunica/actor-query-operation-join": "^5.1.3",
-        "@comunica/actor-query-operation-leftjoin": "^5.1.3",
-        "@comunica/actor-query-operation-minus": "^5.1.3",
-        "@comunica/actor-query-operation-nop": "^5.1.3",
-        "@comunica/actor-query-operation-orderby": "^5.1.3",
-        "@comunica/actor-query-operation-path-alt": "^5.1.3",
-        "@comunica/actor-query-operation-path-inv": "^5.1.3",
-        "@comunica/actor-query-operation-path-link": "^5.1.3",
-        "@comunica/actor-query-operation-path-nps": "^5.1.3",
-        "@comunica/actor-query-operation-path-one-or-more": "^5.1.3",
-        "@comunica/actor-query-operation-path-seq": "^5.1.3",
-        "@comunica/actor-query-operation-path-zero-or-more": "^5.1.3",
-        "@comunica/actor-query-operation-path-zero-or-one": "^5.1.3",
-        "@comunica/actor-query-operation-project": "^5.1.3",
-        "@comunica/actor-query-operation-reduced-hash": "^5.1.3",
-        "@comunica/actor-query-operation-slice": "^5.1.3",
-        "@comunica/actor-query-operation-source": "^5.1.3",
-        "@comunica/actor-query-operation-union": "^5.1.3",
-        "@comunica/actor-query-operation-update-clear": "^5.1.3",
-        "@comunica/actor-query-operation-update-compositeupdate": "^5.1.3",
-        "@comunica/actor-query-operation-update-create": "^5.1.3",
-        "@comunica/actor-query-operation-update-deleteinsert": "^5.1.3",
-        "@comunica/actor-query-operation-update-drop": "^5.1.3",
-        "@comunica/actor-query-operation-update-load": "^5.1.3",
-        "@comunica/actor-query-operation-values": "^5.1.3",
-        "@comunica/actor-query-parse-graphql": "^5.1.3",
-        "@comunica/actor-query-parse-sparql": "^5.1.3",
-        "@comunica/actor-query-process-explain-logical": "^5.1.3",
-        "@comunica/actor-query-process-explain-parsed": "^5.1.3",
-        "@comunica/actor-query-process-explain-physical": "^5.1.3",
-        "@comunica/actor-query-process-explain-query": "^5.1.3",
-        "@comunica/actor-query-process-sequential": "^5.1.3",
-        "@comunica/actor-query-result-serialize-json": "^5.1.3",
-        "@comunica/actor-query-result-serialize-rdf": "^5.1.3",
-        "@comunica/actor-query-result-serialize-simple": "^5.1.3",
-        "@comunica/actor-query-result-serialize-sparql-csv": "^5.1.3",
-        "@comunica/actor-query-result-serialize-sparql-json": "^5.1.3",
-        "@comunica/actor-query-result-serialize-sparql-tsv": "^5.1.3",
-        "@comunica/actor-query-result-serialize-sparql-xml": "^5.1.3",
-        "@comunica/actor-query-result-serialize-stats": "^5.1.3",
-        "@comunica/actor-query-result-serialize-table": "^5.1.3",
-        "@comunica/actor-query-result-serialize-tree": "^5.1.3",
-        "@comunica/actor-query-serialize-sparql": "^5.1.3",
-        "@comunica/actor-query-source-dereference-link-force-sparql": "^5.1.3",
-        "@comunica/actor-query-source-dereference-link-hypermedia": "^5.1.3",
-        "@comunica/actor-query-source-identify-hypermedia": "^5.1.3",
-        "@comunica/actor-query-source-identify-hypermedia-none": "^5.1.3",
-        "@comunica/actor-query-source-identify-hypermedia-qpf": "^5.1.3",
-        "@comunica/actor-query-source-identify-hypermedia-sparql": "^5.1.3",
-        "@comunica/actor-query-source-identify-rdfjs": "^5.1.3",
-        "@comunica/actor-query-source-identify-serialized": "^5.1.3",
-        "@comunica/actor-rdf-join-entries-sort-cardinality": "^5.1.3",
-        "@comunica/actor-rdf-join-entries-sort-selectivity": "^5.1.3",
-        "@comunica/actor-rdf-join-inner-hash": "^5.1.3",
-        "@comunica/actor-rdf-join-inner-multi-bind": "^5.1.3",
-        "@comunica/actor-rdf-join-inner-multi-bind-source": "^5.1.3",
-        "@comunica/actor-rdf-join-inner-multi-empty": "^5.1.3",
-        "@comunica/actor-rdf-join-inner-multi-smallest": "^5.1.3",
-        "@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": "^5.1.3",
-        "@comunica/actor-rdf-join-inner-nestedloop": "^5.1.3",
-        "@comunica/actor-rdf-join-inner-none": "^5.1.3",
-        "@comunica/actor-rdf-join-inner-single": "^5.1.3",
-        "@comunica/actor-rdf-join-inner-symmetrichash": "^5.1.3",
-        "@comunica/actor-rdf-join-minus-hash": "^5.1.3",
-        "@comunica/actor-rdf-join-optional-bind": "^5.1.3",
-        "@comunica/actor-rdf-join-optional-hash": "^5.1.3",
-        "@comunica/actor-rdf-join-optional-nestedloop": "^5.1.3",
-        "@comunica/actor-rdf-join-selectivity-variable-counting": "^5.1.3",
-        "@comunica/actor-rdf-metadata-accumulate-cardinality": "^5.1.3",
-        "@comunica/actor-rdf-metadata-accumulate-pagesize": "^5.1.3",
-        "@comunica/actor-rdf-metadata-accumulate-requesttime": "^5.1.3",
-        "@comunica/actor-rdf-metadata-all": "^5.1.3",
-        "@comunica/actor-rdf-metadata-extract-allow-http-methods": "^5.1.3",
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^5.1.3",
-        "@comunica/actor-rdf-metadata-extract-hydra-count": "^5.1.3",
-        "@comunica/actor-rdf-metadata-extract-hydra-pagesize": "^5.1.3",
-        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^5.1.3",
-        "@comunica/actor-rdf-metadata-extract-post-accepted": "^5.1.3",
-        "@comunica/actor-rdf-metadata-extract-put-accepted": "^5.1.3",
-        "@comunica/actor-rdf-metadata-extract-request-time": "^5.1.3",
-        "@comunica/actor-rdf-metadata-extract-sparql-service": "^5.1.3",
-        "@comunica/actor-rdf-metadata-extract-void": "^5.1.3",
-        "@comunica/actor-rdf-metadata-primary-topic": "^5.1.3",
-        "@comunica/actor-rdf-parse-html": "^5.1.3",
-        "@comunica/actor-rdf-parse-html-microdata": "^5.1.3",
-        "@comunica/actor-rdf-parse-html-rdfa": "^5.1.3",
-        "@comunica/actor-rdf-parse-html-script": "^5.1.3",
-        "@comunica/actor-rdf-parse-jsonld": "^5.1.3",
-        "@comunica/actor-rdf-parse-n3": "^5.1.3",
-        "@comunica/actor-rdf-parse-rdfxml": "^5.1.3",
-        "@comunica/actor-rdf-parse-shaclc": "^5.1.3",
-        "@comunica/actor-rdf-parse-xml-rdfa": "^5.1.3",
-        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^5.1.3",
-        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^5.1.3",
-        "@comunica/actor-rdf-serialize-jsonld": "^5.1.3",
-        "@comunica/actor-rdf-serialize-n3": "^5.1.3",
-        "@comunica/actor-rdf-serialize-shaclc": "^5.1.3",
-        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^5.1.3",
-        "@comunica/actor-rdf-update-hypermedia-put-ldp": "^5.1.3",
-        "@comunica/actor-rdf-update-hypermedia-sparql": "^5.1.3",
-        "@comunica/actor-rdf-update-quads-hypermedia": "^5.1.3",
-        "@comunica/actor-rdf-update-quads-rdfjs-store": "^5.1.3",
-        "@comunica/actor-term-comparator-factory-expression-evaluator": "^5.1.3",
-        "@comunica/bus-function-factory": "^5.1.3",
-        "@comunica/bus-http-invalidate": "^5.1.3",
-        "@comunica/bus-query-operation": "^5.1.3",
-        "@comunica/config-query-sparql": "^5.0.0",
-        "@comunica/core": "^5.1.3",
-        "@comunica/logger-void": "^5.1.3",
-        "@comunica/mediator-all": "^5.1.3",
-        "@comunica/mediator-combine-pipeline": "^5.1.3",
-        "@comunica/mediator-combine-union": "^5.1.3",
-        "@comunica/mediator-join-coefficients-fixed": "^5.1.3",
-        "@comunica/mediator-number": "^5.1.3",
-        "@comunica/mediator-race": "^5.1.3",
-        "@comunica/runner": "^5.1.3",
-        "@comunica/runner-cli": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/actor-bindings-aggregator-factory-average": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-count": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-group-concat": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-max": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-min": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-sample": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-sum": "^5.2.3",
+        "@comunica/actor-bindings-aggregator-factory-wildcard-count": "^5.2.3",
+        "@comunica/actor-context-preprocess-convert-shortcuts": "^5.2.3",
+        "@comunica/actor-context-preprocess-set-defaults": "^5.2.3",
+        "@comunica/actor-context-preprocess-source-to-destination": "^5.2.3",
+        "@comunica/actor-dereference-fallback": "^5.2.3",
+        "@comunica/actor-dereference-http": "^5.2.3",
+        "@comunica/actor-dereference-rdf-parse": "^5.2.3",
+        "@comunica/actor-expression-evaluator-factory-default": "^5.2.3",
+        "@comunica/actor-function-factory-expression-bnode": "^5.2.3",
+        "@comunica/actor-function-factory-expression-bound": "^5.2.3",
+        "@comunica/actor-function-factory-expression-coalesce": "^5.2.3",
+        "@comunica/actor-function-factory-expression-concat": "^5.2.3",
+        "@comunica/actor-function-factory-expression-extensions": "^5.2.3",
+        "@comunica/actor-function-factory-expression-if": "^5.2.3",
+        "@comunica/actor-function-factory-expression-in": "^5.2.3",
+        "@comunica/actor-function-factory-expression-logical-and": "^5.2.3",
+        "@comunica/actor-function-factory-expression-logical-or": "^5.2.3",
+        "@comunica/actor-function-factory-expression-not-in": "^5.2.3",
+        "@comunica/actor-function-factory-expression-same-term": "^5.2.3",
+        "@comunica/actor-function-factory-term-abs": "^5.2.3",
+        "@comunica/actor-function-factory-term-addition": "^5.2.3",
+        "@comunica/actor-function-factory-term-ceil": "^5.2.3",
+        "@comunica/actor-function-factory-term-contains": "^5.2.3",
+        "@comunica/actor-function-factory-term-datatype": "^5.2.3",
+        "@comunica/actor-function-factory-term-day": "^5.2.3",
+        "@comunica/actor-function-factory-term-division": "^5.2.3",
+        "@comunica/actor-function-factory-term-encode-for-uri": "^5.2.3",
+        "@comunica/actor-function-factory-term-equality": "^5.2.3",
+        "@comunica/actor-function-factory-term-floor": "^5.2.3",
+        "@comunica/actor-function-factory-term-greater-than": "^5.2.3",
+        "@comunica/actor-function-factory-term-greater-than-equal": "^5.2.3",
+        "@comunica/actor-function-factory-term-has-lang": "^5.2.3",
+        "@comunica/actor-function-factory-term-has-langdir": "^5.2.3",
+        "@comunica/actor-function-factory-term-hours": "^5.2.3",
+        "@comunica/actor-function-factory-term-inequality": "^5.2.3",
+        "@comunica/actor-function-factory-term-iri": "^5.2.3",
+        "@comunica/actor-function-factory-term-is-blank": "^5.2.3",
+        "@comunica/actor-function-factory-term-is-iri": "^5.2.3",
+        "@comunica/actor-function-factory-term-is-literal": "^5.2.3",
+        "@comunica/actor-function-factory-term-is-numeric": "^5.2.3",
+        "@comunica/actor-function-factory-term-is-triple": "^5.2.3",
+        "@comunica/actor-function-factory-term-lang": "^5.2.3",
+        "@comunica/actor-function-factory-term-langdir": "^5.2.3",
+        "@comunica/actor-function-factory-term-langmatches": "^5.2.3",
+        "@comunica/actor-function-factory-term-lcase": "^5.2.3",
+        "@comunica/actor-function-factory-term-lesser-than": "^5.2.3",
+        "@comunica/actor-function-factory-term-lesser-than-equal": "^5.2.3",
+        "@comunica/actor-function-factory-term-md5": "^5.2.3",
+        "@comunica/actor-function-factory-term-minutes": "^5.2.3",
+        "@comunica/actor-function-factory-term-month": "^5.2.3",
+        "@comunica/actor-function-factory-term-multiplication": "^5.2.3",
+        "@comunica/actor-function-factory-term-not": "^5.2.3",
+        "@comunica/actor-function-factory-term-now": "^5.2.3",
+        "@comunica/actor-function-factory-term-object": "^5.2.3",
+        "@comunica/actor-function-factory-term-predicate": "^5.2.3",
+        "@comunica/actor-function-factory-term-rand": "^5.2.3",
+        "@comunica/actor-function-factory-term-regex": "^5.2.3",
+        "@comunica/actor-function-factory-term-replace": "^5.2.3",
+        "@comunica/actor-function-factory-term-round": "^5.2.3",
+        "@comunica/actor-function-factory-term-seconds": "^5.2.3",
+        "@comunica/actor-function-factory-term-sha1": "^5.2.3",
+        "@comunica/actor-function-factory-term-sha256": "^5.2.3",
+        "@comunica/actor-function-factory-term-sha384": "^5.2.3",
+        "@comunica/actor-function-factory-term-sha512": "^5.2.3",
+        "@comunica/actor-function-factory-term-str": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-after": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-before": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-dt": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-ends": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-lang": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-langdir": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-len": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-starts": "^5.2.3",
+        "@comunica/actor-function-factory-term-str-uuid": "^5.2.3",
+        "@comunica/actor-function-factory-term-sub-str": "^5.2.3",
+        "@comunica/actor-function-factory-term-subject": "^5.2.3",
+        "@comunica/actor-function-factory-term-subtraction": "^5.2.3",
+        "@comunica/actor-function-factory-term-timezone": "^5.2.3",
+        "@comunica/actor-function-factory-term-triple": "^5.2.3",
+        "@comunica/actor-function-factory-term-tz": "^5.2.3",
+        "@comunica/actor-function-factory-term-ucase": "^5.2.3",
+        "@comunica/actor-function-factory-term-unary-minus": "^5.2.3",
+        "@comunica/actor-function-factory-term-unary-plus": "^5.2.3",
+        "@comunica/actor-function-factory-term-uuid": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-boolean": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-date": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-datetime": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-day-time-duration": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-decimal": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-double": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-duration": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-float": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-integer": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-string": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-time": "^5.2.3",
+        "@comunica/actor-function-factory-term-xsd-to-year-month-duration": "^5.2.3",
+        "@comunica/actor-function-factory-term-year": "^5.2.3",
+        "@comunica/actor-hash-bindings-murmur": "^5.2.3",
+        "@comunica/actor-hash-quads-murmur": "^5.2.3",
+        "@comunica/actor-http-fetch": "^5.2.3",
+        "@comunica/actor-http-limit-rate": "^5.2.3",
+        "@comunica/actor-http-proxy": "^5.2.3",
+        "@comunica/actor-http-retry": "^5.2.3",
+        "@comunica/actor-http-retry-body": "^5.2.3",
+        "@comunica/actor-http-wayback": "^5.2.3",
+        "@comunica/actor-init-query": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-assign-sources-exhaustive": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-bgp-to-join": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-construct-distinct": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-describe-to-constructs-subject": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-distinct-terms-pushdown": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-filter-pushdown": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-group-file-sources": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-group-sources": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-join-connected": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-prune-empty-source-operations": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-query-source-identify": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-query-source-skolemize": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-rewrite-add": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-rewrite-copy": "^5.2.3",
+        "@comunica/actor-optimize-query-operation-rewrite-move": "^5.2.3",
+        "@comunica/actor-query-operation-ask": "^5.2.3",
+        "@comunica/actor-query-operation-bgp-join": "^5.2.3",
+        "@comunica/actor-query-operation-construct": "^5.2.3",
+        "@comunica/actor-query-operation-distinct-identity": "^5.2.3",
+        "@comunica/actor-query-operation-extend": "^5.2.3",
+        "@comunica/actor-query-operation-filter": "^5.2.3",
+        "@comunica/actor-query-operation-from-quad": "^5.2.3",
+        "@comunica/actor-query-operation-group": "^5.2.3",
+        "@comunica/actor-query-operation-join": "^5.2.3",
+        "@comunica/actor-query-operation-leftjoin": "^5.2.3",
+        "@comunica/actor-query-operation-minus": "^5.2.3",
+        "@comunica/actor-query-operation-nodes": "^5.2.3",
+        "@comunica/actor-query-operation-nop": "^5.2.3",
+        "@comunica/actor-query-operation-orderby": "^5.2.3",
+        "@comunica/actor-query-operation-path-alt": "^5.2.3",
+        "@comunica/actor-query-operation-path-inv": "^5.2.3",
+        "@comunica/actor-query-operation-path-link": "^5.2.3",
+        "@comunica/actor-query-operation-path-nps": "^5.2.3",
+        "@comunica/actor-query-operation-path-one-or-more": "^5.2.3",
+        "@comunica/actor-query-operation-path-seq": "^5.2.3",
+        "@comunica/actor-query-operation-path-zero-or-more": "^5.2.3",
+        "@comunica/actor-query-operation-path-zero-or-one": "^5.2.3",
+        "@comunica/actor-query-operation-project": "^5.2.3",
+        "@comunica/actor-query-operation-reduced-hash": "^5.2.3",
+        "@comunica/actor-query-operation-slice": "^5.2.3",
+        "@comunica/actor-query-operation-source": "^5.2.3",
+        "@comunica/actor-query-operation-union": "^5.2.3",
+        "@comunica/actor-query-operation-update-clear": "^5.2.3",
+        "@comunica/actor-query-operation-update-compositeupdate": "^5.2.3",
+        "@comunica/actor-query-operation-update-create": "^5.2.3",
+        "@comunica/actor-query-operation-update-deleteinsert": "^5.2.3",
+        "@comunica/actor-query-operation-update-drop": "^5.2.3",
+        "@comunica/actor-query-operation-update-load": "^5.2.3",
+        "@comunica/actor-query-operation-values": "^5.2.3",
+        "@comunica/actor-query-parse-graphql": "^5.2.3",
+        "@comunica/actor-query-parse-sparql": "^5.2.3",
+        "@comunica/actor-query-process-explain-logical": "^5.2.3",
+        "@comunica/actor-query-process-explain-parsed": "^5.2.3",
+        "@comunica/actor-query-process-explain-physical": "^5.2.3",
+        "@comunica/actor-query-process-explain-query": "^5.2.3",
+        "@comunica/actor-query-process-sequential": "^5.2.3",
+        "@comunica/actor-query-result-serialize-json": "^5.2.3",
+        "@comunica/actor-query-result-serialize-rdf": "^5.2.3",
+        "@comunica/actor-query-result-serialize-simple": "^5.2.3",
+        "@comunica/actor-query-result-serialize-sparql-csv": "^5.2.3",
+        "@comunica/actor-query-result-serialize-sparql-json": "^5.2.3",
+        "@comunica/actor-query-result-serialize-sparql-tsv": "^5.2.3",
+        "@comunica/actor-query-result-serialize-sparql-xml": "^5.2.3",
+        "@comunica/actor-query-result-serialize-stats": "^5.2.3",
+        "@comunica/actor-query-result-serialize-table": "^5.2.3",
+        "@comunica/actor-query-result-serialize-tree": "^5.2.3",
+        "@comunica/actor-query-serialize-sparql": "^5.2.3",
+        "@comunica/actor-query-source-dereference-link-force-sparql": "^5.2.3",
+        "@comunica/actor-query-source-dereference-link-hypermedia": "^5.2.3",
+        "@comunica/actor-query-source-identify-compositefile": "^5.2.3",
+        "@comunica/actor-query-source-identify-hypermedia": "^5.2.3",
+        "@comunica/actor-query-source-identify-hypermedia-none": "^5.2.3",
+        "@comunica/actor-query-source-identify-hypermedia-qpf": "^5.2.3",
+        "@comunica/actor-query-source-identify-hypermedia-sparql": "^5.2.3",
+        "@comunica/actor-query-source-identify-rdfjs": "^5.2.3",
+        "@comunica/actor-query-source-identify-serialized": "^5.2.3",
+        "@comunica/actor-rdf-join-entries-sort-cardinality": "^5.2.3",
+        "@comunica/actor-rdf-join-entries-sort-selectivity": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-hash": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-multi-bind": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-multi-bind-source": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-multi-empty": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-multi-smallest": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-nestedloop": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-none": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-single": "^5.2.3",
+        "@comunica/actor-rdf-join-inner-symmetrichash": "^5.2.3",
+        "@comunica/actor-rdf-join-minus-hash": "^5.2.3",
+        "@comunica/actor-rdf-join-optional-bind": "^5.2.3",
+        "@comunica/actor-rdf-join-optional-hash": "^5.2.3",
+        "@comunica/actor-rdf-join-optional-nestedloop": "^5.2.3",
+        "@comunica/actor-rdf-join-selectivity-variable-counting": "^5.2.3",
+        "@comunica/actor-rdf-metadata-accumulate-cardinality": "^5.2.3",
+        "@comunica/actor-rdf-metadata-accumulate-pagesize": "^5.2.3",
+        "@comunica/actor-rdf-metadata-accumulate-requesttime": "^5.2.3",
+        "@comunica/actor-rdf-metadata-all": "^5.2.3",
+        "@comunica/actor-rdf-metadata-extract-allow-http-methods": "^5.2.3",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^5.2.3",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^5.2.3",
+        "@comunica/actor-rdf-metadata-extract-hydra-pagesize": "^5.2.3",
+        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^5.2.3",
+        "@comunica/actor-rdf-metadata-extract-post-accepted": "^5.2.3",
+        "@comunica/actor-rdf-metadata-extract-put-accepted": "^5.2.3",
+        "@comunica/actor-rdf-metadata-extract-request-time": "^5.2.3",
+        "@comunica/actor-rdf-metadata-extract-server-software": "^5.2.3",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^5.2.3",
+        "@comunica/actor-rdf-metadata-extract-void": "^5.2.3",
+        "@comunica/actor-rdf-metadata-primary-topic": "^5.2.3",
+        "@comunica/actor-rdf-parse-html": "^5.2.3",
+        "@comunica/actor-rdf-parse-html-microdata": "^5.2.3",
+        "@comunica/actor-rdf-parse-html-rdfa": "^5.2.3",
+        "@comunica/actor-rdf-parse-html-script": "^5.2.3",
+        "@comunica/actor-rdf-parse-jsonld": "^5.2.3",
+        "@comunica/actor-rdf-parse-n3": "^5.2.3",
+        "@comunica/actor-rdf-parse-rdfxml": "^5.2.3",
+        "@comunica/actor-rdf-parse-shaclc": "^5.2.3",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^5.2.3",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^5.2.3",
+        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^5.2.3",
+        "@comunica/actor-rdf-serialize-jsonld": "^5.2.3",
+        "@comunica/actor-rdf-serialize-n3": "^5.2.3",
+        "@comunica/actor-rdf-serialize-shaclc": "^5.2.3",
+        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^5.2.3",
+        "@comunica/actor-rdf-update-hypermedia-put-ldp": "^5.2.3",
+        "@comunica/actor-rdf-update-hypermedia-sparql": "^5.2.3",
+        "@comunica/actor-rdf-update-quads-hypermedia": "^5.2.3",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^5.2.3",
+        "@comunica/actor-term-comparator-factory-expression-evaluator": "^5.2.3",
+        "@comunica/bus-function-factory": "^5.2.3",
+        "@comunica/bus-http-invalidate": "^5.2.3",
+        "@comunica/bus-query-operation": "^5.2.3",
+        "@comunica/config-query-sparql": "^5.2.1",
+        "@comunica/core": "^5.2.3",
+        "@comunica/logger-void": "^5.2.3",
+        "@comunica/mediator-all": "^5.2.3",
+        "@comunica/mediator-combine-pipeline": "^5.2.3",
+        "@comunica/mediator-combine-union": "^5.2.3",
+        "@comunica/mediator-join-coefficients-fixed": "^5.2.3",
+        "@comunica/mediator-number": "^5.2.3",
+        "@comunica/mediator-race": "^5.2.3",
+        "@comunica/runner": "^5.2.3",
+        "@comunica/runner-cli": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "process": "^0.11.10"
       },
       "bin": {
@@ -12596,13 +12763,13 @@
       }
     },
     "node_modules/@comunica/runner": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-5.1.3.tgz",
-      "integrity": "sha512-SP84pTYFBdHED0KSua4h6r6Gry+3zNFSeiRsihf/s/wS9cs/J+juUteDBdiB9ObC/kg3wRMkMptmRO77CqsfoA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-5.2.3.tgz",
+      "integrity": "sha512-EVkGef4gP4cue+irSFHHv6jfa9mSKOykf18iwtSiKKs35a0Kft9/v2xvty+TFlKEqMjA9Ha2wU3r4nNAaWWusQ==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-init": "^5.1.3",
-        "@comunica/core": "^5.1.3",
+        "@comunica/bus-init": "^5.2.3",
+        "@comunica/core": "^5.2.3",
         "componentsjs": "^6.2.0",
         "process": "^0.11.10"
       },
@@ -12615,14 +12782,14 @@
       }
     },
     "node_modules/@comunica/runner-cli": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-5.1.3.tgz",
-      "integrity": "sha512-58FpohUXPJSDVfHszH83SgQHcC1rSJzccarUgXFxJzJx2NwogsAGOyW6gPOyuUCrSqIEDZER0CABS4iQbbZNIA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-5.2.3.tgz",
+      "integrity": "sha512-MtLZEM3b/RnMQvQ6Z6zFd6Y3UbVCqOIpvgEC3ASmYj8MTOfL79U4tpQWVEj4ROUamdF6DgoiJIctBp33HMBRag==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/core": "^5.1.3",
-        "@comunica/runner": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/runner": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "process": "^0.11.10"
       },
       "bin": {
@@ -12634,12 +12801,12 @@
       }
     },
     "node_modules/@comunica/types": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-5.1.3.tgz",
-      "integrity": "sha512-EbA9yYlx+49zGfmMYnQdbNfdZoUwovjKLXD4ZlpM2TDbo3MUdweyqLcDS00GB+PE5bVzFQf1I2sneEWVfzx3mQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-5.2.3.tgz",
+      "integrity": "sha512-/28Wr3OZEgNlLcdJ5IRnrambic7iYmrrm9eO2NqF2Vo8rDokSdrAwzEVr29peWwW/0gbLmGerclSxFj7lPI4mA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*",
         "@types/yargs": "^17.0.24",
         "asynciterator": "^3.10.0",
@@ -12660,13 +12827,15 @@
       }
     },
     "node_modules/@comunica/utils-algebra": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-algebra/-/utils-algebra-5.1.3.tgz",
-      "integrity": "sha512-y1PSCLXo7rWqqclmwe0BmkxpciH5t0tDNeyb1WpSfs8gxLMlYWXndCwfUkkDH7N6NLBZ2XG3Jy6YOThwg1HU+g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-algebra/-/utils-algebra-5.2.0.tgz",
+      "integrity": "sha512-UYGwvXF8PkV72ivxkE1sjJi9v/5NPiWXjsRdkgOHkRGcUkReLTjMQPWTyQ/QmiW7SkAkbYwWLG8rn8jtAdpgVw==",
       "license": "MIT",
       "dependencies": {
+        "@rdfjs/types": "*",
         "@traqula/algebra-transformations-1-2": "^1.0.1",
-        "@traqula/core": "^1.0.0"
+        "@traqula/core": "^1.0.0",
+        "rdf-terms": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -12674,14 +12843,14 @@
       }
     },
     "node_modules/@comunica/utils-bindings-factory": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-factory/-/utils-bindings-factory-5.1.3.tgz",
-      "integrity": "sha512-cj+yqKX0wlMWrPeKhc8oNqQzqT3dmhTY/MNeP1PA+GbF4+tCOjmUma71H1N89Rhu9DvN2KNXC0hzgKTRweg18g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-factory/-/utils-bindings-factory-5.2.3.tgz",
+      "integrity": "sha512-kf7LPEokpKfMQzkggWsCyvuo8qDDig04ybqVtFl6KBKnoC8qYBKLsoNB7sfQaSdKeAxaIktRvKoNrEAJ+WRc7w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/bus-merge-bindings-context": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/bus-merge-bindings-context": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "immutable": "^5.1.3",
         "rdf-string": "^2.0.1"
@@ -12692,12 +12861,12 @@
       }
     },
     "node_modules/@comunica/utils-bindings-index": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-index/-/utils-bindings-index-5.1.3.tgz",
-      "integrity": "sha512-SRKsQrxP59S5tvpH2v87P1zVTpIVIo6Nil7gaAs8qkEaLUEFyuc+NWAmD4RhqlJb4k1FNxrQTApQF4wEa4bVjQ==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-bindings-index/-/utils-bindings-index-5.2.3.tgz",
+      "integrity": "sha512-sZmHPX20E4nuf5JqWsnOre0n8CJE3iFotZnvfq9Zj34LKaStUUB5M1vtiUM9JgN+gPk2sc0pFGVXNsNjveliiA==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/types": "^5.1.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*"
       },
       "funding": {
@@ -12719,14 +12888,14 @@
       }
     },
     "node_modules/@comunica/utils-expression-evaluator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-5.1.3.tgz",
-      "integrity": "sha512-fUnkx8IG9WyzhRljqDlU8WH05ixVyCvQ8OgWDKIG0cPOoXGJxmg0Qv0z7a2te7m8klaTJiG+KY/YRzwCDY5cww==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-5.2.3.tgz",
+      "integrity": "sha512-u9SjaBIuhUSLthfjRSL+Utsf0EtfUWRZbCI3gOC6RJ8lXUVRSjKKSJZsgvnWSbkoROHczKI9dJPFe4iusO6sYg==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
         "@rdfjs/types": "*",
         "lru-cache": "^11.2.2",
         "rdf-data-factory": "^2.0.0",
@@ -12738,9 +12907,9 @@
       }
     },
     "node_modules/@comunica/utils-expression-evaluator/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -12760,12 +12929,12 @@
       }
     },
     "node_modules/@comunica/utils-metadata": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-metadata/-/utils-metadata-5.1.3.tgz",
-      "integrity": "sha512-N+dH7J5z1RBTKc5hhrj1Vlj4hIut1dZQujXak/CHBufMTFVPC1fLstV/rWbs+xfPv+fgENBbJBmw+U8VSnfl+g==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-metadata/-/utils-metadata-5.2.3.tgz",
+      "integrity": "sha512-2CvKcXI/V/jvRrWnjXa/JF9gsToPtl0l7ISVQeGYYqWfj+9mJwF8qDxo8f0XBb6ihSeu/MF+AHrfZLNNnZnZag==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/types": "^5.1.3",
+        "@comunica/types": "^5.2.3",
         "@rdfjs/types": "*",
         "asynciterator": "^3.10.0"
       },
@@ -12775,16 +12944,16 @@
       }
     },
     "node_modules/@comunica/utils-query-operation": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@comunica/utils-query-operation/-/utils-query-operation-5.1.3.tgz",
-      "integrity": "sha512-veRNX7pDZlIk4CW8Zz/bWLHRsdAFGb3sX3bQ6lAeSdtKki9TXn5J1crMK32MXBhlnDiGnMFrzsKwXUz7ZteM1A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-query-operation/-/utils-query-operation-5.2.3.tgz",
+      "integrity": "sha512-uzZvBeUEvfOWVqzleHzQ8Ruo+Byrmo6pF52UeI7DHFGNSDxCIfyD3flXNbKki2jg4a+s2E3JoY07fSxgi2N11w==",
       "license": "MIT",
       "dependencies": {
-        "@comunica/context-entries": "^5.1.3",
-        "@comunica/core": "^5.1.3",
-        "@comunica/types": "^5.1.3",
-        "@comunica/utils-algebra": "^5.1.3",
-        "@comunica/utils-bindings-factory": "^5.1.3",
+        "@comunica/context-entries": "^5.2.3",
+        "@comunica/core": "^5.2.3",
+        "@comunica/types": "^5.2.3",
+        "@comunica/utils-algebra": "^5.2.0",
+        "@comunica/utils-bindings-factory": "^5.2.3",
         "@rdfjs/types": "*",
         "rdf-data-factory": "^2.0.0",
         "rdf-string": "^2.0.1",
@@ -16624,7 +16793,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16638,7 +16806,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16652,7 +16819,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16666,7 +16832,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16680,7 +16845,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16694,7 +16858,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16708,7 +16871,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16722,7 +16884,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16736,7 +16897,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16750,7 +16910,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16764,7 +16923,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16778,7 +16936,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16792,7 +16949,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16806,7 +16962,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16820,7 +16975,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16834,7 +16988,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16848,7 +17001,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16862,7 +17014,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16876,7 +17027,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16890,7 +17040,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16904,7 +17053,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16918,7 +17066,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16932,7 +17079,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16946,7 +17092,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16960,7 +17105,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17136,7 +17280,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
       "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -17637,36 +17780,36 @@
       }
     },
     "node_modules/@traqula/algebra-sparql-1-1": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@traqula/algebra-sparql-1-1/-/algebra-sparql-1-1-1.0.4.tgz",
-      "integrity": "sha512-i7uj13QTncU8w4dBDTVakYgGLz3y/b6e28w3gFEDYSx84majqf8caiV6O7QrtxE6MWD7oYzs/0UfWEdcmRhqjg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@traqula/algebra-sparql-1-1/-/algebra-sparql-1-1-1.1.1.tgz",
+      "integrity": "sha512-Ux/h4lZPqDyC8ogt0enUC56MC0unVTnO4MBKRRo81bTc1DAk82DHHCDS8WQSotGxMbQ3hGBIJPzSRbm3JmRBOw==",
       "license": "MIT",
       "dependencies": {
-        "@traqula/algebra-transformations-1-1": "^1.0.4",
-        "@traqula/core": "^1.0.3",
-        "@traqula/rules-sparql-1-1": "^1.0.4"
+        "@traqula/algebra-transformations-1-1": "^1.1.1",
+        "@traqula/core": "^1.1.1",
+        "@traqula/rules-sparql-1-1": "^1.1.1"
       }
     },
     "node_modules/@traqula/algebra-sparql-1-2": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@traqula/algebra-sparql-1-2/-/algebra-sparql-1-2-1.0.4.tgz",
-      "integrity": "sha512-3gM1qL2ZjsZUm2rII7VZf5ZPN37IG6bmZwsHBJtGaK06JCv48qRGab55npo6cVwGl6A4H+SQIXCW+5yhuUGZDA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@traqula/algebra-sparql-1-2/-/algebra-sparql-1-2-1.1.1.tgz",
+      "integrity": "sha512-SWqwxOYrMEQil574iscpZ8uD+uI/WNguCmxOnQYAyJ5usqwLmCUBMkR+5KbOY53DFVG1/CMkacopte9xtOTYkw==",
       "license": "MIT",
       "dependencies": {
-        "@traqula/algebra-sparql-1-1": "^1.0.4",
-        "@traqula/algebra-transformations-1-1": "^1.0.4",
-        "@traqula/algebra-transformations-1-2": "^1.0.4",
-        "@traqula/core": "^1.0.3"
+        "@traqula/algebra-sparql-1-1": "^1.1.1",
+        "@traqula/algebra-transformations-1-1": "^1.1.1",
+        "@traqula/algebra-transformations-1-2": "^1.1.1",
+        "@traqula/core": "^1.1.1"
       }
     },
     "node_modules/@traqula/algebra-transformations-1-1": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@traqula/algebra-transformations-1-1/-/algebra-transformations-1-1-1.0.4.tgz",
-      "integrity": "sha512-on+W3j+bU6zjAJrxMe68B5OfC3Vvr4syFC+QO2iUihKmhS+5xrCINt5JGASISl0EdnJpg2PiQ7cXUfdJXhVVCw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@traqula/algebra-transformations-1-1/-/algebra-transformations-1-1-1.1.1.tgz",
+      "integrity": "sha512-nWfZuAsxe2A0qFVpeDMD6mjw33KyecRP0rOlWqh5soy497vXerFmlfxTYj74iHH1yT4wMFBUN30FYUAkkCoVjQ==",
       "license": "MIT",
       "dependencies": {
-        "@traqula/core": "^1.0.3",
-        "@traqula/rules-sparql-1-1": "^1.0.4",
+        "@traqula/core": "^1.1.1",
+        "@traqula/rules-sparql-1-1": "^1.1.1",
         "fast-deep-equal": "^3.1.3",
         "rdf-data-factory": "^2.0.1",
         "rdf-isomorphic": "^2.0.0",
@@ -17674,13 +17817,13 @@
       }
     },
     "node_modules/@traqula/algebra-transformations-1-2": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@traqula/algebra-transformations-1-2/-/algebra-transformations-1-2-1.0.4.tgz",
-      "integrity": "sha512-CLvD1MmDLIjtnKUYmg/bstfH3Wje5a6DTGrHHhxvFmkQo2efvKRa8Ynb8hi7Ivgm7HmZ2Sh5AREcv7jiiECsFw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@traqula/algebra-transformations-1-2/-/algebra-transformations-1-2-1.1.1.tgz",
+      "integrity": "sha512-osW3Z9pNie1xCnpuF7EbHw5yFa3BvxTIQCToOIA+4effw0ZpkqRE7kQL4q8JSkEWZbBdB9FcyTRBojxSmTuAlA==",
       "license": "MIT",
       "dependencies": {
-        "@traqula/algebra-transformations-1-1": "^1.0.4",
-        "@traqula/rules-sparql-1-2": "^1.0.4",
+        "@traqula/algebra-transformations-1-1": "^1.1.1",
+        "@traqula/rules-sparql-1-2": "^1.1.1",
         "rdf-string": "^2.0.0"
       }
     },
@@ -17719,15 +17862,15 @@
       }
     },
     "node_modules/@traqula/generator-sparql-1-2": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@traqula/generator-sparql-1-2/-/generator-sparql-1-2-1.0.4.tgz",
-      "integrity": "sha512-ELvmLXqmH/rWfygEs4LnkTqXSQpuRqxiYDHsovuNmD0/YnDrsf6sI8Ys6XGLfThZkR2y+crFEe0FJQZK9QRyCg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@traqula/generator-sparql-1-2/-/generator-sparql-1-2-1.1.1.tgz",
+      "integrity": "sha512-vhWNsX+27hk17meGrdi8e++x019tP4zASiTsXZPLWuATZdTCZUohZG36moDS7A8LQNUbpH9uzVQfOIMIazU61Q==",
       "license": "MIT",
       "dependencies": {
-        "@traqula/core": "^1.0.3",
-        "@traqula/generator-sparql-1-1": "^1.0.4",
-        "@traqula/rules-sparql-1-1": "^1.0.4",
-        "@traqula/rules-sparql-1-2": "^1.0.4"
+        "@traqula/core": "^1.1.1",
+        "@traqula/generator-sparql-1-1": "^1.1.1",
+        "@traqula/rules-sparql-1-1": "^1.1.1",
+        "@traqula/rules-sparql-1-2": "^1.1.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -17776,13 +17919,13 @@
       }
     },
     "node_modules/@traqula/rules-sparql-1-2": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-2/-/rules-sparql-1-2-1.0.4.tgz",
-      "integrity": "sha512-+eSLnuCdThlGnRr6CeOCRteJll8A6QBxbAgojjCNgwPI9BPYNMs1+/MJRJDMaa0Tc2eegx6+z6qgAX728uyd8g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@traqula/rules-sparql-1-2/-/rules-sparql-1-2-1.1.1.tgz",
+      "integrity": "sha512-VLKNzW32/DGOk0iOstuKXRwNrosYNJjWQM8ztezeAonhR8h4kugbA3ZjNFOnl/c2YMtSobc2hUXFjBhhbOum5A==",
       "license": "MIT",
       "dependencies": {
-        "@traqula/core": "^1.0.3",
-        "@traqula/rules-sparql-1-1": "^1.0.4"
+        "@traqula/core": "^1.1.1",
+        "@traqula/rules-sparql-1-1": "^1.1.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -18388,7 +18531,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/uritemplate": {
@@ -18997,7 +19139,6 @@
       "version": "8.59.3",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
       "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -19732,7 +19873,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -20032,7 +20172,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
       "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -20195,7 +20334,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -22656,7 +22794,6 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
       "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/docker-compose": {
@@ -23441,7 +23578,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
       "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -25070,7 +25206,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -26758,7 +26893,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -29696,7 +29830,7 @@
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -30966,7 +31100,6 @@
       "version": "5.55.5",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
       "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -32709,7 +32842,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/zip-stream": {
@@ -32773,8 +32905,8 @@
       "name": "@dataset-register/core",
       "version": "0.0.1",
       "dependencies": {
-        "@comunica/query-sparql": "^5.1.3",
-        "@comunica/types": "^5.1.3",
+        "@comunica/query-sparql": "^5.2.3",
+        "@comunica/types": "^5.2.3",
         "@lde/dataset": "^0.7.3",
         "@lde/distribution-probe": "^0.1.4",
         "@opentelemetry/api": "^1.9.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,8 +24,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.d.ts",
   "dependencies": {
-    "@comunica/query-sparql": "^5.1.3",
-    "@comunica/types": "^5.1.3",
+    "@comunica/query-sparql": "^5.2.3",
+    "@comunica/types": "^5.2.3",
     "@lde/dataset": "^0.7.3",
     "@lde/distribution-probe": "^0.1.4",
     "@opentelemetry/api": "^1.9.1",


### PR DESCRIPTION
Bumps the comunica group in `@dataset-register/core` from 5.1.3 to 5.2.3:

- `@comunica/query-sparql` `^5.1.3` → `^5.2.3`
- `@comunica/types` `^5.1.3` → `^5.2.3`

(The lockfile change is the full `@comunica/*` subtree moving to 5.2.3.)

## Why a manual PR

This recreates Dependabot PR #1877. Dependabot refused to rebase it (the branch had been edited outside Dependabot) and did not act on `recreate`, and its CI had been wedged for hours by the Playwright `install` hang (fixed on `main` in #2002). Recreating from `main` here gives a clean lockfile and runs against the fixed QA workflow.

Supersedes #1877.
