### PR TITLE
fix(core): cap distribution probes per dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ You can configure the application through environment variables:
   cannot hold a request open indefinitely and stall the crawl, while a large healthy paginated catalogue is not cut off
   mid-traversal. When a request times out the registration is left untouched and retried on the next pass, rather than
   being recorded as gone (default: `30`).
+- `CRAWLER_MAX_DISTRIBUTION_PROBES`: the maximum number of distinct distribution endpoints probed per dataset (minimum
+  `1`). A single dataset can declare tens of thousands of distributions; probing every endpoint stalls a crawl pass for
+  hours. Endpoints beyond the cap are skipped and the skipped count is logged, never silently dropped (default: `100`).
 
 ## Run the tests
 

--- a/apps/crawler/src/config.ts
+++ b/apps/crawler/src/config.ts
@@ -6,6 +6,7 @@ interface Env {
   REGISTRATION_URL_TTL: number;
   CRAWLER_SCHEDULE?: string;
   HTTP_REQUEST_TIMEOUT: number;
+  CRAWLER_MAX_DISTRIBUTION_PROBES: number;
 }
 
 const schema: JSONSchemaType<Env> = {
@@ -32,6 +33,13 @@ const schema: JSONSchemaType<Env> = {
       // nothing) and a negative value throws when used as an AbortSignal delay.
       minimum: 1,
       default: 30,
+    },
+    CRAWLER_MAX_DISTRIBUTION_PROBES: {
+      type: 'number',
+      // At least 1: 0 would skip every probe and a negative value makes the
+      // slice drop endpoints from the end instead of capping.
+      minimum: 1,
+      default: 100,
     },
   },
 };

--- a/apps/crawler/src/main.ts
+++ b/apps/crawler/src/main.ts
@@ -25,7 +25,11 @@ const logger = pino();
 // penalise the rating.
 const validator = new CompositeValidator(
   new ShaclEngineValidator(shacl),
-  new DistributionProbeStage({ healthStore: distributionHealthStore }),
+  new DistributionProbeStage({
+    healthStore: distributionHealthStore,
+    maxProbes: config.CRAWLER_MAX_DISTRIBUTION_PROBES,
+    logger,
+  }),
 );
 
 const crawler = new Crawler(

--- a/packages/core/src/distribution-probe/probe.ts
+++ b/packages/core/src/distribution-probe/probe.ts
@@ -24,6 +24,14 @@ const schema = (property: string): NamedNode =>
 const SPARQL_PROTOCOL_URL = 'https://www.w3.org/TR/sparql11-protocol/';
 const DEFAULT_TIMEOUT_MS = 5000;
 
+/**
+ * Minimal structural logger used to report skipped probes. Compatible with a pino logger,
+ * so callers can pass their existing logger without core depending on pino.
+ */
+export interface ProbeLogger {
+  warn(message: string): void;
+}
+
 export interface DistributionProbeStageOptions {
   /**
    * When set, each failing probe is assessed against this store and promoted to
@@ -47,10 +55,23 @@ export interface DistributionProbeStageOptions {
    * trips rate limiters on the target host, and starves the event loop. Default 20.
    */
   probeConcurrency?: number;
+  /**
+   * Maximum number of candidate distribution URLs to probe per dataset. Bounded because a
+   * single dataset can declare tens of thousands of distributions; probing all of them
+   * stalls a crawl pass for hours. Candidate URLs beyond the cap are skipped (and logged),
+   * never silently dropped. Default 100.
+   */
+  maxProbes?: number;
+  /**
+   * Optional logger used to report how many candidate URLs were skipped once the maxProbes
+   * cap is reached. When omitted, skipped probes are still bounded but not reported.
+   */
+  logger?: ProbeLogger | null;
 }
 
 const DEFAULT_FAILURE_STREAK_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_PROBE_CONCURRENCY = 20;
+const DEFAULT_MAX_PROBES = 100;
 
 interface DistributionCandidate {
   distributionNode: NamedNode | BlankNode;
@@ -73,6 +94,8 @@ export class DistributionProbeStage {
   private readonly timeoutMs: number;
   private readonly failureStreakMaxAgeMs: number;
   private readonly probeConcurrency: number;
+  private readonly maxProbes: number;
+  private readonly logger: ProbeLogger | null;
 
   public constructor(options: DistributionProbeStageOptions = {}) {
     this.healthStore = options.healthStore ?? null;
@@ -81,6 +104,8 @@ export class DistributionProbeStage {
       options.failureStreakMaxAgeMs ?? DEFAULT_FAILURE_STREAK_MAX_AGE_MS;
     this.probeConcurrency =
       options.probeConcurrency ?? DEFAULT_PROBE_CONCURRENCY;
+    this.maxProbes = options.maxProbes ?? DEFAULT_MAX_PROBES;
+    this.logger = options.logger ?? null;
   }
 
   public async run(input: DatasetCore): Promise<Quad[]> {
@@ -93,7 +118,18 @@ export class DistributionProbeStage {
     // vs. dct:conformsTo. Probing each separately reissues an identical query and trips
     // the host's rate limiter, so we coalesce candidates into one probe per endpoint and
     // reuse the verdict for every member.
-    const groups = groupByProbeTarget(candidates);
+    const allGroups = groupByProbeTarget(candidates);
+
+    // Cap the number of distinct endpoints probed. Dedup runs first so the cap is spent on
+    // genuinely different endpoints, never on duplicates; a dataset can declare tens of
+    // thousands of distributions and probing every endpoint stalls a crawl pass for hours.
+    const groups = allGroups.slice(0, this.maxProbes);
+    const skipped = allGroups.length - groups.length;
+    if (skipped > 0) {
+      this.logger?.warn(
+        `Probing ${groups.length} of ${allGroups.length} distinct distribution endpoints; skipped ${skipped} beyond the cap of ${this.maxProbes}`,
+      );
+    }
 
     const probed = await allSettledLimited(
       groups,

--- a/packages/core/test/distribution-probe.test.ts
+++ b/packages/core/test/distribution-probe.test.ts
@@ -382,6 +382,104 @@ describe('DistributionProbeStage', () => {
     expect(peakInFlight).toBeGreaterThan(0);
   });
 
+  it('caps probing at maxProbes distinct endpoints and logs how many were skipped', async () => {
+    const distributionCount = 5;
+    const maxProbes = 2;
+    let probeCount = 0;
+    // Each distribution has a distinct accessURL, so it is its own probe endpoint. A large
+    // Content-Length keeps the probe on HEAD (no GET fallback), so each probed endpoint
+    // maps to exactly one intercepted request.
+    nock('https://example.org')
+      .head(/\/capped-\d+/)
+      .times(distributionCount)
+      .reply(() => {
+        probeCount++;
+        return [
+          200,
+          '',
+          { 'Content-Type': 'text/turtle', 'Content-Length': '100000' },
+        ];
+      });
+
+    const dataset = factory.dataset();
+    const datasetNode = factory.namedNode('https://example.org/d-capped');
+    for (let index = 0; index < distributionCount; index++) {
+      const distributionNode = factory.blankNode();
+      dataset.add(
+        factory.quad(datasetNode, dcat('distribution'), distributionNode),
+      );
+      dataset.add(
+        factory.quad(
+          distributionNode,
+          dcat('accessURL'),
+          factory.namedNode(`https://example.org/capped-${index}`),
+        ),
+      );
+      dataset.add(
+        factory.quad(
+          distributionNode,
+          dcat('mediaType'),
+          factory.literal('text/turtle'),
+        ),
+      );
+    }
+
+    const messages: string[] = [];
+    const stage = new DistributionProbeStage({
+      maxProbes,
+      logger: { warn: (message) => messages.push(message) },
+    });
+    await stage.run(dataset);
+
+    expect(probeCount).toBe(maxProbes); // only the first maxProbes endpoints are probed.
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain('skipped 3');
+  });
+
+  it('caps probing without a logger and does not throw', async () => {
+    const maxProbes = 1;
+    let probeCount = 0;
+    nock('https://example.org')
+      .head(/\/nolog-\d+/)
+      .times(3)
+      .reply(() => {
+        probeCount++;
+        return [
+          200,
+          '',
+          { 'Content-Type': 'text/turtle', 'Content-Length': '100000' },
+        ];
+      });
+
+    const dataset = factory.dataset();
+    const datasetNode = factory.namedNode('https://example.org/d-nolog');
+    for (let index = 0; index < 3; index++) {
+      const distributionNode = factory.blankNode();
+      dataset.add(
+        factory.quad(datasetNode, dcat('distribution'), distributionNode),
+      );
+      dataset.add(
+        factory.quad(
+          distributionNode,
+          dcat('accessURL'),
+          factory.namedNode(`https://example.org/nolog-${index}`),
+        ),
+      );
+      dataset.add(
+        factory.quad(
+          distributionNode,
+          dcat('mediaType'),
+          factory.literal('text/turtle'),
+        ),
+      );
+    }
+
+    const stage = new DistributionProbeStage({ maxProbes }); // no logger passed.
+    await stage.run(dataset);
+
+    expect(probeCount).toBe(maxProbes); // cap still enforced without a logger.
+  });
+
   it('probes schema:contentUrl on a Schema.org distribution', async () => {
     nock('https://example.org')
       .head('/schema-broken')

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 96.66,
+        lines: 96.69,
         functions: 95.2,
-        branches: 88.28,
-        statements: 95.99,
+        branches: 88.47,
+        statements: 96.03,
       },
     },
   },


### PR DESCRIPTION
## Why

A single dataset can declare tens of thousands of distributions (the reported case, `voc_transcriptions_v2.jsonld`, has 13,789). The distribution probe stage fans out one HTTP probe per endpoint, so validating such a registration stalls a crawl pass for hours, and overlapping hourly passes compound it.

## What

Cap the number of **distinct distribution endpoints** probed per dataset.

- New `maxProbes` option on `DistributionProbeStage` (**default 100**).
- **Dedup runs first, then the cap.** `run()` folds candidates into distinct probe endpoints via `groupByProbeTarget` (the coalescing from #2010 – distributions that differ only by a `#query` fragment or by legacy `dcat:mediaType` vs. `dct:conformsTo` collapse to one endpoint), and only then truncates the list of distinct endpoints to the cap. So the cap is spent on genuinely different endpoints, never on duplicates, and a dataset with thousands of distributions that share a handful of URLs stays well under it.
- The worst case is bounded to roughly `cap ÷ concurrency × per-probe timeout` (≈ 25s with the defaults) instead of timing out every pass.
- Distinct endpoints beyond the cap are **skipped and the skipped count is logged** – never silently dropped. A minimal `ProbeLogger` interface keeps `@dataset-register/core` free of a pino dependency while remaining pino-compatible.
- Configurable in the crawler via the new `CRAWLER_MAX_DISTRIBUTION_PROBES` environment variable (default 100), documented in the README.

This is an independent change from the per-page HTTP timeout work (#2009); together they bound the crawler stall described in #2000.

Fix #2000
