### PR TITLE
fix(core): collect distribution candidates in linear time via match()

### DIFF
--- a/packages/core/src/distribution-probe/probe.ts
+++ b/packages/core/src/distribution-probe/probe.ts
@@ -299,31 +299,37 @@ function canonicalProbeUrl(accessUrl: URL): URL {
   return canonical;
 }
 
+/**
+ * Collect every distribution URL worth probing.
+ *
+ * Performance: every lookup goes through `input.match(subject, predicate, null)` rather
+ * than iterating the whole graph. The datasets we receive are `@rdfjs/dataset` instances,
+ * which maintain a subject/predicate/object index, so each `match()` is O(matches) and the
+ * whole pass is O(graph size). A previous version hand-rolled `for (const quad of input)`
+ * scans inside the per-distribution helpers, which is O(distributions × graph size) —
+ * quadratic — and stalled a crawl pass for ~16 minutes on a 13,789-distribution catalogue.
+ *
+ * Two tests guard this and MUST keep passing: "collects distributions through the index
+ * without scanning the whole dataset" fails if a lookup reverts to iterating the dataset,
+ * and "collects a large catalogue in roughly linear time" fails if `match()` ever loses its
+ * index. Do not replace these `match()` calls with manual iteration over `input`.
+ */
 function collectDistributions(input: DatasetCore): DistributionCandidate[] {
   const candidates: DistributionCandidate[] = [];
-
-  for (const quad of input) {
-    const isDcat =
-      quad.predicate.value === dcat('distribution').value &&
-      quad.object.termType !== 'Literal';
-    const isSchema =
-      quad.predicate.value === schema('distribution').value &&
-      quad.object.termType !== 'Literal';
-
-    if (!isDcat && !isSchema) continue;
-
-    const distributionNode = quad.object;
-    if (
-      distributionNode.termType !== 'NamedNode' &&
-      distributionNode.termType !== 'BlankNode'
-    ) {
-      continue;
+  for (const profile of ['dcat', 'schema'] as const) {
+    const distributionPath =
+      profile === 'dcat' ? dcat('distribution') : schema('distribution');
+    for (const quad of input.match(null, distributionPath, null)) {
+      const distributionNode = quad.object;
+      if (
+        distributionNode.termType !== 'NamedNode' &&
+        distributionNode.termType !== 'BlankNode'
+      ) {
+        continue;
+      }
+      candidates.push(...candidatesFor(input, distributionNode, profile));
     }
-    candidates.push(
-      ...candidatesFor(input, distributionNode, isDcat ? 'dcat' : 'schema'),
-    );
   }
-
   return candidates;
 }
 
@@ -365,12 +371,8 @@ function iriValues(
   predicate: NamedNode,
 ): NamedNode[] {
   const values: NamedNode[] = [];
-  for (const quad of input) {
-    if (
-      quad.subject.equals(subject) &&
-      quad.predicate.equals(predicate) &&
-      quad.object.termType === 'NamedNode'
-    ) {
+  for (const quad of input.match(subject, predicate, null)) {
+    if (quad.object.termType === 'NamedNode') {
       values.push(quad.object);
     }
   }
@@ -396,17 +398,9 @@ function literalValue(
   subject: Term,
   predicate: NamedNode,
 ): string | undefined {
-  for (const quad of input) {
+  for (const quad of input.match(subject, predicate, null)) {
     if (
-      quad.subject.equals(subject) &&
-      quad.predicate.equals(predicate) &&
-      quad.object.termType === 'Literal'
-    ) {
-      return quad.object.value;
-    }
-    if (
-      quad.subject.equals(subject) &&
-      quad.predicate.equals(predicate) &&
+      quad.object.termType === 'Literal' ||
       quad.object.termType === 'NamedNode'
     ) {
       return quad.object.value;

--- a/packages/core/test/distribution-probe.test.ts
+++ b/packages/core/test/distribution-probe.test.ts
@@ -1,6 +1,8 @@
 import { URL } from 'url';
+import { performance } from 'node:perf_hooks';
 import nock from 'nock';
 import factory from 'rdf-ext';
+import type { DatasetCore, Quad, Term } from '@rdfjs/types';
 import {
   NetworkError,
   SparqlProbeResult,
@@ -14,6 +16,51 @@ import type {
   DistributionHealthRecord,
   DistributionHealthStore,
 } from '../src/distribution-health-store.js';
+
+/**
+ * Wraps a dataset to count how it is read: every `match()` (the indexed lookup we rely on)
+ * and every full `[Symbol.iterator]` scan. Used to prove collection never falls back to
+ * scanning the whole graph per distribution, which would be O(distributions × graph size).
+ */
+class CountingDataset implements DatasetCore {
+  public matchCalls = 0;
+  public fullScans = 0;
+
+  public constructor(private readonly inner: DatasetCore) {}
+
+  public get size(): number {
+    return this.inner.size;
+  }
+
+  public add(quad: Quad): this {
+    this.inner.add(quad);
+    return this;
+  }
+
+  public delete(quad: Quad): this {
+    this.inner.delete(quad);
+    return this;
+  }
+
+  public has(quad: Quad): boolean {
+    return this.inner.has(quad);
+  }
+
+  public match(
+    subject?: Term | null,
+    predicate?: Term | null,
+    object?: Term | null,
+    graph?: Term | null,
+  ): DatasetCore {
+    this.matchCalls++;
+    return this.inner.match(subject, predicate, object, graph);
+  }
+
+  public [Symbol.iterator](): Iterator<Quad> {
+    this.fullScans++;
+    return this.inner[Symbol.iterator]();
+  }
+}
 
 const ndeProbePrefix = 'https://def.nde.nl/probe#';
 
@@ -479,6 +526,120 @@ describe('DistributionProbeStage', () => {
 
     expect(probeCount).toBe(maxProbes); // cap still enforced without a logger.
   });
+
+  it('yields no candidate for a dangling distribution node with no quads of its own', async () => {
+    const dataset = factory.dataset();
+    const datasetNode = factory.namedNode('https://example.org/d-dangling');
+    const distributionNode = factory.blankNode();
+    // The distribution is linked but has no accessURL / mediaType / anything.
+    dataset.add(
+      factory.quad(datasetNode, dcat('distribution'), distributionNode),
+    );
+
+    const stage = new DistributionProbeStage();
+    const quads = await stage.run(dataset);
+
+    expect(quads).toHaveLength(0); // nothing to probe, no violation emitted.
+  });
+
+  it('ignores a distribution link whose object is a literal', async () => {
+    const dataset = factory.dataset();
+    const datasetNode = factory.namedNode('https://example.org/d-literal-dist');
+    // A malformed `dcat:distribution "text"` — the object is not a node, so it is skipped.
+    dataset.add(
+      factory.quad(
+        datasetNode,
+        dcat('distribution'),
+        factory.literal('not a distribution node'),
+      ),
+    );
+
+    const stage = new DistributionProbeStage();
+    const quads = await stage.run(dataset);
+
+    expect(quads).toHaveLength(0);
+  });
+
+  it('ignores a distribution mediaType that is a blank node (neither literal nor IRI)', async () => {
+    const dataset = factory.dataset();
+    const datasetNode = factory.namedNode('https://example.org/d-bnode-mt');
+    const distributionNode = factory.blankNode();
+    dataset.add(
+      factory.quad(datasetNode, dcat('distribution'), distributionNode),
+    );
+    // mediaType points to a blank node, which literalValue must skip; with no URL to
+    // probe, no candidate is produced.
+    dataset.add(
+      factory.quad(distributionNode, dcat('mediaType'), factory.blankNode()),
+    );
+
+    const stage = new DistributionProbeStage();
+    const quads = await stage.run(dataset);
+
+    expect(quads).toHaveLength(0);
+  });
+
+  // Regression guard: collection must resolve distribution properties through the dataset's
+  // index (match()), never by scanning the whole graph per distribution. See the doc comment
+  // on collectDistributions; a regression here reintroduces the O(distributions × graph)
+  // stall this code was written to remove.
+  it('collects distributions through the index without scanning the whole dataset', async () => {
+    const inner = factory.dataset();
+    const datasetNode = factory.namedNode('https://example.org/d-idx');
+    // Distributions without an accessURL: collected (exercising every property lookup) but
+    // never probed, so the test needs no network mock.
+    for (let index = 0; index < 3; index++) {
+      const distributionNode = factory.blankNode();
+      inner.add(
+        factory.quad(datasetNode, dcat('distribution'), distributionNode),
+      );
+      inner.add(
+        factory.quad(
+          distributionNode,
+          dcat('mediaType'),
+          factory.literal('text/turtle'),
+        ),
+      );
+    }
+    const counting = new CountingDataset(inner);
+
+    const stage = new DistributionProbeStage();
+    await stage.run(counting);
+
+    // Collection must go through match(); it must never iterate the whole dataset.
+    expect(counting.matchCalls).toBeGreaterThan(0);
+    expect(counting.fullScans).toBe(0);
+  });
+
+  // Regression guard for the dependency: if the dataset ever stops being indexed, match()
+  // degrades to a full scan and this collection becomes quadratic (minutes). The generous
+  // budget separates O(n) (~hundreds of ms) from O(n²) (minutes) without flaking on slow CI.
+  it('collects a large catalogue in roughly linear time', async () => {
+    const dataset = factory.dataset();
+    const datasetNode = factory.namedNode('https://example.org/d-big');
+    const distributionCount = 20000;
+    for (let index = 0; index < distributionCount; index++) {
+      const distributionNode = factory.blankNode();
+      dataset.add(
+        factory.quad(datasetNode, dcat('distribution'), distributionNode),
+      );
+      dataset.add(
+        factory.quad(
+          distributionNode,
+          dcat('mediaType'),
+          factory.literal('text/turtle'),
+        ),
+      );
+    }
+
+    const stage = new DistributionProbeStage();
+    const start = performance.now();
+    const quads = await stage.run(dataset);
+    const elapsedMs = performance.now() - start;
+
+    expect(quads).toHaveLength(0); // no accessURL, nothing to probe
+    expect(elapsedMs).toBeLessThan(5000); // a quadratic regression would take minutes
+  }, 30000);
 
   it('probes schema:contentUrl on a Schema.org distribution', async () => {
     nock('https://example.org')

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 96.69,
+        lines: 96.83,
         functions: 95.2,
-        branches: 88.47,
-        statements: 96.03,
+        branches: 88.2,
+        statements: 96.29,
       },
     },
   },


### PR DESCRIPTION
## Why

`collectDistributions` in the distribution-probe stage resolved each distribution's properties by scanning the **entire** input graph — every `iriValues` / `literalValue` / `iriValue` call was a full `for (const quad of input)` pass, and `candidatesFor` makes several per distribution. That makes candidate collection **O(distributions × graph size)**.

For a dataset declaring tens of thousands of distributions (the motivating case has 13,789), this CPU cost alone stalls a crawl pass for minutes *before any probing happens* — independent of the outbound-probe fan-out that #2011 caps.

## What

Resolve every lookup through the dataset's **index** instead of scanning, using the RDF/JS `DatasetCore.match(subject, predicate, null)` interface method. The datasets we receive are `@rdfjs/dataset` v2 instances, which maintain subject/predicate/object indexes, so each `match()` is O(matches) and the whole pass is **O(graph size)**. Behaviour is unchanged.

Benchmark (synthetic catalogue, 4 quads per distribution, same machine):

| distributions | quads | before (scan per distribution) | after (`match()`) |
|--------------:|------:|-------------------------------:|------------------:|
| 1,000 | 4,000 | 6,354 ms | ~6 ms |
| 4,000 | 16,000 | 80,472 ms | ~18 ms |
| **13,789** | 55,156 | **> 8 min (killed)** | **~205 ms** |

The before-curve roughly triples per doubling (O(n²)); the after-curve is linear.

### Why `match()` rather than a hand-rolled index

`match()` leans on the library's existing index, so it's the idiomatic, fewer-lines option. It is **O(n)**, not quadratic — the linear benchmark confirms the index is real. The one caveat: the `DatasetCore` *type* only guarantees `match()` exists, not that it's indexed; indexing is a property of the concrete `@rdfjs/dataset` implementation. The regression tests below lock both halves of that in.

### Regression guards (TDD)

Two tests guard against silently sliding back to O(n²):

- **Code regression** — `collects distributions through the index without scanning the whole dataset`: wraps the input in a `CountingDataset` and asserts collection issues `match()` calls and performs **zero** full-dataset iterations. Fails the instant any lookup reverts to `for (const quad of input)`.
- **Dependency regression** — `collects a large catalogue in roughly linear time`: collects 20,000 distributions within a generous wall-clock budget (runs in ~0.6 s; a quadratic regression would take tens of minutes). Catches `@rdfjs/dataset` ever losing its index.

A doc comment on `collectDistributions` explains the indexed-lookup requirement and points at these tests.

Also adds small edge-case tests (dangling distribution node, literal `dcat:distribution` object, non-literal/non-IRI `mediaType`).

This is complementary to the per-dataset probe cap (#2011, merged): that bounds the outbound HTTP fan-out, this removes the local quadratic scan. Both are needed to fully resolve the stall.

Refs #2000
