### PR TITLE
build(deps): bump @lde/distribution-probe to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14679,9 +14679,9 @@
       }
     },
     "node_modules/@lde/distribution-probe": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@lde/distribution-probe/-/distribution-probe-0.1.4.tgz",
-      "integrity": "sha512-qu06jBZc3bjDLGvNGAEjwrQLkEw4511lfpEzkqjfNVYV8c/Jzfaj4jH0x9JQD8QoZzJgrn1S6jxSLlVagOjjkA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@lde/distribution-probe/-/distribution-probe-0.1.5.tgz",
+      "integrity": "sha512-JLKVcCSf59Kt4yGDgP7zECytO2+v+VVGZQPlWZDB6YW31+6TogUbRAxLrCQH96F9H1aQQdviFeww/olK7Bj7jw==",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.4",


### PR DESCRIPTION
build(deps): bump @lde/distribution-probe to 0.1.5

Brings in ldelements/lde#425: a SPARQL endpoint that answers a SELECT/ASK query in
application/sparql-results+xml (not just +json) is now treated as reachable, fixing the
spurious "HTTP 200 OK" content-type violation seen when validating SPARQL distributions.
In-range bump (packages/core declares ^0.1.4), so only the lockfile changes.
