### PR TITLE
fix(api): report probe-cap truncation + correct cap JSDoc

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -21,9 +21,16 @@ await (async () => {
   // Strict mode for the API: any failing distribution probe emits sh:Violation, so a
   // registration with a broken link is rejected synchronously. No health-store state is
   // read or written on this path; the crawler path has its own lenient composite.
+  //
+  // The probe cap (default 100 distinct endpoints) still applies here, so a registration
+  // declaring tens of thousands of distributions is bounded rather than hanging the request;
+  // endpoints beyond the cap are not link-checked at submit time. Pass a logger so that
+  // truncation is reported rather than silently dropped.
   const validator = new CompositeValidator(
     new ShaclEngineValidator(shacl),
-    new DistributionProbeStage(),
+    new DistributionProbeStage({
+      logger: config.LOG ? { warn: (message) => console.warn(message) } : null,
+    }),
   );
 
   try {

--- a/packages/core/src/distribution-probe/probe.ts
+++ b/packages/core/src/distribution-probe/probe.ts
@@ -56,15 +56,15 @@ export interface DistributionProbeStageOptions {
    */
   probeConcurrency?: number;
   /**
-   * Maximum number of candidate distribution URLs to probe per dataset. Bounded because a
-   * single dataset can declare tens of thousands of distributions; probing all of them
-   * stalls a crawl pass for hours. Candidate URLs beyond the cap are skipped (and logged),
-   * never silently dropped. Default 100.
+   * Maximum number of distinct distribution endpoints to probe per dataset, applied after
+   * candidates are coalesced by probe target. Bounded because a single dataset can declare
+   * tens of thousands of distributions; probing every endpoint stalls a crawl pass for hours.
+   * Endpoints beyond the cap are skipped (and logged), never silently dropped. Default 100.
    */
   maxProbes?: number;
   /**
-   * Optional logger used to report how many candidate URLs were skipped once the maxProbes
-   * cap is reached. When omitted, skipped probes are still bounded but not reported.
+   * Optional logger used to report how many distinct endpoints were skipped once the
+   * maxProbes cap is reached. When omitted, skipped probes are still bounded but not reported.
    */
   logger?: ProbeLogger | null;
 }


### PR DESCRIPTION
Follow-up to the probe-cap work (#2011) addressing two review findings.

## 1. API capped strict validation silently

`apps/api/src/main.ts` builds `DistributionProbeStage` with the default cap (100 distinct endpoints) but passed **no logger**. The API runs *strict* synchronous validation — a registration with a broken link is rejected on submit — but a registration declaring more than 100 distinct endpoints was capped silently: endpoints beyond the cap are never link-checked, with no signal at all.

This keeps the cap (a one-shot submission of tens of thousands of endpoints should be bounded, not hang the request) but makes the truncation **observable**: a console-backed logger, gated on the existing `LOG` flag, now reports the skipped count. The strict-mode comment is updated to state that endpoints beyond the cap are not link-checked at submit time.

> Note: this is a deliberate trade-off, not a full fix — very large catalogues remain only partially link-checked synchronously. If we'd rather the API probe *everything* (accepting slow submits) or surface the truncation to the client in the response, that's a larger change; flagging for a decision.

## 2. JSDoc drift

`DistributionProbeStageOptions.maxProbes` / `logger` JSDoc still described the cap as operating on "candidate distribution URLs". Since #2011 it caps **distinct distribution endpoints** (after coalescing candidates by probe target), matching the README and the runtime log message. Comment-only.

Refs #2000
