### PR TITLE
fix(shacl): write contentUrl description as plain HTML, link web API spec-side

### DIFF
--- a/requirements/attributes.liquid
+++ b/requirements/attributes.liquid
@@ -37,6 +37,7 @@
             | replace: "BCP 47", "[[!BCP47]]"
             | replace: "DERA", "[[!DERA]]"
             | replace: "IRI", "[[!IRI]]"
+            | replace: "web API", "[=web API=]"
             | replace: "MUST", "*MUST*"
             | replace: "SHOULD", "*SHOULD*"
         -%}

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -499,9 +499,9 @@ nde-dataset:DistributionShape
             sh:minCount 1 ;
             sh:maxCount 1 ;
             sh:severity sh:Violation ;
-            sh:description """De URL die rechtstreeks toegang biedt tot de distributie zelf: het databestand of het endpoint van de [=web API=].
+            sh:description """De URL die rechtstreeks toegang biedt tot de distributie zelf: het databestand of het endpoint van de web-API.
                 Gebruik `schema:documentation` als er daarnaast een documentatiepagina is die de distributie beschrijft of ontsluit (zoals een SPARQL-UI of een downloadlandingspagina)."""@nl,
-                """The URL that provides direct access to the distribution itself: the data file or the [=web API=] endpoint.
+                """The URL that provides direct access to the distribution itself: the data file or the web API endpoint.
                 Use `schema:documentation` if there is also a documentation page that describes or provides access to the distribution (such as a SPARQL UI or a download landing page)."""@en ;
             sh:message "Voeg de URL toe waar de distributie rechtstreeks toegankelijk is"@nl, "Add the URL where the distribution can be directly accessed"@en ;
         ] ,


### PR DESCRIPTION
## Problem

The validation page rendered raw Bikeshed syntax in the `schema:contentUrl` error description, e.g. “… het endpoint van de [=web API=].”

## Cause

`requirements/shacl.ttl` `sh:description` values are the single source of truth shared by the validation UI and the Bikeshed specification. Per the convention established in #1915, descriptions are written as **plain HTML**, and Bikeshed token expansion happens **spec-side** in `attributes.liquid` (via Liquid `replace` filters on common terms such as `IRI`, `BCP 47`, `MUST`). The `schema:contentUrl` description embedded a `[=web API=]` dfn autolink directly, against that convention, so it leaked verbatim into the UI.

## Fix

- Render “web API” as plain text in the Dutch and English `schema:contentUrl` descriptions, matching the existing `schema:documentation` description. The validation UI (which consumes `/shacl` directly) now shows clean prose.
- Add `web API` to the `attributes.liquid` replace filters, so the generated specification still autolinks it to the `Web API` `<dfn>` — just like `IRI` and `BCP 47`. The browser stays plain HTML; the link is generated spec-side from the common term.

`requirements/index.bs` is not tracked; CI regenerates it via `requirements-publish.yml`, which also runs Bikeshed and validates the autolink resolves.
