### PR TITLE
feat(browser): surface IIIF presence on dataset cards and detail page

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -232,6 +232,55 @@
   "detail_classes_for_value_type": "Classes for {valueTypeName}",
   "detail_properties_for_value_type": "Properties for {valueTypeName}",
   "opens_in_new_tab": "opens in new tab",
+  "dataset_iiif_manifests": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{display} IIIF manifest",
+        "countPlural=other": "{display} IIIF manifests"
+      }
+    }
+  ],
+  "nde_compatibility": "NDE compatibility",
+  "nde_compatibility_description": "Shows which NDE criteria this dataset meets.",
+  "nde_compat_iiif_heading_provided": "Provides IIIF media",
+  "nde_compat_iiif_heading_not_provided": "Does not provide IIIF media",
+  "nde_compat_iiif_heading_unavailable": "IIIF media unavailable",
+  "nde_compat_iiif_explanation": "With IIIF, the images in a dataset can be viewed in any IIIF viewer.",
+  "nde_compat_iiif_count": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{display} manifest found.",
+        "countPlural=other": "{display} manifests found."
+      }
+    }
+  ],
+  "nde_compat_iiif_count_failed": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{display} manifest declared, but it could not be validated.",
+        "countPlural=other": "{display} manifests declared, but none of the sampled manifests could be validated."
+      }
+    }
+  ],
+  "nde_compat_learn_more": "Learn more",
   "validate_page_title": "Validate a dataset description",
   "validate_page_intro_before": "Have you created and published your dataset description? And do you want to know if it meets the ",
   "validate_page_intro_after": "? And do you have a NDE-compatible collection information system? Then this validation will happen automatically. Why is this important? Only descriptions that meet the requirements will be included in the Dataset Register.",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -232,6 +232,55 @@
   "detail_classes_for_value_type": "Typen voor {valueTypeName}",
   "detail_properties_for_value_type": "Eigenschappen voor {valueTypeName}",
   "opens_in_new_tab": "opent in nieuw tabblad",
+  "dataset_iiif_manifests": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{display} IIIF-manifest",
+        "countPlural=other": "{display} IIIF-manifesten"
+      }
+    }
+  ],
+  "nde_compatibility": "NDE-compatibiliteit",
+  "nde_compatibility_description": "Laat zien aan welke NDE-criteria deze dataset voldoet.",
+  "nde_compat_iiif_heading_provided": "Biedt IIIF-media",
+  "nde_compat_iiif_heading_not_provided": "Biedt geen IIIF-media",
+  "nde_compat_iiif_heading_unavailable": "IIIF-media niet beschikbaar",
+  "nde_compat_iiif_explanation": "Met IIIF zijn de afbeeldingen in een dataset in elke IIIF-viewer te bekijken.",
+  "nde_compat_iiif_count": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{display} manifest gevonden.",
+        "countPlural=other": "{display} manifesten gevonden."
+      }
+    }
+  ],
+  "nde_compat_iiif_count_failed": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{display} manifest opgegeven, maar deze kon niet worden gevalideerd.",
+        "countPlural=other": "{display} manifesten opgegeven, maar geen van de gecontroleerde manifesten kon worden gevalideerd."
+      }
+    }
+  ],
+  "nde_compat_learn_more": "Meer informatie",
   "validate_page_title": "Controleer een datasetbeschrijving",
   "validate_page_intro_before": "Heb je je datasetbeschrijving gemaakt en gepubliceerd? En wil je weten of deze voldoet aan de ",
   "validate_page_intro_after": "? En beschik je over een NDE-compatibel collectie-informatiesysteem? Dan gebeurt die controle automatisch. Waarom is dit belangrijk? Alleen beschrijvingen die aan de eisen voldoen, neemt het Datasetregister op.",

--- a/apps/browser/src/lib/components/DatasetCard.svelte
+++ b/apps/browser/src/lib/components/DatasetCard.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import * as m from '$lib/paraglide/messages';
   import { getLocale } from '$lib/paraglide/runtime';
-  import { type DatasetCard } from '$lib/services/datasets';
+  import {
+    type DatasetCard,
+    iiifManifestCount,
+    providesWorkingIiif,
+  } from '$lib/services/datasets';
   import { getLocalizedValue, localizeHref } from '$lib/utils/i18n';
   import { RDF_MEDIA_TYPES } from '$lib/constants.js';
   import { datasetDetailHref } from '$lib/url';
@@ -38,6 +42,13 @@
           distribution.mediaType as (typeof RDF_MEDIA_TYPES)[number],
         ),
     ),
+  );
+
+  // Show the icon only for working IIIF; the tooltip reports the declared count.
+  const hasWorkingIiif = $derived(providesWorkingIiif(dataset));
+  const iiifManifests = $derived(iiifManifestCount(dataset));
+  const iiifManifestsDisplay = $derived(
+    formatNumber(iiifManifests, getLocale()),
   );
 </script>
 
@@ -119,7 +130,7 @@
     </div>
   {/if}
 
-  {#if hasSparqlDistribution || hasRdfDistribution || dataset.size}
+  {#if hasSparqlDistribution || hasRdfDistribution || dataset.size || hasWorkingIiif}
     <div class="mt-2.5 text-[0.9375rem] leading-[1.5] flex items-center gap-4">
       {#if hasSparqlDistribution}
         <div class="group relative flex items-center gap-1.5">
@@ -204,6 +215,44 @@
           <span class="text-gray-700 dark:text-gray-300"
             >{formatNumber(dataset.size, getLocale())}
             {m.dataset_triples({ count: dataset.size })}</span
+          >
+        </div>
+      {/if}
+
+      {#if hasWorkingIiif}
+        <!-- The manifest count lives in the tooltip. -->
+        <div class="group relative flex items-center gap-1.5">
+          <div
+            class="invisible absolute bottom-full left-1/2 mb-2 -translate-x-1/2 transform rounded bg-gray-800 px-2 py-1 text-xs whitespace-nowrap text-white opacity-0 transition-opacity duration-200 group-hover:visible group-hover:opacity-100"
+          >
+            {m.dataset_iiif_manifests({
+              count: iiifManifests,
+              display: iiifManifestsDisplay,
+            })}
+            <div
+              class="absolute top-full left-1/2 h-0 w-0 -translate-x-1/2 border-t-4 border-r-4 border-l-4 border-t-gray-800 border-r-transparent border-l-transparent"
+            ></div>
+          </div>
+          <svg
+            class="w-4 h-4 text-gray-600 dark:text-gray-400 flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-label={m.dataset_iiif_manifests({
+              count: iiifManifests,
+              display: iiifManifestsDisplay,
+            })}
+          >
+            <!-- Image icon: IIIF exposes the dataset’s images. -->
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+          <span class="text-gray-700 dark:text-gray-300"
+            >{iiifManifestsDisplay} IIIF</span
           >
         </div>
       {/if}

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+  import * as m from '$lib/paraglide/messages';
+  import { getLocale } from '$lib/paraglide/runtime';
+  import { Tooltip } from 'flowbite-svelte';
+  import CheckOutline from 'flowbite-svelte-icons/CheckOutline.svelte';
+  import CloseOutline from 'flowbite-svelte-icons/CloseOutline.svelte';
+  import InfoCircleSolid from 'flowbite-svelte-icons/InfoCircleSolid.svelte';
+  import {
+    compatibilityCriteria,
+    IIIF_VINKJES_URL,
+    type CompatibilityCriterion,
+    type IiifManifests,
+  } from '$lib/services/nde-compatibility';
+
+  let { iiifManifests }: { iiifManifests: IiifManifests } = $props();
+
+  const criteria = $derived(compatibilityCriteria({ iiif: iiifManifests }));
+
+  // The heading states the actual situation: a dataset legitimately may have no
+  // media (unmet, neutral), may provide working media (met), or may declare media
+  // that could not be loaded (failed).
+  function heading(criterion: CompatibilityCriterion): string {
+    switch (criterion.key) {
+      case 'iiif':
+        switch (criterion.state) {
+          case 'met':
+            return m.nde_compat_iiif_heading_provided();
+          case 'failed':
+            return m.nde_compat_iiif_heading_unavailable();
+          case 'unmet':
+            return m.nde_compat_iiif_heading_not_provided();
+        }
+    }
+  }
+
+  function explanation(criterion: CompatibilityCriterion): string {
+    switch (criterion.key) {
+      case 'iiif':
+        return m.nde_compat_iiif_explanation();
+    }
+  }
+
+  // The count line is omitted when the criterion is unmet; the empty checkbox
+  // already signals absence. When media is declared but broken it reports the
+  // declared count and the validation failure.
+  function detail(criterion: CompatibilityCriterion): string | null {
+    // Pass the raw count for plural selection and a locale-formatted string for
+    // display, matching the grouped numbers in the Linked Data Summary.
+    const count = criterion.count;
+    const display = count.toLocaleString(getLocale());
+    switch (criterion.key) {
+      case 'iiif':
+        switch (criterion.state) {
+          case 'met':
+            return m.nde_compat_iiif_count({ count, display });
+          case 'failed':
+            return m.nde_compat_iiif_count_failed({ count, display });
+          case 'unmet':
+            return null;
+        }
+    }
+  }
+
+  function learnMoreHref(criterion: CompatibilityCriterion): string {
+    switch (criterion.key) {
+      case 'iiif':
+        return IIIF_VINKJES_URL;
+    }
+  }
+</script>
+
+<section class="mb-8" aria-labelledby="nde-compatibility-heading">
+  <h2
+    id="nde-compatibility-heading"
+    class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
+  >
+    {m.nde_compatibility()}
+    <span id="tooltip-nde-compatibility" class="cursor-pointer">
+      <InfoCircleSolid
+        class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+      />
+    </span>
+    <Tooltip triggeredBy="#tooltip-nde-compatibility"
+      >{m.nde_compatibility_description()}</Tooltip
+    >
+  </h2>
+  <div
+    class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+  >
+    <ul class="divide-y divide-gray-200 dark:divide-gray-700">
+      {#each criteria as criterion (criterion.key)}
+        <li class="flex items-start gap-3 px-4 py-3">
+          <!-- Status box. Green tick = met, red cross = declared but broken,
+               neutral empty = not provided (a legitimate, non-failure state).
+               The heading carries the status for assistive technology, so the
+               box is decorative. -->
+          <span
+            class={`mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border ${
+              criterion.state === 'met'
+                ? 'border-green-600 bg-green-600 text-white dark:border-green-500 dark:bg-green-500'
+                : criterion.state === 'failed'
+                  ? 'border-red-600 bg-red-600 text-white dark:border-red-500 dark:bg-red-500'
+                  : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-700'
+            }`}
+            aria-hidden="true"
+          >
+            {#if criterion.state === 'met'}
+              <CheckOutline class="h-3.5 w-3.5" />
+            {:else if criterion.state === 'failed'}
+              <CloseOutline class="h-3.5 w-3.5" />
+            {/if}
+          </span>
+          <div class="min-w-0">
+            <h3 class="text-base font-medium text-gray-900 dark:text-white">
+              {heading(criterion)}
+            </h3>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              {explanation(criterion)}
+              <a
+                href={learnMoreHref(criterion)}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-blue-600 hover:underline dark:text-blue-400"
+              >
+                {m.nde_compat_learn_more()}
+                <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+              </a>
+            </p>
+            {#if detail(criterion)}
+              <p
+                class="mt-1 text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                {detail(criterion)}
+              </p>
+            {/if}
+          </div>
+        </li>
+      {/each}
+    </ul>
+  </div>
+</section>

--- a/apps/browser/src/lib/rdf.ts
+++ b/apps/browser/src/lib/rdf.ts
@@ -21,6 +21,7 @@ export const voidNs = createNamespace({
     'objectsTarget',
     'dataDump',
     'sparqlEndpoint',
+    'subset',
   ],
 } as const);
 

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -13,6 +13,10 @@ import {
 import { BaseDatasetSchema, BaseDistributionSchema } from './datasets.js';
 import { shortenUri } from '$lib/utils/prefix';
 import { isUri, lookupTermLabels } from './network-of-terms.js';
+import {
+  IIIF_PRESENTATION_API,
+  type IiifManifests,
+} from './nde-compatibility.js';
 import { getLocale } from '$lib/paraglide/runtime';
 import { REGISTRATION_STATUS_BASE_URI } from '@dataset-register/core/constants';
 import {
@@ -376,10 +380,75 @@ export interface DatasetDetailResult {
   summary: DatasetSummary | null;
   linksets: Linkset[];
   temporalCoverages: TemporalCoverage[];
+  iiifManifests: IiifManifests;
   resolvedTerms: Promise<Record<string, string>>;
 }
 
 const fetcher = new SparqlEndpointFetcher();
+
+// Reads the IIIF manifest figures from the Knowledge Graph: the declared count
+// (void:subset keyed on dcterms:conformsTo, counted with void:entities) plus the
+// validation measurements (how many manifests were sampled and how many of those
+// resolved to a valid IIIF Presentation manifest). sampled/validated are null
+// when no validation measurement has been recorded yet.
+async function fetchIiifManifests(datasetUri: string): Promise<IiifManifests> {
+  const query = `
+    PREFIX void: <http://rdfs.org/ns/void#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX dqv: <http://www.w3.org/ns/dqv#>
+    PREFIX nde: <https://def.nde.nl/metric#>
+    SELECT ?declared ?sampled ?validated WHERE {
+      <${datasetUri}> void:subset [
+        dct:conformsTo <${IIIF_PRESENTATION_API}> ;
+        void:entities ?declared
+      ] .
+      OPTIONAL {
+        <${datasetUri}> dqv:hasQualityMeasurement [
+          dqv:isMeasurementOf nde:manifests-sampled ;
+          dqv:value ?sampled
+        ]
+      }
+      OPTIONAL {
+        <${datasetUri}> dqv:hasQualityMeasurement [
+          dqv:isMeasurementOf nde:manifests-validated ;
+          dqv:value ?validated
+        ]
+      }
+    }
+    LIMIT 1
+  `;
+  const none: IiifManifests = { declared: 0, sampled: null, validated: null };
+  try {
+    const bindingsStream = await fetcher.fetchBindings(
+      PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+      query,
+    );
+    for await (const raw of bindingsStream) {
+      const binding = raw as unknown as {
+        declared?: { value: string };
+        sampled?: { value: string };
+        validated?: { value: string };
+      };
+      return {
+        declared: binding.declared?.value
+          ? parseInt(binding.declared.value, 10)
+          : 0,
+        sampled: binding.sampled?.value
+          ? parseInt(binding.sampled.value, 10)
+          : null,
+        validated: binding.validated?.value
+          ? parseInt(binding.validated.value, 10)
+          : null,
+      };
+    }
+  } catch (e: unknown) {
+    console.error(
+      'IIIF manifests query failed:',
+      e instanceof Error ? e.message : e,
+    );
+  }
+  return none;
+}
 
 async function fetchDistributionCount(query: string): Promise<number> {
   const bindingsStream = await fetcher.fetchBindings(
@@ -579,6 +648,7 @@ export async function fetchDatasetDetail(
     linksets,
     classPartitionResult,
     temporalCoverages,
+    iiifManifests,
   ] = await Promise.all([
     detailLens.query(datasetQuery),
     distributionLens.query(distributionQuery),
@@ -593,6 +663,7 @@ export async function fetchDatasetDetail(
     linksLens.find({ where: { subjectsTarget: datasetUri } }),
     classPartitionLens.findByIri(datasetUri),
     fetchTemporalCoverage(datasetUri),
+    fetchIiifManifests(datasetUri),
   ]);
 
   const dataset = datasets.find((d) => d.$id === datasetUri) ?? datasets[0];
@@ -633,6 +704,7 @@ export async function fetchDatasetDetail(
     summary: summaryWithClassPartition,
     linksets,
     temporalCoverages,
+    iiifManifests,
     resolvedTerms,
   };
 }

--- a/apps/browser/src/lib/services/datasets.test.ts
+++ b/apps/browser/src/lib/services/datasets.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  iiifManifestCount,
+  providesWorkingIiif,
+  type DatasetCard,
+} from './datasets';
+import { IIIF_PRESENTATION_API } from './nde-compatibility';
+
+// The helpers only read the IIIF fields, so a minimal cast keeps the fixtures
+// focused on the behaviour under test.
+function card(fields: Record<string, unknown>): DatasetCard {
+  return fields as unknown as DatasetCard;
+}
+
+function iiifSubset(entities: number) {
+  return { $id: '_:iiif', conformsTo: IIIF_PRESENTATION_API, entities };
+}
+
+describe('iiifManifestCount', () => {
+  it('returns the declared entity count of the IIIF subset', () => {
+    expect(iiifManifestCount(card({ iiifSubset: iiifSubset(42) }))).toBe(42);
+  });
+
+  it('returns 0 when there is no IIIF subset', () => {
+    expect(iiifManifestCount(card({ iiifSubset: null }))).toBe(0);
+  });
+
+  it('ignores a subset with a different conformsTo discriminator', () => {
+    expect(
+      iiifManifestCount(
+        card({
+          iiifSubset: {
+            $id: '_:other',
+            conformsTo: 'http://example.org/other',
+            entities: 7,
+          },
+        }),
+      ),
+    ).toBe(0);
+  });
+});
+
+describe('providesWorkingIiif', () => {
+  it('is true when sampled manifests validated', () => {
+    expect(
+      providesWorkingIiif(
+        card({
+          iiifSubset: iiifSubset(100),
+          iiifManifestsSampled: 10,
+          iiifManifestsValidated: 8,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is false when manifests are declared but none validated', () => {
+    expect(
+      providesWorkingIiif(
+        card({
+          iiifSubset: iiifSubset(4152),
+          iiifManifestsSampled: 10,
+          iiifManifestsValidated: 0,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('is true when declared but not yet validated (no evidence of failure)', () => {
+    expect(providesWorkingIiif(card({ iiifSubset: iiifSubset(5) }))).toBe(true);
+  });
+
+  it('is false when no IIIF subset is declared', () => {
+    expect(providesWorkingIiif(card({ iiifSubset: null }))).toBe(false);
+  });
+});

--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -7,6 +7,13 @@ import { PUBLIC_SPARQL_ENDPOINT } from '$env/static/public';
 import { schemaNs as schema, voidNs } from '../rdf.js';
 import { getLocale } from '$lib/paraglide/runtime';
 import { normalizeMediaType } from '$lib/utils/sparql';
+import {
+  IIIF_PRESENTATION_API,
+  MANIFESTS_SAMPLED_METRIC,
+  MANIFESTS_VALIDATED_METRIC,
+  iiifState,
+  type IiifManifests,
+} from '$lib/services/nde-compatibility';
 
 export const SPARQL_ENDPOINT = PUBLIC_SPARQL_ENDPOINT;
 const fetcher = new SparqlEndpointFetcher();
@@ -86,6 +93,35 @@ export const DatasetCardSchema = {
     '@type': xsd.integer,
     '@optional': true,
   },
+  // The number of IIIF Presentation manifests detected in the dataset, recorded
+  // in the Knowledge Graph as a void:subset keyed on dcterms:conformsTo. The
+  // card query only ever projects the IIIF subset (see datasetCardsQuery), so a
+  // single optional value suffices.
+  iiifSubset: {
+    '@id': voidNs.subset,
+    '@optional': true,
+    '@schema': {
+      conformsTo: {
+        '@id': dcterms.conformsTo,
+      },
+      entities: {
+        '@id': voidNs.entities,
+        '@type': xsd.integer,
+      },
+    },
+  },
+  // IIIF manifest validation measurements, projected onto the dataset by the
+  // card query so the icon can be limited to datasets with working IIIF.
+  iiifManifestsSampled: {
+    '@id': MANIFESTS_SAMPLED_METRIC,
+    '@type': xsd.integer,
+    '@optional': true,
+  },
+  iiifManifestsValidated: {
+    '@id': MANIFESTS_VALIDATED_METRIC,
+    '@type': xsd.integer,
+    '@optional': true,
+  },
   datePosted: {
     '@id': schema.datePosted,
     '@type': xsd.dateTime,
@@ -95,6 +131,34 @@ export const DatasetCardSchema = {
 
 export type DatasetCard = SchemaInterface<typeof DatasetCardSchema>;
 
+// The IIIF manifest figures for a card: declared count plus the validation
+// measurements (null when the dataset declares no IIIF or has no measurement).
+function cardIiifManifests(dataset: DatasetCard): IiifManifests {
+  const subset = dataset.iiifSubset;
+  const declared =
+    subset && subset.conformsTo === IIIF_PRESENTATION_API
+      ? (subset.entities ?? 0)
+      : 0;
+  return {
+    declared,
+    sampled: dataset.iiifManifestsSampled ?? null,
+    validated: dataset.iiifManifestsValidated ?? null,
+  };
+}
+
+// The number of IIIF Presentation manifests the dataset declares, for the card
+// tooltip.
+export function iiifManifestCount(dataset: DatasetCard): number {
+  return cardIiifManifests(dataset).declared;
+}
+
+// Whether the dataset provides working IIIF media. The card icon is shown only
+// in this case — not when manifests are declared but failed validation, and not
+// when none are declared.
+export function providesWorkingIiif(dataset: DatasetCard): boolean {
+  return iiifState(cardIiifManifests(dataset)) === 'met';
+}
+
 const datasetCards = createLens(DatasetCardSchema, {
   sources: [SPARQL_ENDPOINT],
 });
@@ -102,8 +166,10 @@ const datasetCards = createLens(DatasetCardSchema, {
 export const prefixes = `
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX dqv: <http://www.w3.org/ns/dqv#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>			
+PREFIX nde: <https://def.nde.nl/metric#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX schema: <https://schema.org/>
 PREFIX void: <http://rdfs.org/ns/void#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -171,6 +237,9 @@ export function datasetCardsQuery(
       dct:license ?license ;
       dcat:distribution ?distribution ;
       void:triples ?size ;
+      void:subset ?iiifSubset ;
+      nde:manifests-sampled ?iiifSampled ;
+      nde:manifests-validated ?iiifValidated ;
       schema:status ?status ;
       schema:datePosted ?datePosted .
     ?publisher a foaf:Agent ;
@@ -178,6 +247,8 @@ export function datasetCardsQuery(
     ?distribution a dcat:Distribution ;
       dcat:mediaType ?mediaType ;
       dct:conformsTo ?conformsTo .
+    ?iiifSubset dct:conformsTo <${IIIF_PRESENTATION_API}> ;
+      void:entities ?iiifManifests .
   }
   WHERE {
     # Inside the default graph, which contains the registry's metadata.
@@ -244,11 +315,30 @@ export function datasetCardsQuery(
       }
     }
 
-    # Fetch dataset size from Dataset Knowledge Graph via SPARQL Federation
+    # Fetch dataset size and IIIF manifest count from the Dataset Knowledge Graph
+    # via SPARQL Federation. The IIIF subset is itself optional: not every
+    # dataset exposes IIIF Presentation manifests.
     OPTIONAL {
       SERVICE <https://triplestore.netwerkdigitaalerfgoed.nl/repositories/dataset-knowledge-graph> {
         ?dataset a void:Dataset ;
           void:triples ?size .
+        OPTIONAL {
+          ?dataset void:subset ?iiifSubset .
+          ?iiifSubset dct:conformsTo <${IIIF_PRESENTATION_API}> ;
+            void:entities ?iiifManifests .
+          OPTIONAL {
+            ?dataset dqv:hasQualityMeasurement [
+              dqv:isMeasurementOf nde:manifests-sampled ;
+              dqv:value ?iiifSampled
+            ] .
+          }
+          OPTIONAL {
+            ?dataset dqv:hasQualityMeasurement [
+              dqv:isMeasurementOf nde:manifests-validated ;
+              dqv:value ?iiifValidated
+            ] .
+          }
+        }
       }
     }
   }

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { compatibilityCriteria, iiifState } from './nde-compatibility';
+
+describe('iiifState', () => {
+  it('is met when at least one sampled manifest validated', () => {
+    expect(iiifState({ declared: 100, sampled: 10, validated: 8 })).toBe('met');
+  });
+
+  it('is failed when manifests are declared but none of the sampled validated', () => {
+    expect(iiifState({ declared: 4152, sampled: 10, validated: 0 })).toBe(
+      'failed',
+    );
+  });
+
+  it('is unmet when no manifests are declared', () => {
+    expect(iiifState({ declared: 0, sampled: null, validated: null })).toBe(
+      'unmet',
+    );
+  });
+
+  it('treats declared-but-not-yet-sampled as met (no evidence of failure)', () => {
+    expect(iiifState({ declared: 5, sampled: null, validated: null })).toBe(
+      'met',
+    );
+    expect(iiifState({ declared: 5, sampled: 0, validated: 0 })).toBe('met');
+  });
+});
+
+describe('compatibilityCriteria', () => {
+  it('exposes the declared count and computed state for IIIF', () => {
+    const [iiif] = compatibilityCriteria({
+      iiif: { declared: 4152, sampled: 10, validated: 0 },
+    });
+    expect(iiif.key).toBe('iiif');
+    expect(iiif.state).toBe('failed');
+    expect(iiif.count).toBe(4152);
+  });
+
+  it('renders the IIIF criterion regardless of state, so publishers always see it', () => {
+    expect(
+      compatibilityCriteria({
+        iiif: { declared: 0, sampled: null, validated: null },
+      }),
+    ).toHaveLength(1);
+  });
+});

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -1,0 +1,79 @@
+// The NDE compatibility (“vinkjes”) criteria surfaced on the dataset detail page.
+// This module holds the locale-independent logic — which criteria there are and
+// what state each is in — so it can be unit-tested without the UI. The component
+// maps each criterion to its translated heading, explanation and count.
+
+// Version-less IIIF Presentation API namespace used as the discriminator of the
+// `void:subset` that records detected IIIF Presentation manifests in the
+// Dataset Knowledge Graph.
+export const IIIF_PRESENTATION_API = 'http://iiif.io/api/presentation/';
+
+// NDE’s documentation on the criteria (“vinkjes”).
+export const IIIF_VINKJES_URL =
+  'https://netwerkdigitaalerfgoed.nl/aanpak/bruikbaar/#vinkjes';
+
+// DQV metric IRIs for the IIIF manifest validation measurements recorded by the
+// Dataset Knowledge Graph.
+export const MANIFESTS_SAMPLED_METRIC =
+  'https://def.nde.nl/metric#manifests-sampled';
+export const MANIFESTS_VALIDATED_METRIC =
+  'https://def.nde.nl/metric#manifests-validated';
+
+export type CompatibilityCriterionKey = 'iiif';
+
+// 'met'    — the dataset provides working media (validated, or declared with no
+//            evidence of failure).
+// 'failed' — the dataset declares media, but every sampled manifest failed to
+//            load (declared but broken).
+// 'unmet'  — the dataset declares no media. A legitimate, neutral state.
+export type CompatibilityState = 'met' | 'failed' | 'unmet';
+
+// IIIF manifest figures from the Knowledge Graph: how many manifests the dataset
+// declares (void:entities), and — once the pipeline has sampled them — how many
+// of the sampled manifests resolved to a valid IIIF Presentation manifest.
+// `sampled`/`validated` are null when no validation measurement exists yet.
+export interface IiifManifests {
+  declared: number;
+  sampled: number | null;
+  validated: number | null;
+}
+
+export interface CompatibilityCriterion {
+  key: CompatibilityCriterionKey;
+  state: CompatibilityState;
+  count: number;
+}
+
+export interface CompatibilityInput {
+  iiif: IiifManifests;
+}
+
+export function iiifState(manifests: IiifManifests): CompatibilityState {
+  if (manifests.declared <= 0) {
+    return 'unmet';
+  }
+  if ((manifests.validated ?? 0) > 0) {
+    return 'met';
+  }
+  if ((manifests.sampled ?? 0) > 0) {
+    // Manifests were sampled but none validated: declared but broken.
+    return 'failed';
+  }
+  // Declared but not yet sampled: no evidence of failure, so treat as provided.
+  return 'met';
+}
+
+// Builds the list of NDE criteria for a dataset. Today this is a single IIIF
+// row; follow-up work (#1222, #1969) appends rows here without the component
+// having to change.
+export function compatibilityCriteria(
+  input: CompatibilityInput,
+): CompatibilityCriterion[] {
+  return [
+    {
+      key: 'iiif',
+      state: iiifState(input.iiif),
+      count: input.iiif.declared,
+    },
+  ];
+}

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -41,6 +41,7 @@
   } from '$lib/services/dataset-detail.js';
   import { getRelativeTimeString } from '$lib/utils/relative-time';
   import ClassPropertiesWidget from '$lib/components/ClassPropertiesWidget.svelte';
+  import NdeCompatibility from '$lib/components/NdeCompatibility.svelte';
 
   // Data is loaded server-side via +page.ts for SEO
   const { data }: { data: DatasetDetailResult } = $props();
@@ -50,6 +51,7 @@
   const summary = $derived(data.summary);
   const linksets = $derived(data.linksets);
   const temporalCoverages = $derived(data.temporalCoverages);
+  const iiifManifests = $derived(data.iiifManifests);
 
   // SEO: canonical and hreflang URLs
   const datasetPath = $derived(datasetDetailHref(dataset.$id));
@@ -1264,6 +1266,9 @@
       {/if}
     </div>
   {/if}
+
+  <!-- NDE compatibility (“vinkjes”) -->
+  <NdeCompatibility {iiifManifests} />
 
   <!-- VoID Summary Section -->
   {#if summary && hasVoidStats}


### PR DESCRIPTION
Surfaces IIIF Presentation manifest presence in the dataset-register browser, consuming the IIIF data the Dataset Knowledge Graph publishes: the declared `void:subset … dcterms:conformsTo <http://iiif.io/api/presentation/> ; void:entities` count and the DQV validation measurements (`nde:manifests-sampled` / `nde:manifests-validated`).

This is the browser half of the cross-repo issue; the detection + validation stages live in `dataset-knowledge-graph` and ship independently:
- Detection (declared `void:subset` count): netwerk-digitaal-erfgoed/dataset-knowledge-graph#297
- Validation (`nde:manifests-sampled` / `nde:manifests-validated` DQV measurements): netwerk-digitaal-erfgoed/dataset-knowledge-graph#310

## Changes

### Dataset card
- An icon-only IIIF (image) icon joins the existing SPARQL/RDF/size row, shown when the dataset declares at least one manifest. The count is revealed in a hover tooltip.
- The count is read through the **existing** federated `SERVICE` block that already fetches `void:triples` (size), so there is no extra SPARQL round-trip.

### Dataset detail page — “NDE compatibility” section
- A new “NDE compatibility” section is rendered on **every** dataset, positioned after Distributions and before the Linked Data Summary, with a header tooltip (which refers to the NDE criteria) like the other sections.
- It currently holds a single **IIIF** row, framed as a list of criterion rows so the remaining vinkjes (#1222, #1969) can be appended without restructuring.
- The row is **tri-state**, driven by the Knowledge Graph validation measurements:
  - **Provides IIIF media** — green check. Manifests validated (or declared with no evidence of failure). Shows “{n} manifests found.”
  - **IIIF media unavailable** — red cross. Manifests are *declared* but none of the sampled manifests could be loaded (declared but broken). Shows “{n} manifests declared, but none could be validated.”
  - **Does not provide IIIF media** — neutral empty box (never red; having no media is a legitimate state). No count line.
- The explanation sits inline with a “Learn more” link to NDE’s vinkjes documentation.

### Supporting
- `services/nde-compatibility.ts` holds the locale-independent criterion/state logic, unit-tested separately from the UI.
- Dutch + English translations with Paraglide pluralisation.

## Try it

Each state has a real, registered example — the links open the dataset on the live site (the “NDE compatibility” section itself appears once this PR is deployed):

| State | Example dataset | KG figures |
|---|---|---|
| ✅ Provides IIIF media | [Museumfederatie Fryslân – Museum objecten](https://datasetregister.netwerkdigitaalerfgoed.nl/dataset?uri=https%3A%2F%2Fonserfgoed.noorderstruun.nl%2FAtlantisPubliek%2Fdata%2Fdataset%2FMuseumfederatie%2BFrysl%25c3%25a2n%2B-%2BMuseum%2Bobjecten) | 30,917 declared (not yet sampled) |
| ❌ IIIF media unavailable | [Collectie Universiteitsmuseum Utrecht](https://datasetregister.netwerkdigitaalerfgoed.nl/dataset?uri=https%3A%2F%2Fcollections.uu.nl%2Fdataregister) | 4,152 declared · 0 of 10 sampled validated |
| ⬜ Does not provide IIIF media | [NMVW collection archives](https://datasetregister.netwerkdigitaalerfgoed.nl/dataset?uri=https%3A%2F%2Fdata.colonialcollections.nl%2Fnmvw%2Fcollection-archives) | none declared |

The working dataset also shows the IIIF icon on its search-result card; the broken one does not (the card icon is validation-aware).

## Notes
- The IIIF version (v2/v3) is collapsed to a single version-less marker, per the issue.
- The **card** icon is validation-aware: it shows only for working IIIF (the `met` state), so a declared-but-broken dataset shows no card icon and surfaces the red “unavailable” state only on its detail page.
- Component-render tests were not added: the browser package’s vitest config has no client/browser test project (`*.svelte.test` files are excluded), so the consumer-facing logic is covered as unit tests instead.

Fix #1996


