### PR TITLE
feat(browser): surface NDE Schema.org Application Profile conformance

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -246,8 +246,16 @@
       }
     }
   ],
+  "dataset_schema_ap_nde": "Conforms to the NDE Schema.org Application Profile (sampled)",
   "nde_compatibility": "NDE compatibility",
   "nde_compatibility_description": "Shows which NDE criteria this dataset meets.",
+  "nde_compat_schema_ap_nde_heading_conforms": "Conforms to the NDE Schema.org Application Profile",
+  "nde_compat_schema_ap_nde_heading_not_conforms": "Does not conform to the NDE Schema.org Application Profile",
+  "nde_compat_schema_ap_nde_heading_not_applicable": "The NDE Schema.org Application Profile does not apply",
+  "nde_compat_schema_ap_nde_explanation_conforms": "No violations were found in a sample of this dataset.",
+  "nde_compat_schema_ap_nde_explanation_violations": "At least one sampled resource violated the NDE Schema.org Application Profile.",
+  "nde_compat_schema_ap_nde_explanation_declared_but_empty": "This dataset declares conformance to the NDE Schema.org Application Profile, but none of its resources use the profile’s classes.",
+  "nde_compat_schema_ap_nde_explanation_not_applicable": "This dataset uses a different data model, so the profile does not apply.",
   "nde_compat_iiif_heading_provided": "Provides IIIF media",
   "nde_compat_iiif_heading_not_provided": "Does not provide IIIF media",
   "nde_compat_iiif_heading_unavailable": "IIIF media unavailable",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -246,8 +246,16 @@
       }
     }
   ],
+  "dataset_schema_ap_nde": "Voldoet aan het NDE Schema.org-applicatieprofiel (steekproef)",
   "nde_compatibility": "NDE-compatibiliteit",
   "nde_compatibility_description": "Laat zien aan welke NDE-criteria deze dataset voldoet.",
+  "nde_compat_schema_ap_nde_heading_conforms": "Voldoet aan het NDE Schema.org-applicatieprofiel",
+  "nde_compat_schema_ap_nde_heading_not_conforms": "Voldoet niet aan het NDE Schema.org-applicatieprofiel",
+  "nde_compat_schema_ap_nde_heading_not_applicable": "Het NDE Schema.org-applicatieprofiel is niet van toepassing",
+  "nde_compat_schema_ap_nde_explanation_conforms": "Er zijn geen overtredingen gevonden in een steekproef van deze dataset.",
+  "nde_compat_schema_ap_nde_explanation_violations": "Ten minste één gecontroleerde resource voldeed niet aan het NDE Schema.org-applicatieprofiel.",
+  "nde_compat_schema_ap_nde_explanation_declared_but_empty": "Deze dataset geeft aan te voldoen aan het NDE Schema.org-applicatieprofiel, maar geen van de resources gebruikt de klassen van het profiel.",
+  "nde_compat_schema_ap_nde_explanation_not_applicable": "Deze dataset gebruikt een ander datamodel, dus het profiel is niet van toepassing.",
   "nde_compat_iiif_heading_provided": "Biedt IIIF-media",
   "nde_compat_iiif_heading_not_provided": "Biedt geen IIIF-media",
   "nde_compat_iiif_heading_unavailable": "IIIF-media niet beschikbaar",

--- a/apps/browser/src/lib/components/DatasetCard.svelte
+++ b/apps/browser/src/lib/components/DatasetCard.svelte
@@ -3,9 +3,11 @@
   import { getLocale } from '$lib/paraglide/runtime';
   import {
     type DatasetCard,
+    conformsToSchemaApNde,
     iiifManifestCount,
     providesWorkingIiif,
   } from '$lib/services/datasets';
+  import BadgeCheckOutline from 'flowbite-svelte-icons/BadgeCheckOutline.svelte';
   import { getLocalizedValue, localizeHref } from '$lib/utils/i18n';
   import { RDF_MEDIA_TYPES } from '$lib/constants.js';
   import { datasetDetailHref } from '$lib/url';
@@ -43,6 +45,10 @@
         ),
     ),
   );
+
+  // Show the badge only when the dataset conforms to the NDE Schema.org
+  // Application Profile in the sampled resources.
+  const conformsToProfile = $derived(conformsToSchemaApNde(dataset));
 
   // Show the icon only for working IIIF; the tooltip reports the declared count.
   const hasWorkingIiif = $derived(providesWorkingIiif(dataset));
@@ -130,8 +136,28 @@
     </div>
   {/if}
 
-  {#if hasSparqlDistribution || hasRdfDistribution || dataset.size || hasWorkingIiif}
+  {#if conformsToProfile || hasSparqlDistribution || hasRdfDistribution || dataset.size || hasWorkingIiif}
     <div class="mt-2.5 text-[0.9375rem] leading-[1.5] flex items-center gap-4">
+      {#if conformsToProfile}
+        <!-- Leftmost: conforms to the NDE Schema.org Application Profile. The
+             green glyph reads as “verified”; the tooltip carries the full,
+             sample-scoped claim. -->
+        <div class="group relative flex items-center gap-1.5">
+          <div
+            class="invisible absolute bottom-full left-1/2 mb-2 -translate-x-1/2 transform rounded bg-gray-800 px-2 py-1 text-xs whitespace-nowrap text-white opacity-0 transition-opacity duration-200 group-hover:visible group-hover:opacity-100"
+          >
+            {m.dataset_schema_ap_nde()}
+            <div
+              class="absolute top-full left-1/2 h-0 w-0 -translate-x-1/2 border-t-4 border-r-4 border-l-4 border-t-gray-800 border-r-transparent border-l-transparent"
+            ></div>
+          </div>
+          <BadgeCheckOutline
+            class="h-4 w-4 flex-shrink-0 text-green-600 dark:text-green-500"
+            aria-label={m.dataset_schema_ap_nde()}
+          />
+        </div>
+      {/if}
+
       {#if hasSparqlDistribution}
         <div class="group relative flex items-center gap-1.5">
           <div

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -8,19 +8,37 @@
   import {
     compatibilityCriteria,
     IIIF_VINKJES_URL,
+    SCHEMA_AP_NDE_PROFILE,
     type CompatibilityCriterion,
     type IiifManifests,
+    type SchemaApNdeConformance,
   } from '$lib/services/nde-compatibility';
 
-  let { iiifManifests }: { iiifManifests: IiifManifests } = $props();
+  let {
+    iiifManifests,
+    schemaApNde,
+  }: { iiifManifests: IiifManifests; schemaApNde: SchemaApNdeConformance } =
+    $props();
 
-  const criteria = $derived(compatibilityCriteria({ iiif: iiifManifests }));
+  const criteria = $derived(
+    compatibilityCriteria({ schemaApNde, iiif: iiifManifests }),
+  );
 
   // The heading states the actual situation: a dataset legitimately may have no
   // media (unmet, neutral), may provide working media (met), or may declare media
   // that could not be loaded (failed).
   function heading(criterion: CompatibilityCriterion): string {
     switch (criterion.key) {
+      case 'schema-ap-nde':
+        switch (criterion.state) {
+          case 'met':
+            return m.nde_compat_schema_ap_nde_heading_conforms();
+          case 'failed':
+            return m.nde_compat_schema_ap_nde_heading_not_conforms();
+          case 'unmet':
+            return m.nde_compat_schema_ap_nde_heading_not_applicable();
+        }
+      // eslint-disable-next-line no-fallthrough
       case 'iiif':
         switch (criterion.state) {
           case 'met':
@@ -35,6 +53,18 @@
 
   function explanation(criterion: CompatibilityCriterion): string {
     switch (criterion.key) {
+      case 'schema-ap-nde':
+        switch (criterion.state) {
+          case 'met':
+            return m.nde_compat_schema_ap_nde_explanation_conforms();
+          case 'failed':
+            return criterion.reason === 'declared-but-empty'
+              ? m.nde_compat_schema_ap_nde_explanation_declared_but_empty()
+              : m.nde_compat_schema_ap_nde_explanation_violations();
+          case 'unmet':
+            return m.nde_compat_schema_ap_nde_explanation_not_applicable();
+        }
+      // eslint-disable-next-line no-fallthrough
       case 'iiif':
         return m.nde_compat_iiif_explanation();
     }
@@ -49,6 +79,9 @@
     const count = criterion.count;
     const display = count.toLocaleString(getLocale());
     switch (criterion.key) {
+      case 'schema-ap-nde':
+        // No raw counts for the profile criterion in this version.
+        return null;
       case 'iiif':
         switch (criterion.state) {
           case 'met':
@@ -63,6 +96,8 @@
 
   function learnMoreHref(criterion: CompatibilityCriterion): string {
     switch (criterion.key) {
+      case 'schema-ap-nde':
+        return SCHEMA_AP_NDE_PROFILE;
       case 'iiif':
         return IIIF_VINKJES_URL;
     }

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -15,7 +15,9 @@ import { shortenUri } from '$lib/utils/prefix';
 import { isUri, lookupTermLabels } from './network-of-terms.js';
 import {
   IIIF_PRESENTATION_API,
+  SCHEMA_AP_NDE_PROFILE,
   type IiifManifests,
+  type SchemaApNdeConformance,
 } from './nde-compatibility.js';
 import { getLocale } from '$lib/paraglide/runtime';
 import { REGISTRATION_STATUS_BASE_URI } from '@dataset-register/core/constants';
@@ -381,6 +383,7 @@ export interface DatasetDetailResult {
   linksets: Linkset[];
   temporalCoverages: TemporalCoverage[];
   iiifManifests: IiifManifests;
+  schemaApNde: SchemaApNdeConformance;
   resolvedTerms: Promise<Record<string, string>>;
 }
 
@@ -448,6 +451,86 @@ async function fetchIiifManifests(datasetUri: string): Promise<IiifManifests> {
     );
   }
   return none;
+}
+
+// Reads the SCHEMA-AP-NDE sample conformance for a dataset: the co-emitted
+// quads-validated count and conformance boolean from the Knowledge Graph, plus
+// whether any distribution declares the profile in the register.
+// quadsValidated/conformant are null when no measurement exists yet.
+async function fetchSchemaApNdeConformance(
+  datasetUri: string,
+): Promise<SchemaApNdeConformance> {
+  const measurementQuery = `
+    PREFIX dqv: <http://www.w3.org/ns/dqv#>
+    PREFIX nde: <https://def.nde.nl/metric#>
+    SELECT ?quadsValidated ?conformant WHERE {
+      <${datasetUri}> dqv:hasQualityMeasurement
+        [ dqv:isMeasurementOf nde:quads-validated ; dqv:value ?quadsValidated ] ,
+        [ dqv:isMeasurementOf nde:schema-ap-nde-sample-conformance ; dqv:value ?conformant ] .
+    }
+    LIMIT 1
+  `;
+  // The register’s internal model is DCAT: the publisher-facing schema:usageInfo
+  // is normalised to dct:conformsTo on the distribution at ingest, so the claim
+  // is read from dct:conformsTo here. A distribution may carry several values
+  // (e.g. the SPARQL protocol URI alongside the profile), so match the profile
+  // URI specifically.
+  const declarationQuery = `
+    PREFIX dcat: <http://www.w3.org/ns/dcat#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    ASK {
+      GRAPH ?g {
+        <${datasetUri}> dcat:distribution/dct:conformsTo <${SCHEMA_AP_NDE_PROFILE}> .
+      }
+    }
+  `;
+
+  const measurement = (async () => {
+    try {
+      const bindingsStream = await fetcher.fetchBindings(
+        PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+        measurementQuery,
+      );
+      for await (const raw of bindingsStream) {
+        const binding = raw as unknown as {
+          quadsValidated?: { value: string };
+          conformant?: { value: string };
+        };
+        return {
+          quadsValidated: binding.quadsValidated?.value
+            ? parseInt(binding.quadsValidated.value, 10)
+            : null,
+          conformant: binding.conformant?.value
+            ? binding.conformant.value === 'true'
+            : null,
+        };
+      }
+    } catch (e: unknown) {
+      console.error(
+        'SCHEMA-AP-NDE conformance query failed:',
+        e instanceof Error ? e.message : e,
+      );
+    }
+    return { quadsValidated: null, conformant: null };
+  })();
+
+  const declaresProfile = (async () => {
+    try {
+      return await fetcher.fetchAsk(PUBLIC_SPARQL_ENDPOINT, declarationQuery);
+    } catch (e: unknown) {
+      console.error(
+        'SCHEMA-AP-NDE conformsTo query failed:',
+        e instanceof Error ? e.message : e,
+      );
+      return false;
+    }
+  })();
+
+  const [{ quadsValidated, conformant }, declares] = await Promise.all([
+    measurement,
+    declaresProfile,
+  ]);
+  return { quadsValidated, conformant, declaresProfile: declares };
 }
 
 async function fetchDistributionCount(query: string): Promise<number> {
@@ -649,6 +732,7 @@ export async function fetchDatasetDetail(
     classPartitionResult,
     temporalCoverages,
     iiifManifests,
+    schemaApNde,
   ] = await Promise.all([
     detailLens.query(datasetQuery),
     distributionLens.query(distributionQuery),
@@ -664,6 +748,7 @@ export async function fetchDatasetDetail(
     classPartitionLens.findByIri(datasetUri),
     fetchTemporalCoverage(datasetUri),
     fetchIiifManifests(datasetUri),
+    fetchSchemaApNdeConformance(datasetUri),
   ]);
 
   const dataset = datasets.find((d) => d.$id === datasetUri) ?? datasets[0];
@@ -705,6 +790,7 @@ export async function fetchDatasetDetail(
     linksets,
     temporalCoverages,
     iiifManifests,
+    schemaApNde,
     resolvedTerms,
   };
 }

--- a/apps/browser/src/lib/services/datasets.test.ts
+++ b/apps/browser/src/lib/services/datasets.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  conformsToSchemaApNde,
   iiifManifestCount,
   providesWorkingIiif,
   type DatasetCard,
@@ -71,5 +72,35 @@ describe('providesWorkingIiif', () => {
 
   it('is false when no IIIF subset is declared', () => {
     expect(providesWorkingIiif(card({ iiifSubset: null }))).toBe(false);
+  });
+});
+
+describe('conformsToSchemaApNde', () => {
+  it('is true when the validated sample conforms', () => {
+    expect(
+      conformsToSchemaApNde(
+        card({ schemaApNdeQuadsValidated: 200, schemaApNdeConformant: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is false when the validated sample does not conform', () => {
+    expect(
+      conformsToSchemaApNde(
+        card({ schemaApNdeQuadsValidated: 200, schemaApNdeConformant: false }),
+      ),
+    ).toBe(false);
+  });
+
+  it('is false when zero quads were validated (profile does not apply)', () => {
+    expect(
+      conformsToSchemaApNde(
+        card({ schemaApNdeQuadsValidated: 0, schemaApNdeConformant: false }),
+      ),
+    ).toBe(false);
+  });
+
+  it('is false when no conformance measurement exists', () => {
+    expect(conformsToSchemaApNde(card({}))).toBe(false);
   });
 });

--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -11,8 +11,12 @@ import {
   IIIF_PRESENTATION_API,
   MANIFESTS_SAMPLED_METRIC,
   MANIFESTS_VALIDATED_METRIC,
+  QUADS_VALIDATED_METRIC,
+  SCHEMA_AP_NDE_CONFORMANCE_METRIC,
   iiifState,
+  schemaApNdeState,
   type IiifManifests,
+  type SchemaApNdeConformance,
 } from '$lib/services/nde-compatibility';
 
 export const SPARQL_ENDPOINT = PUBLIC_SPARQL_ENDPOINT;
@@ -122,6 +126,18 @@ export const DatasetCardSchema = {
     '@type': xsd.integer,
     '@optional': true,
   },
+  // SCHEMA-AP-NDE sample-conformance measurements, projected onto the dataset by
+  // the card query so the badge can be limited to conforming datasets.
+  schemaApNdeQuadsValidated: {
+    '@id': QUADS_VALIDATED_METRIC,
+    '@type': xsd.integer,
+    '@optional': true,
+  },
+  schemaApNdeConformant: {
+    '@id': SCHEMA_AP_NDE_CONFORMANCE_METRIC,
+    '@type': xsd.boolean,
+    '@optional': true,
+  },
   datePosted: {
     '@id': schema.datePosted,
     '@type': xsd.dateTime,
@@ -157,6 +173,24 @@ export function iiifManifestCount(dataset: DatasetCard): number {
 // when none are declared.
 export function providesWorkingIiif(dataset: DatasetCard): boolean {
   return iiifState(cardIiifManifests(dataset)) === 'met';
+}
+
+// The SCHEMA-AP-NDE conformance figures for a card. The card only ever shows the
+// badge in the `met` state, which never depends on the `dct:conformsTo` claim
+// (that claim only splits the `failed`/`unmet` branch), so the card leaves it
+// false rather than fetching it.
+function cardSchemaApNde(dataset: DatasetCard): SchemaApNdeConformance {
+  return {
+    quadsValidated: dataset.schemaApNdeQuadsValidated ?? null,
+    conformant: dataset.schemaApNdeConformant ?? null,
+    declaresProfile: false,
+  };
+}
+
+// Whether the dataset conforms to the NDE Schema.org Application Profile in the
+// sampled resources. The card badge is shown only in this case.
+export function conformsToSchemaApNde(dataset: DatasetCard): boolean {
+  return schemaApNdeState(cardSchemaApNde(dataset)).state === 'met';
 }
 
 const datasetCards = createLens(DatasetCardSchema, {
@@ -240,6 +274,8 @@ export function datasetCardsQuery(
       void:subset ?iiifSubset ;
       nde:manifests-sampled ?iiifSampled ;
       nde:manifests-validated ?iiifValidated ;
+      nde:quads-validated ?schemaApNdeQuadsValidated ;
+      nde:schema-ap-nde-sample-conformance ?schemaApNdeConformant ;
       schema:status ?status ;
       schema:datePosted ?datePosted .
     ?publisher a foaf:Agent ;
@@ -338,6 +374,20 @@ export function datasetCardsQuery(
               dqv:value ?iiifValidated
             ] .
           }
+        }
+        # SCHEMA-AP-NDE sample conformance. Anchored on quads-validated with the
+        # conformance boolean co-required in the same OPTIONAL: the two are
+        # co-emitted, so this single left-join boundary keeps one row per dataset
+        # (no UNION, no nested OPTIONAL) and does not multiply the multi-valued
+        # patterns outside the SERVICE block.
+        OPTIONAL {
+          ?dataset dqv:hasQualityMeasurement [
+            dqv:isMeasurementOf nde:quads-validated ;
+            dqv:value ?schemaApNdeQuadsValidated
+          ] , [
+            dqv:isMeasurementOf nde:schema-ap-nde-sample-conformance ;
+            dqv:value ?schemaApNdeConformant
+          ] .
         }
       }
     }

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { compatibilityCriteria, iiifState } from './nde-compatibility';
+import {
+  compatibilityCriteria,
+  iiifState,
+  schemaApNdeState,
+  type SchemaApNdeConformance,
+} from './nde-compatibility';
+
+// A neutral conformance fixture for tests that focus on another criterion.
+const noSchemaApNde: SchemaApNdeConformance = {
+  quadsValidated: null,
+  conformant: null,
+  declaresProfile: false,
+};
 
 describe('iiifState', () => {
   it('is met when at least one sampled manifest validated', () => {
@@ -26,9 +38,87 @@ describe('iiifState', () => {
   });
 });
 
+describe('schemaApNdeState', () => {
+  it('is met when the validated sample conforms', () => {
+    expect(
+      schemaApNdeState({
+        quadsValidated: 200,
+        conformant: true,
+        declaresProfile: false,
+      }),
+    ).toEqual({ state: 'met' });
+  });
+
+  it('is failed/violations when the validated sample does not conform', () => {
+    expect(
+      schemaApNdeState({
+        quadsValidated: 200,
+        conformant: false,
+        declaresProfile: false,
+      }),
+    ).toEqual({ state: 'failed', reason: 'violations' });
+  });
+
+  it('lets the measurement win over the claim when conclusive', () => {
+    // A passing measurement stays met even if the dataset also declares the
+    // profile; a failing one stays failed/violations.
+    expect(
+      schemaApNdeState({
+        quadsValidated: 200,
+        conformant: true,
+        declaresProfile: true,
+      }),
+    ).toEqual({ state: 'met' });
+    expect(
+      schemaApNdeState({
+        quadsValidated: 200,
+        conformant: false,
+        declaresProfile: true,
+      }),
+    ).toEqual({ state: 'failed', reason: 'violations' });
+  });
+
+  it('is failed/declared-but-empty when zero quads validated yet the profile is declared', () => {
+    expect(
+      schemaApNdeState({
+        quadsValidated: 0,
+        conformant: false,
+        declaresProfile: true,
+      }),
+    ).toEqual({ state: 'failed', reason: 'declared-but-empty' });
+  });
+
+  it('is unmet when zero quads validated and no claim (different data model)', () => {
+    expect(
+      schemaApNdeState({
+        quadsValidated: 0,
+        conformant: false,
+        declaresProfile: false,
+      }),
+    ).toEqual({ state: 'unmet' });
+  });
+
+  it('is unmet when no measurement exists, even if the profile is declared', () => {
+    expect(
+      schemaApNdeState({
+        quadsValidated: null,
+        conformant: null,
+        declaresProfile: true,
+      }),
+    ).toEqual({ state: 'unmet' });
+  });
+
+  it('treats a missing or partial input as a neutral unmet rather than throwing', () => {
+    expect(schemaApNdeState(undefined)).toEqual({ state: 'unmet' });
+    expect(schemaApNdeState({})).toEqual({ state: 'unmet' });
+    expect(schemaApNdeState({ conformant: false })).toEqual({ state: 'unmet' });
+  });
+});
+
 describe('compatibilityCriteria', () => {
   it('exposes the declared count and computed state for IIIF', () => {
-    const [iiif] = compatibilityCriteria({
+    const [, iiif] = compatibilityCriteria({
+      schemaApNde: noSchemaApNde,
       iiif: { declared: 4152, sampled: 10, validated: 0 },
     });
     expect(iiif.key).toBe('iiif');
@@ -36,11 +126,26 @@ describe('compatibilityCriteria', () => {
     expect(iiif.count).toBe(4152);
   });
 
-  it('renders the IIIF criterion regardless of state, so publishers always see it', () => {
+  it('leads with the schema-ap-nde criterion and carries its failure reason', () => {
+    const [schemaApNde] = compatibilityCriteria({
+      schemaApNde: {
+        quadsValidated: 0,
+        conformant: false,
+        declaresProfile: true,
+      },
+      iiif: { declared: 0, sampled: null, validated: null },
+    });
+    expect(schemaApNde.key).toBe('schema-ap-nde');
+    expect(schemaApNde.state).toBe('failed');
+    expect(schemaApNde.reason).toBe('declared-but-empty');
+  });
+
+  it('renders both criteria regardless of state, so publishers always see them', () => {
     expect(
       compatibilityCriteria({
+        schemaApNde: noSchemaApNde,
         iiif: { declared: 0, sampled: null, validated: null },
       }),
-    ).toHaveLength(1);
+    ).toHaveLength(2);
   });
 });

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -12,6 +12,12 @@ export const IIIF_PRESENTATION_API = 'http://iiif.io/api/presentation/';
 export const IIIF_VINKJES_URL =
   'https://netwerkdigitaalerfgoed.nl/aanpak/bruikbaar/#vinkjes';
 
+// The NDE Schema.org Application Profile. A distribution declares compliance with
+// `dct:conformsTo` pointing here (the register’s internal model is DCAT, so the
+// publisher-facing schema:usageInfo is normalised to dct:conformsTo at ingest).
+// Also linked from the detail page as the criterion’s documentation.
+export const SCHEMA_AP_NDE_PROFILE = 'https://docs.nde.nl/schema-profile/';
+
 // DQV metric IRIs for the IIIF manifest validation measurements recorded by the
 // Dataset Knowledge Graph.
 export const MANIFESTS_SAMPLED_METRIC =
@@ -19,7 +25,19 @@ export const MANIFESTS_SAMPLED_METRIC =
 export const MANIFESTS_VALIDATED_METRIC =
   'https://def.nde.nl/metric#manifests-validated';
 
-export type CompatibilityCriterionKey = 'iiif';
+// DQV metric IRIs for the SCHEMA-AP-NDE sample-conformance measurements recorded
+// by the Dataset Knowledge Graph. `quads-validated` is how many quads of the
+// sampled resources were validated against the profile; the conformance boolean
+// is whether that sample passed. The two are co-emitted, so both are present or
+// both absent.
+export const SCHEMA_AP_NDE_CONFORMANCE_METRIC =
+  'https://def.nde.nl/metric#schema-ap-nde-sample-conformance';
+export const QUADS_VALIDATED_METRIC =
+  'https://def.nde.nl/metric#quads-validated';
+
+// The schema-ap-nde criterion is ordered before iiif, matching the usual order
+// in NDE communication.
+export type CompatibilityCriterionKey = 'schema-ap-nde' | 'iiif';
 
 // 'met'    — the dataset provides working media (validated, or declared with no
 //            evidence of failure).
@@ -27,6 +45,15 @@ export type CompatibilityCriterionKey = 'iiif';
 //            load (declared but broken).
 // 'unmet'  — the dataset declares no media. A legitimate, neutral state.
 export type CompatibilityState = 'met' | 'failed' | 'unmet';
+
+// Why a schema-ap-nde criterion is in the `failed` state:
+// 'violations'         — the sample exercised the profile’s classes but at least
+//                        one sampled resource violated a constraint.
+// 'declared-but-empty' — the dataset declares conformance (a distribution’s
+//                        `dct:conformsTo` points at the profile), yet the
+//                        sample validated zero quads: none of its resources use
+//                        the profile’s classes.
+export type CompatibilityFailureReason = 'violations' | 'declared-but-empty';
 
 // IIIF manifest figures from the Knowledge Graph: how many manifests the dataset
 // declares (void:entities), and — once the pipeline has sampled them — how many
@@ -38,14 +65,59 @@ export interface IiifManifests {
   validated: number | null;
 }
 
+// SCHEMA-AP-NDE sample-conformance figures from the Knowledge Graph plus whether
+// the dataset declares conformance via a distribution’s `dct:conformsTo`.
+// `quadsValidated`/`conformant` are null when no conformance measurement exists
+// yet; they are co-emitted, so they are null together.
+export interface SchemaApNdeConformance {
+  quadsValidated: number | null;
+  conformant: boolean | null;
+  declaresProfile: boolean;
+}
+
 export interface CompatibilityCriterion {
   key: CompatibilityCriterionKey;
   state: CompatibilityState;
   count: number;
+  reason?: CompatibilityFailureReason;
 }
 
 export interface CompatibilityInput {
+  schemaApNde: SchemaApNdeConformance;
   iiif: IiifManifests;
+}
+
+// Derives the SCHEMA-AP-NDE conformance state. The measurement is authoritative
+// wherever it is conclusive (`quadsValidated > 0`): a passing sample is `met`, a
+// failing one is `failed`/'violations'. The `dct:conformsTo` claim only tips
+// the otherwise-neutral branch where the sample validated zero quads — a dataset
+// that claims the profile but uses none of its classes is a real discrepancy
+// ('declared-but-empty'), not a neutral “different model”. Absent any
+// measurement the criterion is neutral (`unmet`), claim or not.
+//
+// The input is treated defensively: a missing object or undefined fields (e.g. a
+// partial payload, never the full contract) collapse to the same neutral `unmet`
+// as an absent measurement rather than throwing or reading as a false negative.
+export function schemaApNdeState(
+  conformance: Partial<SchemaApNdeConformance> | undefined | null,
+): {
+  state: CompatibilityState;
+  reason?: CompatibilityFailureReason;
+} {
+  const quadsValidated = conformance?.quadsValidated ?? null;
+  const conformant = conformance?.conformant ?? null;
+  const declaresProfile = conformance?.declaresProfile ?? false;
+  if (quadsValidated === null) {
+    return { state: 'unmet' };
+  }
+  if (quadsValidated > 0) {
+    return conformant
+      ? { state: 'met' }
+      : { state: 'failed', reason: 'violations' };
+  }
+  return declaresProfile
+    ? { state: 'failed', reason: 'declared-but-empty' }
+    : { state: 'unmet' };
 }
 
 export function iiifState(manifests: IiifManifests): CompatibilityState {
@@ -63,13 +135,19 @@ export function iiifState(manifests: IiifManifests): CompatibilityState {
   return 'met';
 }
 
-// Builds the list of NDE criteria for a dataset. Today this is a single IIIF
-// row; follow-up work (#1222, #1969) appends rows here without the component
-// having to change.
+// Builds the list of NDE criteria for a dataset. The schema-ap-nde row leads,
+// matching the usual order in NDE communication; the IIIF row follows.
 export function compatibilityCriteria(
   input: CompatibilityInput,
 ): CompatibilityCriterion[] {
+  const schemaApNde = schemaApNdeState(input.schemaApNde);
   return [
+    {
+      key: 'schema-ap-nde',
+      state: schemaApNde.state,
+      count: 0,
+      reason: schemaApNde.reason,
+    },
     {
       key: 'iiif',
       state: iiifState(input.iiif),

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -52,6 +52,7 @@
   const linksets = $derived(data.linksets);
   const temporalCoverages = $derived(data.temporalCoverages);
   const iiifManifests = $derived(data.iiifManifests);
+  const schemaApNde = $derived(data.schemaApNde);
 
   // SEO: canonical and hreflang URLs
   const datasetPath = $derived(datasetDetailHref(dataset.$id));
@@ -1268,7 +1269,7 @@
   {/if}
 
   <!-- NDE compatibility (“vinkjes”) -->
-  <NdeCompatibility {iiifManifests} />
+  <NdeCompatibility {iiifManifests} {schemaApNde} />
 
   <!-- VoID Summary Section -->
   {#if summary && hasVoidStats}


### PR DESCRIPTION
Surfaces the Dataset Knowledge Graph’s SCHEMA-AP-NDE sample-conformance measurement in the browser, as a new criterion in the existing “NDE compatibility” section and as a card badge.

Fix #1969

## What

- **Conformance state model** (`nde-compatibility.ts`, deep module): a new `schema-ap-nde` criterion, ordered before `iiif`, derived from the co-emitted `quads-validated` count and conformance boolean plus the dataset’s profile claim. The measurement is authoritative where conclusive (`quads-validated > 0`); the claim only tips the otherwise-neutral zero-quads branch.

  | Condition | State | reason |
  |---|---|---|
  | `quads-validated > 0` && conformant | `met` | – |
  | `quads-validated > 0` && not conformant | `failed` | `violations` |
  | `quads-validated == 0` && declares profile | `failed` | `declared-but-empty` |
  | `quads-validated == 0` && no claim | `unmet` | – |
  | no measurement | `unmet` | – |

- **Dataset card**: a leftmost green badge-check glyph, shown **only** in the `met` state, with a sample-scoped tooltip. The measurements ride along the existing federated `SERVICE` block via one new `OPTIONAL` (single left-join boundary, no row multiplication).

- **Dataset detail**: an always-rendered profile row in the NDE compatibility section, with headings/explanations for all four states. The profile claim is read from `dct:conformsTo` — the register’s internal model is DCAT, so the publisher-facing `schema:usageInfo` is normalised to `dct:conformsTo` at ingest. Queries use `dct:conformsTo` only.

- **Copy** (`en.json` / `nl.json`): spells out “the NDE Schema.org Application Profile” / “het NDE Schema.org-applicatieprofiel”; no “SHACL” or “SCHEMA-AP-NDE” acronym, no raw counts, sample-scoped wording.

The verdict is honest about its basis: it reflects a sample of resources per class, not an exhaustive check, and the copy says so.

## Example datasets per state

Verified against the live register and Knowledge Graph:

| State | Example dataset |
|---|---|
| `met` (conforms) | [Li-MA single channel video artworks](https://datasetregister.netwerkdigitaalerfgoed.nl/dataset?uri=https://data.mediakunst.net/dataset/lima-single-channel-artworks) |
| `failed` / `violations` | [Muziekweb](https://datasetregister.netwerkdigitaalerfgoed.nl/dataset?uri=http://data.beeldengeluid.nl/id/dataset/0026) |
| `failed` / `declared-but-empty` | — *(no live example: zero datasets currently declare the profile via `dct:conformsTo`)* |
| `unmet` (does not apply) | [GTAA](https://datasetregister.netwerkdigitaalerfgoed.nl/dataset?uri=http://data.beeldengeluid.nl/id/dataset/0010) |

Note: `declared-but-empty` has no real example yet because no publisher currently declares the profile. The branch is covered by unit tests.

## Tests

Unit tests cover the conformance state logic (all input combinations, both failure reasons, the claim fold, and the measurement-wins-over-claim rule) and the card helper. Svelte components and SPARQL wiring remain shallow glue, untested, consistent with the IIIF work (#2024).

## Out of scope (per PRD)

Search facet, failure drill-down, raw coverage counts, and a docs-site update are deferred.
