### PR TITLE
feat(browser): gate NDE compatibility checks on dataset analysis

### DIFF
--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -15,10 +15,14 @@
   } from '$lib/services/nde-compatibility';
 
   let {
+    isAnalyzed,
     iiifManifests,
     schemaApNde,
-  }: { iiifManifests: IiifManifests; schemaApNde: SchemaApNdeConformance } =
-    $props();
+  }: {
+    isAnalyzed: boolean;
+    iiifManifests: IiifManifests;
+    schemaApNde: SchemaApNdeConformance;
+  } = $props();
 
   const criteria = $derived(
     compatibilityCriteria({ schemaApNde, iiif: iiifManifests }),
@@ -104,73 +108,77 @@
   }
 </script>
 
-<section class="mb-8" aria-labelledby="nde-compatibility-heading">
-  <h2
-    id="nde-compatibility-heading"
-    class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
-  >
-    {m.nde_compatibility()}
-    <span id="tooltip-nde-compatibility" class="cursor-pointer">
-      <InfoCircleSolid
-        class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
-      />
-    </span>
-    <Tooltip triggeredBy="#tooltip-nde-compatibility"
-      >{m.nde_compatibility_description()}</Tooltip
+<!-- The criteria are assessed from the dataset’s analysis in the Knowledge
+     Graph, so the section is shown only for a dataset that has been analyzed. -->
+{#if isAnalyzed}
+  <section class="mb-8" aria-labelledby="nde-compatibility-heading">
+    <h2
+      id="nde-compatibility-heading"
+      class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
     >
-  </h2>
-  <div
-    class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
-  >
-    <ul class="divide-y divide-gray-200 dark:divide-gray-700">
-      {#each criteria as criterion (criterion.key)}
-        <li class="flex items-start gap-3 px-4 py-3">
-          <!-- Status box. Green tick = met, red cross = declared but broken,
+      {m.nde_compatibility()}
+      <span id="tooltip-nde-compatibility" class="cursor-pointer">
+        <InfoCircleSolid
+          class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+        />
+      </span>
+      <Tooltip triggeredBy="#tooltip-nde-compatibility"
+        >{m.nde_compatibility_description()}</Tooltip
+      >
+    </h2>
+    <div
+      class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+    >
+      <ul class="divide-y divide-gray-200 dark:divide-gray-700">
+        {#each criteria as criterion (criterion.key)}
+          <li class="flex items-start gap-3 px-4 py-3">
+            <!-- Status box. Green tick = met, red cross = declared but broken,
                neutral empty = not provided (a legitimate, non-failure state).
                The heading carries the status for assistive technology, so the
                box is decorative. -->
-          <span
-            class={`mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border ${
-              criterion.state === 'met'
-                ? 'border-green-600 bg-green-600 text-white dark:border-green-500 dark:bg-green-500'
-                : criterion.state === 'failed'
-                  ? 'border-red-600 bg-red-600 text-white dark:border-red-500 dark:bg-red-500'
-                  : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-700'
-            }`}
-            aria-hidden="true"
-          >
-            {#if criterion.state === 'met'}
-              <CheckOutline class="h-3.5 w-3.5" />
-            {:else if criterion.state === 'failed'}
-              <CloseOutline class="h-3.5 w-3.5" />
-            {/if}
-          </span>
-          <div class="min-w-0">
-            <h3 class="text-base font-medium text-gray-900 dark:text-white">
-              {heading(criterion)}
-            </h3>
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-              {explanation(criterion)}
-              <a
-                href={learnMoreHref(criterion)}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                {m.nde_compat_learn_more()}
-                <span class="sr-only"> ({m.opens_in_new_tab()})</span>
-              </a>
-            </p>
-            {#if detail(criterion)}
-              <p
-                class="mt-1 text-sm font-medium text-gray-700 dark:text-gray-300"
-              >
-                {detail(criterion)}
+            <span
+              class={`mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border ${
+                criterion.state === 'met'
+                  ? 'border-green-600 bg-green-600 text-white dark:border-green-500 dark:bg-green-500'
+                  : criterion.state === 'failed'
+                    ? 'border-red-600 bg-red-600 text-white dark:border-red-500 dark:bg-red-500'
+                    : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-700'
+              }`}
+              aria-hidden="true"
+            >
+              {#if criterion.state === 'met'}
+                <CheckOutline class="h-3.5 w-3.5" />
+              {:else if criterion.state === 'failed'}
+                <CloseOutline class="h-3.5 w-3.5" />
+              {/if}
+            </span>
+            <div class="min-w-0">
+              <h3 class="text-base font-medium text-gray-900 dark:text-white">
+                {heading(criterion)}
+              </h3>
+              <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                {explanation(criterion)}
+                <a
+                  href={learnMoreHref(criterion)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {m.nde_compat_learn_more()}
+                  <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                </a>
               </p>
-            {/if}
-          </div>
-        </li>
-      {/each}
-    </ul>
-  </div>
-</section>
+              {#if detail(criterion)}
+                <p
+                  class="mt-1 text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  {detail(criterion)}
+                </p>
+              {/if}
+            </div>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  </section>
+{/if}

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -795,6 +795,14 @@ export async function fetchDatasetDetail(
   };
 }
 
+// Whether the dataset has been analyzed by the Dataset Knowledge Graph. The DKG
+// produces a VoID summary only once it has crawled the dataset, so its presence
+// signals that the dataset was analyzed. The NDE compatibility criteria are
+// assessed from that analysis, so they are only shown for an analyzed dataset.
+export function isAnalyzed(summary: DatasetSummary | null): boolean {
+  return summary !== null;
+}
+
 export function displayMissingProperties(ratingExplanation: string): string[] {
   return ratingExplanation
     .split(', ')

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -38,6 +38,7 @@
   import {
     displayMissingProperties,
     getRegistrationStatus,
+    isAnalyzed,
   } from '$lib/services/dataset-detail.js';
   import { getRelativeTimeString } from '$lib/utils/relative-time';
   import ClassPropertiesWidget from '$lib/components/ClassPropertiesWidget.svelte';
@@ -1269,7 +1270,11 @@
   {/if}
 
   <!-- NDE compatibility (“vinkjes”) -->
-  <NdeCompatibility {iiifManifests} {schemaApNde} />
+  <NdeCompatibility
+    isAnalyzed={isAnalyzed(summary)}
+    {iiifManifests}
+    {schemaApNde}
+  />
 
   <!-- VoID Summary Section -->
   {#if summary && hasVoidStats}


### PR DESCRIPTION
## What

Gate the individual NDE compatibility checks on the dataset detail page on whether the dataset has been **analyzed** by the Dataset Knowledge Graph (DKG), rather than always rendering them.

## Why

The SCHEMA-AP-NDE and IIIF criteria are derived from the DKG’s analysis of the dataset’s RDF. For a dataset the DKG has not analyzed (for example a non-RDF dataset), there is nothing to assess for those checks.

## How

- Add an `isAnalyzed(summary)` helper in `dataset-detail.ts`. The DKG produces a VoID summary only once it has crawled a dataset, so the presence of that summary signals the dataset was analyzed.
- Mark SCHEMA-AP-NDE and IIIF as analysis-dependent and drop them from the criteria list when the dataset is not analyzed, instead of hiding the whole section.
- Show the section whenever any criterion remains. A future criterion that applies to any dataset (regardless of analysis) will keep the section visible and show itself even for non-analyzed datasets.

## Out of scope

The per-criterion state logic is unchanged. An analyzed dataset that has no IIIF media, or that uses a different data model than SCHEMA-AP-NDE, keeps its neutral grey state – those are legitimate, non-failure situations and are not shown as red.
