### PR TITLE
feat(browser): gate NDE compatibility checks on dataset analysis

### DIFF
--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -15,13 +15,17 @@
   } from '$lib/services/nde-compatibility';
 
   let {
+    isAnalyzed,
     iiifManifests,
     schemaApNde,
-  }: { iiifManifests: IiifManifests; schemaApNde: SchemaApNdeConformance } =
-    $props();
+  }: {
+    isAnalyzed: boolean;
+    iiifManifests: IiifManifests;
+    schemaApNde: SchemaApNdeConformance;
+  } = $props();
 
   const criteria = $derived(
-    compatibilityCriteria({ schemaApNde, iiif: iiifManifests }),
+    compatibilityCriteria({ isAnalyzed, schemaApNde, iiif: iiifManifests }),
   );
 
   // The heading states the actual situation: a dataset legitimately may have no
@@ -104,73 +108,77 @@
   }
 </script>
 
-<section class="mb-8" aria-labelledby="nde-compatibility-heading">
-  <h2
-    id="nde-compatibility-heading"
-    class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
-  >
-    {m.nde_compatibility()}
-    <span id="tooltip-nde-compatibility" class="cursor-pointer">
-      <InfoCircleSolid
-        class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
-      />
-    </span>
-    <Tooltip triggeredBy="#tooltip-nde-compatibility"
-      >{m.nde_compatibility_description()}</Tooltip
+<!-- Analysis-dependent criteria are dropped for a dataset that has not been
+     analyzed; the section is shown whenever any criterion remains. -->
+{#if criteria.length > 0}
+  <section class="mb-8" aria-labelledby="nde-compatibility-heading">
+    <h2
+      id="nde-compatibility-heading"
+      class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
     >
-  </h2>
-  <div
-    class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
-  >
-    <ul class="divide-y divide-gray-200 dark:divide-gray-700">
-      {#each criteria as criterion (criterion.key)}
-        <li class="flex items-start gap-3 px-4 py-3">
-          <!-- Status box. Green tick = met, red cross = declared but broken,
+      {m.nde_compatibility()}
+      <span id="tooltip-nde-compatibility" class="cursor-pointer">
+        <InfoCircleSolid
+          class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+        />
+      </span>
+      <Tooltip triggeredBy="#tooltip-nde-compatibility"
+        >{m.nde_compatibility_description()}</Tooltip
+      >
+    </h2>
+    <div
+      class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+    >
+      <ul class="divide-y divide-gray-200 dark:divide-gray-700">
+        {#each criteria as criterion (criterion.key)}
+          <li class="flex items-start gap-3 px-4 py-3">
+            <!-- Status box. Green tick = met, red cross = declared but broken,
                neutral empty = not provided (a legitimate, non-failure state).
                The heading carries the status for assistive technology, so the
                box is decorative. -->
-          <span
-            class={`mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border ${
-              criterion.state === 'met'
-                ? 'border-green-600 bg-green-600 text-white dark:border-green-500 dark:bg-green-500'
-                : criterion.state === 'failed'
-                  ? 'border-red-600 bg-red-600 text-white dark:border-red-500 dark:bg-red-500'
-                  : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-700'
-            }`}
-            aria-hidden="true"
-          >
-            {#if criterion.state === 'met'}
-              <CheckOutline class="h-3.5 w-3.5" />
-            {:else if criterion.state === 'failed'}
-              <CloseOutline class="h-3.5 w-3.5" />
-            {/if}
-          </span>
-          <div class="min-w-0">
-            <h3 class="text-base font-medium text-gray-900 dark:text-white">
-              {heading(criterion)}
-            </h3>
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-              {explanation(criterion)}
-              <a
-                href={learnMoreHref(criterion)}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-blue-600 hover:underline dark:text-blue-400"
-              >
-                {m.nde_compat_learn_more()}
-                <span class="sr-only"> ({m.opens_in_new_tab()})</span>
-              </a>
-            </p>
-            {#if detail(criterion)}
-              <p
-                class="mt-1 text-sm font-medium text-gray-700 dark:text-gray-300"
-              >
-                {detail(criterion)}
+            <span
+              class={`mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border ${
+                criterion.state === 'met'
+                  ? 'border-green-600 bg-green-600 text-white dark:border-green-500 dark:bg-green-500'
+                  : criterion.state === 'failed'
+                    ? 'border-red-600 bg-red-600 text-white dark:border-red-500 dark:bg-red-500'
+                    : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-700'
+              }`}
+              aria-hidden="true"
+            >
+              {#if criterion.state === 'met'}
+                <CheckOutline class="h-3.5 w-3.5" />
+              {:else if criterion.state === 'failed'}
+                <CloseOutline class="h-3.5 w-3.5" />
+              {/if}
+            </span>
+            <div class="min-w-0">
+              <h3 class="text-base font-medium text-gray-900 dark:text-white">
+                {heading(criterion)}
+              </h3>
+              <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                {explanation(criterion)}
+                <a
+                  href={learnMoreHref(criterion)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {m.nde_compat_learn_more()}
+                  <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                </a>
               </p>
-            {/if}
-          </div>
-        </li>
-      {/each}
-    </ul>
-  </div>
-</section>
+              {#if detail(criterion)}
+                <p
+                  class="mt-1 text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  {detail(criterion)}
+                </p>
+              {/if}
+            </div>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  </section>
+{/if}

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -795,6 +795,14 @@ export async function fetchDatasetDetail(
   };
 }
 
+// Whether the dataset has been analyzed by the Dataset Knowledge Graph. The DKG
+// produces a VoID summary only once it has crawled the dataset, so its presence
+// signals that the dataset was analyzed. The NDE compatibility criteria are
+// assessed from that analysis, so they are only shown for an analyzed dataset.
+export function isAnalyzed(summary: DatasetSummary | null): boolean {
+  return summary !== null;
+}
+
 export function displayMissingProperties(ratingExplanation: string): string[] {
   return ratingExplanation
     .split(', ')

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -118,6 +118,7 @@ describe('schemaApNdeState', () => {
 describe('compatibilityCriteria', () => {
   it('exposes the declared count and computed state for IIIF', () => {
     const [, iiif] = compatibilityCriteria({
+      isAnalyzed: true,
       schemaApNde: noSchemaApNde,
       iiif: { declared: 4152, sampled: 10, validated: 0 },
     });
@@ -128,6 +129,7 @@ describe('compatibilityCriteria', () => {
 
   it('leads with the schema-ap-nde criterion and carries its failure reason', () => {
     const [schemaApNde] = compatibilityCriteria({
+      isAnalyzed: true,
       schemaApNde: {
         quadsValidated: 0,
         conformant: false,
@@ -140,12 +142,29 @@ describe('compatibilityCriteria', () => {
     expect(schemaApNde.reason).toBe('declared-but-empty');
   });
 
-  it('renders both criteria regardless of state, so publishers always see them', () => {
+  it('renders both criteria regardless of state for an analyzed dataset', () => {
     expect(
       compatibilityCriteria({
+        isAnalyzed: true,
         schemaApNde: noSchemaApNde,
         iiif: { declared: 0, sampled: null, validated: null },
       }),
     ).toHaveLength(2);
+  });
+
+  it('drops the analysis-dependent criteria when the dataset is not analyzed', () => {
+    // Both current criteria depend on analysis, so a non-analyzed dataset yields
+    // none — until a criterion that applies to any dataset is added.
+    expect(
+      compatibilityCriteria({
+        isAnalyzed: false,
+        schemaApNde: {
+          quadsValidated: 200,
+          conformant: true,
+          declaresProfile: true,
+        },
+        iiif: { declared: 4152, sampled: 10, validated: 8 },
+      }),
+    ).toEqual([]);
   });
 });

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -39,6 +39,13 @@ export const QUADS_VALIDATED_METRIC =
 // in NDE communication.
 export type CompatibilityCriterionKey = 'schema-ap-nde' | 'iiif';
 
+// Criteria that can only be assessed from the dataset’s analysis in the Dataset
+// Knowledge Graph, so they are shown only for an analyzed dataset. A criterion
+// that applies to any dataset is left out of this set; it is always shown and so
+// keeps the section visible even for a dataset that has not been analyzed.
+const ANALYSIS_DEPENDENT_CRITERIA: ReadonlySet<CompatibilityCriterionKey> =
+  new Set(['schema-ap-nde', 'iiif']);
+
 // 'met'    — the dataset provides working media (validated, or declared with no
 //            evidence of failure).
 // 'failed' — the dataset declares media, but every sampled manifest failed to
@@ -83,6 +90,9 @@ export interface CompatibilityCriterion {
 }
 
 export interface CompatibilityInput {
+  // Whether the dataset has been analyzed by the Dataset Knowledge Graph.
+  // Analysis-dependent criteria are dropped when this is false.
+  isAnalyzed: boolean;
   schemaApNde: SchemaApNdeConformance;
   iiif: IiifManifests;
 }
@@ -136,12 +146,15 @@ export function iiifState(manifests: IiifManifests): CompatibilityState {
 }
 
 // Builds the list of NDE criteria for a dataset. The schema-ap-nde row leads,
-// matching the usual order in NDE communication; the IIIF row follows.
+// matching the usual order in NDE communication; the IIIF row follows. Criteria
+// that depend on the dataset’s analysis are dropped when the dataset has not
+// been analyzed; the detail page shows the section whenever any criterion
+// remains.
 export function compatibilityCriteria(
   input: CompatibilityInput,
 ): CompatibilityCriterion[] {
   const schemaApNde = schemaApNdeState(input.schemaApNde);
-  return [
+  const criteria: CompatibilityCriterion[] = [
     {
       key: 'schema-ap-nde',
       state: schemaApNde.state,
@@ -154,4 +167,8 @@ export function compatibilityCriteria(
       count: input.iiif.declared,
     },
   ];
+  return criteria.filter(
+    (criterion) =>
+      input.isAnalyzed || !ANALYSIS_DEPENDENT_CRITERIA.has(criterion.key),
+  );
 }

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -38,6 +38,7 @@
   import {
     displayMissingProperties,
     getRegistrationStatus,
+    isAnalyzed,
   } from '$lib/services/dataset-detail.js';
   import { getRelativeTimeString } from '$lib/utils/relative-time';
   import ClassPropertiesWidget from '$lib/components/ClassPropertiesWidget.svelte';
@@ -1269,7 +1270,11 @@
   {/if}
 
   <!-- NDE compatibility (“vinkjes”) -->
-  <NdeCompatibility {iiifManifests} {schemaApNde} />
+  <NdeCompatibility
+    isAnalyzed={isAnalyzed(summary)}
+    {iiifManifests}
+    {schemaApNde}
+  />
 
   <!-- VoID Summary Section -->
   {#if summary && hasVoidStats}


### PR DESCRIPTION
## What

Gate the individual NDE compatibility checks on the dataset detail page on whether the dataset has been **analyzed** by the Dataset Knowledge Graph (DKG), rather than always rendering them.

## Why

The SCHEMA-AP-NDE and IIIF criteria are derived from the DKG’s analysis of the dataset’s RDF. For a dataset the DKG has not analyzed (for example a non-RDF dataset), there is nothing to assess for those checks.

## How

- Add an `isAnalyzed(summary)` helper in `dataset-detail.ts`. The DKG produces a VoID summary only once it has crawled a dataset, so the presence of that summary signals the dataset was analyzed.
- Mark SCHEMA-AP-NDE and IIIF as analysis-dependent and drop them from the criteria list when the dataset is not analyzed, instead of hiding the whole section.
- Show the section whenever any criterion remains. A future criterion that applies to any dataset (regardless of analysis) will keep the section visible and show itself even for non-analyzed datasets.

## Out of scope

The per-criterion state logic is unchanged. An analyzed dataset that has no IIIF media, or that uses a different data model than SCHEMA-AP-NDE, keeps its neutral grey state – those are legitimate, non-failure situations and are not shown as red.
