### PR TITLE
feat(browser): link registration NDE compatibility item to its section

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -255,6 +255,7 @@
   "nde_compat_registration_explanation_registered": "This dataset’s description is registered in the Dataset Register, so it can be found and reused.",
   "nde_compat_registration_explanation_gone": "The registration URL is no longer accessible, so the description can no longer be retrieved.",
   "nde_compat_registration_explanation_invalid": "The description no longer conforms to the requirements for datasets.",
+  "nde_compat_registration_view_details": "View registration details",
   "nde_compat_schema_ap_nde_heading_conforms": "Conforms to the NDE Schema.org Application Profile",
   "nde_compat_schema_ap_nde_heading_not_conforms": "Does not conform to the NDE Schema.org Application Profile",
   "nde_compat_schema_ap_nde_heading_not_applicable": "The NDE Schema.org Application Profile does not apply",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -255,6 +255,7 @@
   "nde_compat_registration_explanation_registered": "De beschrijving van deze dataset is geregistreerd in het Datasetregister, zodat de dataset vindbaar en herbruikbaar is.",
   "nde_compat_registration_explanation_gone": "De registratie-URL is niet meer toegankelijk, dus de beschrijving kan niet meer worden opgehaald.",
   "nde_compat_registration_explanation_invalid": "De beschrijving voldoet niet meer aan de eisen voor datasets.",
+  "nde_compat_registration_view_details": "Bekijk registratiegegevens",
   "nde_compat_schema_ap_nde_heading_conforms": "Voldoet aan het NDE Schema.org-applicatieprofiel",
   "nde_compat_schema_ap_nde_heading_not_conforms": "Voldoet niet aan het NDE Schema.org-applicatieprofiel",
   "nde_compat_schema_ap_nde_heading_not_applicable": "Het NDE Schema.org-applicatieprofiel is niet van toepassing",

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -137,6 +137,13 @@
         return NDE_VINKJES_URL;
     }
   }
+
+  // The registration criterion links to the Registration section further down
+  // the same page, where the registration URL, status and date are listed. Other
+  // criteria have no such in-page counterpart.
+  function detailsAnchor(criterion: CompatibilityCriterion): string | null {
+    return criterion.key === 'registration' ? '#registration' : null;
+  }
 </script>
 
 <!-- Analysis-dependent criteria are dropped for a dataset that has not been
@@ -198,6 +205,14 @@
                   {m.nde_compat_learn_more()}
                   <span class="sr-only"> ({m.opens_in_new_tab()})</span>
                 </a>
+                {#if detailsAnchor(criterion)}
+                  <a
+                    href={detailsAnchor(criterion)}
+                    class="text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {m.nde_compat_registration_view_details()}
+                  </a>
+                {/if}
               </p>
               {#if detail(criterion)}
                 <p

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -1542,7 +1542,10 @@
 
   <!-- Registration Section -->
   <div class="mb-8">
-    <h2 class="mb-4 text-xl font-semibold text-gray-900 dark:text-white">
+    <h2
+      id="registration"
+      class="mb-4 scroll-mt-4 text-xl font-semibold text-gray-900 dark:text-white"
+    >
       {m.detail_registration()}
     </h2>
     <div


### PR DESCRIPTION
Links the registration row in the NDE compatibility (“vinkjes”) section to the Registration section further down the dataset detail page, where the registration URL, status and date are listed.

## Changes

- Anchor the Registration section heading with `id="registration"` (plus `scroll-mt-4` so the heading isn’t flush against the viewport top after the jump).
- Add a `detailsAnchor()` helper in `NdeCompatibility.svelte` that returns `#registration` for the registration criterion only, and render a `View registration details` in-page link next to the existing `Learn more` link.
- Add the `nde_compat_registration_view_details` message in English and Dutch.
