### PR TITLE
feat(browser): add Linked data NDE compatibility item

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -255,13 +255,30 @@
   "nde_compat_registration_explanation_registered": "This dataset’s description is registered in the Dataset Register, so it can be found and reused.",
   "nde_compat_registration_explanation_gone": "The registration URL is no longer accessible, so the description can no longer be retrieved.",
   "nde_compat_registration_explanation_invalid": "The description no longer conforms to the requirements for datasets.",
-  "nde_compat_schema_ap_nde_heading_conforms": "Conforms to the NDE Schema.org Application Profile",
-  "nde_compat_schema_ap_nde_heading_not_conforms": "Does not conform to the NDE Schema.org Application Profile",
-  "nde_compat_schema_ap_nde_heading_not_applicable": "The NDE Schema.org Application Profile does not apply",
-  "nde_compat_schema_ap_nde_explanation_conforms": "No violations were found in a sample of this dataset.",
-  "nde_compat_schema_ap_nde_explanation_violations": "At least one sampled resource violated the NDE Schema.org Application Profile.",
-  "nde_compat_schema_ap_nde_explanation_declared_but_empty": "This dataset declares conformance to the NDE Schema.org Application Profile, but none of its resources use the profile’s classes.",
-  "nde_compat_schema_ap_nde_explanation_not_applicable": "This dataset uses a different data model, so the profile does not apply.",
+  "nde_compat_linked_data_heading_conforms": "Provides linked data conforming to the NDE Application Profile",
+  "nde_compat_linked_data_heading_not_conforms": "Provides linked data",
+  "nde_compat_linked_data_heading_pending": "Linked data not yet assessed",
+  "nde_compat_linked_data_heading_none": "Does not provide linked data",
+  "nde_compat_linked_data_heading_empty": "Could not retrieve linked data",
+  "nde_compat_linked_data_explanation_conforms": "This dataset provides linked data conforming to the NDE Schema.org Application Profile, making the data easy to find and reuse.",
+  "nde_compat_linked_data_explanation_not_conforms": "This dataset provides linked data, but it does not yet conform to the NDE Schema.org Application Profile.",
+  "nde_compat_linked_data_explanation_pending": "This dataset provides linked data. Its content has not been assessed yet.",
+  "nde_compat_linked_data_explanation_none": "This dataset provides no linked data, which makes the data harder to reuse.",
+  "nde_compat_linked_data_explanation_empty": "This dataset declares linked data, but its content could not be retrieved.",
+  "nde_compat_linked_data_count": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{display} fact found.",
+        "countPlural=other": "{display} facts found."
+      }
+    }
+  ],
   "nde_compat_iiif_heading_provided": "Provides IIIF media",
   "nde_compat_iiif_heading_not_provided": "Does not provide IIIF media",
   "nde_compat_iiif_heading_unavailable": "IIIF media unavailable",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -255,13 +255,30 @@
   "nde_compat_registration_explanation_registered": "De beschrijving van deze dataset is geregistreerd in het Datasetregister, zodat de dataset vindbaar en herbruikbaar is.",
   "nde_compat_registration_explanation_gone": "De registratie-URL is niet meer toegankelijk, dus de beschrijving kan niet meer worden opgehaald.",
   "nde_compat_registration_explanation_invalid": "De beschrijving voldoet niet meer aan de eisen voor datasets.",
-  "nde_compat_schema_ap_nde_heading_conforms": "Voldoet aan het NDE Schema.org-applicatieprofiel",
-  "nde_compat_schema_ap_nde_heading_not_conforms": "Voldoet niet aan het NDE Schema.org-applicatieprofiel",
-  "nde_compat_schema_ap_nde_heading_not_applicable": "Het NDE Schema.org-applicatieprofiel is niet van toepassing",
-  "nde_compat_schema_ap_nde_explanation_conforms": "Er zijn geen overtredingen gevonden in een steekproef van deze dataset.",
-  "nde_compat_schema_ap_nde_explanation_violations": "Ten minste één gecontroleerde resource voldeed niet aan het NDE Schema.org-applicatieprofiel.",
-  "nde_compat_schema_ap_nde_explanation_declared_but_empty": "Deze dataset geeft aan te voldoen aan het NDE Schema.org-applicatieprofiel, maar geen van de resources gebruikt de klassen van het profiel.",
-  "nde_compat_schema_ap_nde_explanation_not_applicable": "Deze dataset gebruikt een ander datamodel, dus het profiel is niet van toepassing.",
+  "nde_compat_linked_data_heading_conforms": "Biedt linked data volgens het NDE-applicatieprofiel",
+  "nde_compat_linked_data_heading_not_conforms": "Biedt linked data",
+  "nde_compat_linked_data_heading_pending": "Linked data nog niet beoordeeld",
+  "nde_compat_linked_data_heading_none": "Biedt geen linked data",
+  "nde_compat_linked_data_heading_empty": "Kon geen linked data ophalen",
+  "nde_compat_linked_data_explanation_conforms": "Deze dataset biedt linked data die voldoet aan het NDE Schema.org-applicatieprofiel, zodat de gegevens goed vindbaar en herbruikbaar zijn.",
+  "nde_compat_linked_data_explanation_not_conforms": "Deze dataset biedt linked data, maar deze voldoet nog niet aan het NDE Schema.org-applicatieprofiel.",
+  "nde_compat_linked_data_explanation_pending": "Deze dataset biedt linked data. De inhoud is nog niet beoordeeld.",
+  "nde_compat_linked_data_explanation_none": "Deze dataset biedt geen linked data, waardoor de gegevens minder goed herbruikbaar zijn.",
+  "nde_compat_linked_data_explanation_empty": "Deze dataset geeft linked data op, maar de inhoud kon niet worden opgehaald.",
+  "nde_compat_linked_data_count": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{display} feit gevonden.",
+        "countPlural=other": "{display} feiten gevonden."
+      }
+    }
+  ],
   "nde_compat_iiif_heading_provided": "Biedt IIIF-media",
   "nde_compat_iiif_heading_not_provided": "Biedt geen IIIF-media",
   "nde_compat_iiif_heading_unavailable": "IIIF-media niet beschikbaar",

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -4,6 +4,7 @@
   import { Tooltip } from 'flowbite-svelte';
   import CheckOutline from 'flowbite-svelte-icons/CheckOutline.svelte';
   import CloseOutline from 'flowbite-svelte-icons/CloseOutline.svelte';
+  import ExclamationCircleOutline from 'flowbite-svelte-icons/ExclamationCircleOutline.svelte';
   import InfoCircleSolid from 'flowbite-svelte-icons/InfoCircleSolid.svelte';
   import {
     compatibilityCriteria,
@@ -11,27 +12,27 @@
     SCHEMA_AP_NDE_PROFILE,
     type CompatibilityCriterion,
     type IiifManifests,
+    type LinkedData,
     type RegistrationFailureReason,
-    type SchemaApNdeConformance,
   } from '$lib/services/nde-compatibility';
 
   let {
     isAnalyzed,
     registrationStatus,
     iiifManifests,
-    schemaApNde,
+    linkedData,
   }: {
     isAnalyzed: boolean;
     registrationStatus: RegistrationFailureReason | null;
     iiifManifests: IiifManifests;
-    schemaApNde: SchemaApNdeConformance;
+    linkedData: LinkedData;
   } = $props();
 
   const criteria = $derived(
     compatibilityCriteria({
       isAnalyzed,
       registration: registrationStatus,
-      schemaApNde,
+      linkedData,
       iiif: iiifManifests,
     }),
   );
@@ -50,14 +51,18 @@
           default:
             return m.nde_compat_registration_heading_registered();
         }
-      case 'schema-ap-nde':
+      case 'linked-data':
         switch (criterion.state) {
           case 'met':
-            return m.nde_compat_schema_ap_nde_heading_conforms();
-          case 'failed':
-            return m.nde_compat_schema_ap_nde_heading_not_conforms();
+            return m.nde_compat_linked_data_heading_conforms();
+          case 'warning':
+            return m.nde_compat_linked_data_heading_not_conforms();
           case 'unmet':
-            return m.nde_compat_schema_ap_nde_heading_not_applicable();
+            return m.nde_compat_linked_data_heading_pending();
+          case 'failed':
+            return criterion.reason === 'empty'
+              ? m.nde_compat_linked_data_heading_empty()
+              : m.nde_compat_linked_data_heading_none();
         }
       // eslint-disable-next-line no-fallthrough
       case 'iiif':
@@ -66,7 +71,8 @@
             return m.nde_compat_iiif_heading_provided();
           case 'failed':
             return m.nde_compat_iiif_heading_unavailable();
-          case 'unmet':
+          // IIIF has no warning tier; unmet means no media.
+          default:
             return m.nde_compat_iiif_heading_not_provided();
         }
     }
@@ -83,16 +89,18 @@
           default:
             return m.nde_compat_registration_explanation_registered();
         }
-      case 'schema-ap-nde':
+      case 'linked-data':
         switch (criterion.state) {
           case 'met':
-            return m.nde_compat_schema_ap_nde_explanation_conforms();
-          case 'failed':
-            return criterion.reason === 'declared-but-empty'
-              ? m.nde_compat_schema_ap_nde_explanation_declared_but_empty()
-              : m.nde_compat_schema_ap_nde_explanation_violations();
+            return m.nde_compat_linked_data_explanation_conforms();
+          case 'warning':
+            return m.nde_compat_linked_data_explanation_not_conforms();
           case 'unmet':
-            return m.nde_compat_schema_ap_nde_explanation_not_applicable();
+            return m.nde_compat_linked_data_explanation_pending();
+          case 'failed':
+            return criterion.reason === 'empty'
+              ? m.nde_compat_linked_data_explanation_empty()
+              : m.nde_compat_linked_data_explanation_none();
         }
       // eslint-disable-next-line no-fallthrough
       case 'iiif':
@@ -112,16 +120,21 @@
       case 'registration':
         // The registration criterion carries no count.
         return null;
-      case 'schema-ap-nde':
-        // No raw counts for the profile criterion in this version.
-        return null;
+      case 'linked-data':
+        // The fact count (void:triples) is shown only when the dataset actually
+        // has linked data with a known triple count.
+        return (criterion.state === 'met' || criterion.state === 'warning') &&
+          count > 0
+          ? m.nde_compat_linked_data_count({ count, display })
+          : null;
       case 'iiif':
         switch (criterion.state) {
           case 'met':
             return m.nde_compat_iiif_count({ count, display });
           case 'failed':
             return m.nde_compat_iiif_count_failed({ count, display });
-          case 'unmet':
+          // IIIF has no warning tier; unmet carries no count.
+          default:
             return null;
         }
     }
@@ -131,7 +144,7 @@
     switch (criterion.key) {
       case 'registration':
         return NDE_VINKJES_URL;
-      case 'schema-ap-nde':
+      case 'linked-data':
         return SCHEMA_AP_NDE_PROFILE;
       case 'iiif':
         return NDE_VINKJES_URL;
@@ -163,22 +176,26 @@
       <ul class="divide-y divide-gray-200 dark:divide-gray-700">
         {#each criteria as criterion (criterion.key)}
           <li class="flex items-start gap-3 px-4 py-3">
-            <!-- Status box. Green tick = met, red cross = declared but broken,
-               neutral empty = not provided (a legitimate, non-failure state).
-               The heading carries the status for assistive technology, so the
-               box is decorative. -->
+            <!-- Status box. Green tick = met, orange exclamation = warning, red
+               cross = error, neutral empty = pending or not applicable. The
+               heading carries the status for assistive technology, so the box is
+               decorative. -->
             <span
               class={`mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded border ${
                 criterion.state === 'met'
                   ? 'border-green-600 bg-green-600 text-white dark:border-green-500 dark:bg-green-500'
-                  : criterion.state === 'failed'
-                    ? 'border-red-600 bg-red-600 text-white dark:border-red-500 dark:bg-red-500'
-                    : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-700'
+                  : criterion.state === 'warning'
+                    ? 'border-orange-500 bg-orange-500 text-white dark:border-orange-400 dark:bg-orange-400'
+                    : criterion.state === 'failed'
+                      ? 'border-red-600 bg-red-600 text-white dark:border-red-500 dark:bg-red-500'
+                      : 'border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-700'
               }`}
               aria-hidden="true"
             >
               {#if criterion.state === 'met'}
                 <CheckOutline class="h-3.5 w-3.5" />
+              {:else if criterion.state === 'warning'}
+                <ExclamationCircleOutline class="h-3.5 w-3.5" />
               {:else if criterion.state === 'failed'}
                 <CloseOutline class="h-3.5 w-3.5" />
               {/if}

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -19,6 +19,7 @@ import {
   type LinkedData,
 } from './nde-compatibility.js';
 import { offersLinkedData } from '$lib/utils/distribution';
+import { normalizeMediaType } from '$lib/utils/sparql';
 import { getLocale } from '$lib/paraglide/runtime';
 import { REGISTRATION_STATUS_BASE_URI } from '@dataset-register/core/constants';
 import {
@@ -646,7 +647,7 @@ export async function fetchDatasetDetail(
         dcat:accessURL ?accessURL ;
         foaf:page ?landingPage ;
         dct:description ?description ;
-        dcat:mediaType ?rawMediaType ;
+        dcat:mediaType ?mediaType ;
         dct:format ?format ;
         dct:issued ?issued ;
         dct:modified ?modified ;
@@ -660,7 +661,10 @@ export async function fetchDatasetDetail(
         ?distribution dcat:accessURL ?accessURL .
         OPTIONAL { ?distribution foaf:page ?landingPage }
         OPTIONAL { ?distribution dct:description ?description }
-        OPTIONAL { ?distribution dcat:mediaType ?rawMediaType }
+        OPTIONAL {
+          ?distribution dcat:mediaType ?rawMediaType .
+          ${normalizeMediaType('?rawMediaType', '?mediaType')}
+        }
         OPTIONAL { ?distribution dct:format ?format }
         OPTIONAL { ?distribution dct:issued ?issued }
         OPTIONAL { ?distribution dct:modified ?modified }

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -15,10 +15,10 @@ import { shortenUri } from '$lib/utils/prefix';
 import { isUri, lookupTermLabels } from './network-of-terms.js';
 import {
   IIIF_PRESENTATION_API,
-  SCHEMA_AP_NDE_PROFILE,
   type IiifManifests,
-  type SchemaApNdeConformance,
+  type LinkedData,
 } from './nde-compatibility.js';
+import { offersLinkedData } from '$lib/utils/distribution';
 import { getLocale } from '$lib/paraglide/runtime';
 import { REGISTRATION_STATUS_BASE_URI } from '@dataset-register/core/constants';
 import {
@@ -383,7 +383,7 @@ export interface DatasetDetailResult {
   linksets: Linkset[];
   temporalCoverages: TemporalCoverage[];
   iiifManifests: IiifManifests;
-  schemaApNde: SchemaApNdeConformance;
+  linkedData: LinkedData;
   resolvedTerms: Promise<Record<string, string>>;
 }
 
@@ -453,84 +453,42 @@ async function fetchIiifManifests(datasetUri: string): Promise<IiifManifests> {
   return none;
 }
 
-// Reads the SCHEMA-AP-NDE sample conformance for a dataset: the co-emitted
-// quads-validated count and conformance boolean from the Knowledge Graph, plus
-// whether any distribution declares the profile in the register.
-// quadsValidated/conformant are null when no measurement exists yet.
-async function fetchSchemaApNdeConformance(
+// Reads the SCHEMA-AP-NDE sample conformance boolean for a dataset from the
+// Knowledge Graph. This co-emitted measurement decides whether a dataset that
+// provides linked data conforms to the profile (🟢) or only warns (🟠). Returns
+// null when no conformance measurement exists yet.
+async function fetchSchemaApNdeConformant(
   datasetUri: string,
-): Promise<SchemaApNdeConformance> {
-  const measurementQuery = `
+): Promise<boolean | null> {
+  const query = `
     PREFIX dqv: <http://www.w3.org/ns/dqv#>
     PREFIX nde: <https://def.nde.nl/metric#>
-    SELECT ?quadsValidated ?conformant WHERE {
+    SELECT ?conformant WHERE {
       <${datasetUri}> dqv:hasQualityMeasurement
-        [ dqv:isMeasurementOf nde:quads-validated ; dqv:value ?quadsValidated ] ,
         [ dqv:isMeasurementOf nde:schema-ap-nde-sample-conformance ; dqv:value ?conformant ] .
     }
     LIMIT 1
   `;
-  // The register’s internal model is DCAT: the publisher-facing schema:usageInfo
-  // is normalised to dct:conformsTo on the distribution at ingest, so the claim
-  // is read from dct:conformsTo here. A distribution may carry several values
-  // (e.g. the SPARQL protocol URI alongside the profile), so match the profile
-  // URI specifically.
-  const declarationQuery = `
-    PREFIX dcat: <http://www.w3.org/ns/dcat#>
-    PREFIX dct: <http://purl.org/dc/terms/>
-    ASK {
-      GRAPH ?g {
-        <${datasetUri}> dcat:distribution/dct:conformsTo <${SCHEMA_AP_NDE_PROFILE}> .
-      }
+  try {
+    const bindingsStream = await fetcher.fetchBindings(
+      PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+      query,
+    );
+    for await (const raw of bindingsStream) {
+      const binding = raw as unknown as {
+        conformant?: { value: string };
+      };
+      return binding.conformant?.value
+        ? binding.conformant.value === 'true'
+        : null;
     }
-  `;
-
-  const measurement = (async () => {
-    try {
-      const bindingsStream = await fetcher.fetchBindings(
-        PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
-        measurementQuery,
-      );
-      for await (const raw of bindingsStream) {
-        const binding = raw as unknown as {
-          quadsValidated?: { value: string };
-          conformant?: { value: string };
-        };
-        return {
-          quadsValidated: binding.quadsValidated?.value
-            ? parseInt(binding.quadsValidated.value, 10)
-            : null,
-          conformant: binding.conformant?.value
-            ? binding.conformant.value === 'true'
-            : null,
-        };
-      }
-    } catch (e: unknown) {
-      console.error(
-        'SCHEMA-AP-NDE conformance query failed:',
-        e instanceof Error ? e.message : e,
-      );
-    }
-    return { quadsValidated: null, conformant: null };
-  })();
-
-  const declaresProfile = (async () => {
-    try {
-      return await fetcher.fetchAsk(PUBLIC_SPARQL_ENDPOINT, declarationQuery);
-    } catch (e: unknown) {
-      console.error(
-        'SCHEMA-AP-NDE conformsTo query failed:',
-        e instanceof Error ? e.message : e,
-      );
-      return false;
-    }
-  })();
-
-  const [{ quadsValidated, conformant }, declares] = await Promise.all([
-    measurement,
-    declaresProfile,
-  ]);
-  return { quadsValidated, conformant, declaresProfile: declares };
+  } catch (e: unknown) {
+    console.error(
+      'SCHEMA-AP-NDE conformance query failed:',
+      e instanceof Error ? e.message : e,
+    );
+  }
+  return null;
 }
 
 async function fetchDistributionCount(query: string): Promise<number> {
@@ -732,7 +690,7 @@ export async function fetchDatasetDetail(
     classPartitionResult,
     temporalCoverages,
     iiifManifests,
-    schemaApNde,
+    schemaApNdeConformant,
   ] = await Promise.all([
     detailLens.query(datasetQuery),
     distributionLens.query(distributionQuery),
@@ -748,7 +706,7 @@ export async function fetchDatasetDetail(
     classPartitionLens.findByIri(datasetUri),
     fetchTemporalCoverage(datasetUri),
     fetchIiifManifests(datasetUri),
-    fetchSchemaApNdeConformance(datasetUri),
+    fetchSchemaApNdeConformant(datasetUri),
   ]);
 
   const dataset = datasets.find((d) => d.$id === datasetUri) ?? datasets[0];
@@ -763,6 +721,18 @@ export async function fetchDatasetDetail(
         classPartition: classPartitionResult?.classPartition ?? null,
       }
     : null;
+
+  // The Linked data criterion: whether a linked-data distribution is declared in
+  // the register (reusing the same RDF notion as the search facet, over the
+  // distributions already loaded), whether the Knowledge Graph produced a
+  // void:Dataset with content, and whether that content conforms to SCHEMA-AP-NDE.
+  const linkedData: LinkedData = {
+    declared: offersLinkedData(distributions),
+    hasVoidDataset: summaryWithClassPartition !== null,
+    hasContent: hasLinkedDataContent(summaryWithClassPartition),
+    conformant: schemaApNdeConformant,
+    triples: summaryWithClassPartition?.triples ?? null,
+  };
 
   // Resolve term URIs (e.g. spatial/temporal) to human-readable labels
   // via the Network of Terms API. Returned as an unawaited promise so
@@ -790,7 +760,7 @@ export async function fetchDatasetDetail(
     linksets,
     temporalCoverages,
     iiifManifests,
-    schemaApNde,
+    linkedData,
     resolvedTerms,
   };
 }
@@ -801,6 +771,19 @@ export async function fetchDatasetDetail(
 // assessed from that analysis, so they are only shown for an analyzed dataset.
 export function isAnalyzed(summary: DatasetSummary | null): boolean {
   return summary !== null;
+}
+
+// Whether the Knowledge Graph extracted any linked-data content for the dataset.
+// A composite test rather than void:triples alone: large datasets can have a
+// full class partition (or distinct subjects) yet a missing triples aggregate,
+// so any of the three signals counts as content.
+export function hasLinkedDataContent(summary: DatasetSummary | null): boolean {
+  return (
+    summary !== null &&
+    ((summary.triples ?? 0) > 0 ||
+      (summary.classPartition?.length ?? 0) > 0 ||
+      (summary.distinctSubjects ?? 0) > 0)
+  );
 }
 
 export function displayMissingProperties(ratingExplanation: string): string[] {

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -2,16 +2,20 @@ import { describe, expect, it } from 'vitest';
 import {
   compatibilityCriteria,
   iiifState,
+  linkedDataState,
   registrationState,
   schemaApNdeState,
-  type SchemaApNdeConformance,
+  type LinkedData,
 } from './nde-compatibility';
 
-// A neutral conformance fixture for tests that focus on another criterion.
-const noSchemaApNde: SchemaApNdeConformance = {
-  quadsValidated: null,
+// A neutral linked-data fixture for tests that focus on another criterion: no
+// distribution declared and nothing analyzed yet.
+const noLinkedData: LinkedData = {
+  declared: false,
+  hasVoidDataset: false,
+  hasContent: false,
   conformant: null,
-  declaresProfile: false,
+  triples: null,
 };
 
 describe('iiifState', () => {
@@ -116,6 +120,93 @@ describe('schemaApNdeState', () => {
   });
 });
 
+describe('linkedDataState', () => {
+  it('is met when content conforms to the profile', () => {
+    expect(
+      linkedDataState({
+        declared: true,
+        hasVoidDataset: true,
+        hasContent: true,
+        conformant: true,
+        triples: 1000,
+      }),
+    ).toEqual({ state: 'met' });
+  });
+
+  it('is a warning when content does not (yet) conform', () => {
+    expect(
+      linkedDataState({
+        declared: true,
+        hasVoidDataset: true,
+        hasContent: true,
+        conformant: false,
+        triples: 1000,
+      }),
+    ).toEqual({ state: 'warning' });
+    // No conformance measurement yet still warns: there is content, just no
+    // confirmation it conforms.
+    expect(
+      linkedDataState({
+        declared: true,
+        hasVoidDataset: true,
+        hasContent: true,
+        conformant: null,
+        triples: 1000,
+      }),
+    ).toEqual({ state: 'warning' });
+  });
+
+  it('lets content win even when no distribution was detected in the register', () => {
+    // The detail page loads a bounded set of distributions, so `declared` can be
+    // a false negative; extracted content is authoritative.
+    expect(
+      linkedDataState({
+        declared: false,
+        hasVoidDataset: true,
+        hasContent: true,
+        conformant: true,
+        triples: 1000,
+      }),
+    ).toEqual({ state: 'met' });
+  });
+
+  it('is failed/no-linked-data when nothing is declared and there is no content', () => {
+    expect(
+      linkedDataState({
+        declared: false,
+        hasVoidDataset: false,
+        hasContent: false,
+        conformant: null,
+        triples: null,
+      }),
+    ).toEqual({ state: 'failed', reason: 'no-linked-data' });
+  });
+
+  it('is unmet (pending) when declared but not yet analyzed', () => {
+    expect(
+      linkedDataState({
+        declared: true,
+        hasVoidDataset: false,
+        hasContent: false,
+        conformant: null,
+        triples: null,
+      }),
+    ).toEqual({ state: 'unmet' });
+  });
+
+  it('is failed/empty when declared and analyzed but no content was extracted', () => {
+    expect(
+      linkedDataState({
+        declared: true,
+        hasVoidDataset: true,
+        hasContent: false,
+        conformant: null,
+        triples: null,
+      }),
+    ).toEqual({ state: 'failed', reason: 'empty' });
+  });
+});
+
 describe('registrationState', () => {
   it('is met when the dataset is registered and valid', () => {
     expect(registrationState(null)).toEqual({ state: 'met' });
@@ -142,7 +233,7 @@ describe('compatibilityCriteria', () => {
     const [, , iiif] = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
-      schemaApNde: noSchemaApNde,
+      linkedData: noLinkedData,
       iiif: { declared: 4152, sampled: 10, validated: 0 },
     });
     expect(iiif.key).toBe('iiif');
@@ -154,7 +245,7 @@ describe('compatibilityCriteria', () => {
     const [registration] = compatibilityCriteria({
       isAnalyzed: true,
       registration: 'gone',
-      schemaApNde: noSchemaApNde,
+      linkedData: noLinkedData,
       iiif: { declared: 0, sampled: null, validated: null },
     });
     expect(registration.key).toBe('registration');
@@ -162,20 +253,40 @@ describe('compatibilityCriteria', () => {
     expect(registration.reason).toBe('gone');
   });
 
-  it('carries the schema-ap-nde failure reason on the second criterion', () => {
-    const [, schemaApNde] = compatibilityCriteria({
+  it('exposes the linked-data state and fact count on the second criterion', () => {
+    const [, linkedData] = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
-      schemaApNde: {
-        quadsValidated: 0,
-        conformant: false,
-        declaresProfile: true,
+      linkedData: {
+        declared: true,
+        hasVoidDataset: true,
+        hasContent: true,
+        conformant: true,
+        triples: 1234,
       },
       iiif: { declared: 0, sampled: null, validated: null },
     });
-    expect(schemaApNde.key).toBe('schema-ap-nde');
-    expect(schemaApNde.state).toBe('failed');
-    expect(schemaApNde.reason).toBe('declared-but-empty');
+    expect(linkedData.key).toBe('linked-data');
+    expect(linkedData.state).toBe('met');
+    expect(linkedData.count).toBe(1234);
+  });
+
+  it('carries the linked-data failure reason on the second criterion', () => {
+    const [, linkedData] = compatibilityCriteria({
+      isAnalyzed: true,
+      registration: null,
+      linkedData: {
+        declared: true,
+        hasVoidDataset: true,
+        hasContent: false,
+        conformant: null,
+        triples: null,
+      },
+      iiif: { declared: 0, sampled: null, validated: null },
+    });
+    expect(linkedData.key).toBe('linked-data');
+    expect(linkedData.state).toBe('failed');
+    expect(linkedData.reason).toBe('empty');
   });
 
   it('renders all three criteria regardless of state for an analyzed dataset', () => {
@@ -183,26 +294,28 @@ describe('compatibilityCriteria', () => {
       compatibilityCriteria({
         isAnalyzed: true,
         registration: null,
-        schemaApNde: noSchemaApNde,
+        linkedData: noLinkedData,
         iiif: { declared: 0, sampled: null, validated: null },
       }),
     ).toHaveLength(3);
   });
 
-  it('keeps the registration criterion when the dataset is not analyzed', () => {
-    // The analysis-dependent criteria are dropped, but registration applies to
-    // any dataset, so it remains and keeps the section visible.
+  it('keeps the foundational criteria when the dataset is not analyzed', () => {
+    // The analysis-dependent IIIF criterion is dropped, but registration and
+    // linked data are foundational, so they remain and keep the section visible.
     expect(
       compatibilityCriteria({
         isAnalyzed: false,
         registration: null,
-        schemaApNde: {
-          quadsValidated: 200,
-          conformant: true,
-          declaresProfile: true,
+        linkedData: {
+          declared: true,
+          hasVoidDataset: false,
+          hasContent: false,
+          conformant: null,
+          triples: null,
         },
         iiif: { declared: 4152, sampled: 10, validated: 8 },
       }).map((criterion) => criterion.key),
-    ).toEqual(['registration']);
+    ).toEqual(['registration', 'linked-data']);
   });
 });

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -37,26 +37,26 @@ export const QUADS_VALIDATED_METRIC =
   'https://def.nde.nl/metric#quads-validated';
 
 // The registration criterion leads — every registered dataset has it, so it
-// anchors the section regardless of analysis. The schema-ap-nde criterion is
+// anchors the section regardless of analysis. The linked-data criterion is
 // ordered before iiif, matching the usual order in NDE communication.
-export type CompatibilityCriterionKey =
-  | 'registration'
-  | 'schema-ap-nde'
-  | 'iiif';
+export type CompatibilityCriterionKey = 'registration' | 'linked-data' | 'iiif';
 
 // Criteria that can only be assessed from the dataset’s analysis in the Dataset
-// Knowledge Graph, so they are shown only for an analyzed dataset. Registration
-// is left out: it applies to any dataset, is always shown, and so keeps the
-// section visible even for a dataset that has not been analyzed.
+// Knowledge Graph, so they are shown only for an analyzed dataset. The
+// foundational criteria (registration, linked data) are left out: they apply to
+// any dataset, are always shown, and so keep the section visible even for a
+// dataset that has not been analyzed.
 const ANALYSIS_DEPENDENT_CRITERIA: ReadonlySet<CompatibilityCriterionKey> =
-  new Set(['schema-ap-nde', 'iiif']);
+  new Set(['iiif']);
 
-// 'met'    — the dataset provides working media (validated, or declared with no
-//            evidence of failure).
-// 'failed' — the dataset declares media, but every sampled manifest failed to
-//            load (declared but broken).
-// 'unmet'  — the dataset declares no media. A legitimate, neutral state.
-export type CompatibilityState = 'met' | 'failed' | 'unmet';
+// The four assessment tiers a criterion can take. Not every criterion uses all
+// of them (IIIF, for instance, has no 'warning'):
+// 'met'     — 🟢 good.
+// 'warning' — 🟠 present but not (yet) up to the recommended standard.
+// 'failed'  — 🔴 error.
+// 'unmet'   — ⚪ neutral. Either pending (will still be assessed) or, for IIIF,
+//             not applicable.
+export type CompatibilityState = 'met' | 'warning' | 'failed' | 'unmet';
 
 // Why a registration criterion is in the `failed` state, mirroring the dataset’s
 // status in the register:
@@ -64,17 +64,29 @@ export type CompatibilityState = 'met' | 'failed' | 'unmet';
 // 'invalid' — the description no longer conforms to the requirements.
 export type RegistrationFailureReason = 'gone' | 'invalid';
 
-// Why a criterion is in the `failed` state. The schema-ap-nde reasons:
+// Why the linked-data criterion is in the `failed` state:
+// 'no-linked-data' — the register lists no linked-data distribution, so there is
+//                    nothing to assess (“biedt geen linked data”).
+// 'empty'          — a distribution is declared and the dataset was analyzed,
+//                    but the Knowledge Graph extracted no content (“kon geen
+//                    linked data ophalen”).
+export type LinkedDataFailureReason = 'no-linked-data' | 'empty';
+
+// Why the SCHEMA-AP-NDE conformance check (still surfaced on the dataset card)
+// is in the `failed` state:
 // 'violations'         — the sample exercised the profile’s classes but at least
 //                        one sampled resource violated a constraint.
 // 'declared-but-empty' — the dataset declares conformance (a distribution’s
 //                        `dct:conformsTo` points at the profile), yet the
 //                        sample validated zero quads: none of its resources use
 //                        the profile’s classes.
-// The registration reasons ('gone', 'invalid') carry the dataset’s status.
+export type SchemaApNdeFailureReason = 'violations' | 'declared-but-empty';
+
+// Why a criterion is in the `failed` state. The registration reasons ('gone',
+// 'invalid') carry the dataset’s status; the linked-data reasons say why no
+// linked data could be assessed.
 export type CompatibilityFailureReason =
-  | 'violations'
-  | 'declared-but-empty'
+  | LinkedDataFailureReason
   | RegistrationFailureReason;
 
 // IIIF manifest figures from the Knowledge Graph: how many manifests the dataset
@@ -97,6 +109,26 @@ export interface SchemaApNdeConformance {
   declaresProfile: boolean;
 }
 
+// The signals behind the Linked data criterion:
+// 'declared'       — the register lists a linked-data distribution (a SPARQL
+//                    endpoint or RDF download).
+// 'hasVoidDataset' — the Knowledge Graph produced a void:Dataset (the dataset
+//                    was analyzed).
+// 'hasContent'     — that void:Dataset carries extracted content (triples, a
+//                    class partition, or distinct subjects). A composite test:
+//                    large datasets can have a full class partition yet a missing
+//                    void:triples aggregate.
+// 'conformant'     — whether a sampled set of resources conforms to
+//                    SCHEMA-AP-NDE; null when no conformance measurement exists.
+// 'triples'        — void:triples, for the “n feiten” count; null when absent.
+export interface LinkedData {
+  declared: boolean;
+  hasVoidDataset: boolean;
+  hasContent: boolean;
+  conformant: boolean | null;
+  triples: number | null;
+}
+
 export interface CompatibilityCriterion {
   key: CompatibilityCriterionKey;
   state: CompatibilityState;
@@ -111,7 +143,7 @@ export interface CompatibilityInput {
   // The dataset’s registration status: null when registered and valid, or the
   // failure reason when the registration is gone or invalid.
   registration: RegistrationFailureReason | null;
-  schemaApNde: SchemaApNdeConformance;
+  linkedData: LinkedData;
   iiif: IiifManifests;
 }
 
@@ -145,7 +177,7 @@ export function schemaApNdeState(
   conformance: Partial<SchemaApNdeConformance> | undefined | null,
 ): {
   state: CompatibilityState;
-  reason?: CompatibilityFailureReason;
+  reason?: SchemaApNdeFailureReason;
 } {
   const quadsValidated = conformance?.quadsValidated ?? null;
   const conformant = conformance?.conformant ?? null;
@@ -161,6 +193,30 @@ export function schemaApNdeState(
   return declaresProfile
     ? { state: 'failed', reason: 'declared-but-empty' }
     : { state: 'unmet' };
+}
+
+// Derives the Linked data state. Content is the strongest signal: a dataset the
+// Knowledge Graph extracted content from provides linked data whatever the
+// register lists, so conformance to SCHEMA-AP-NDE then splits good (🟢, `met`)
+// from a warning (🟠, content that does not — or does not yet — conform). With no
+// content the criterion is judged from what is declared: nothing declared is a
+// plain `failed`/'no-linked-data'; a declared distribution awaiting analysis is
+// neutral pending (⚪, `unmet`); a declared distribution that was analyzed but
+// yielded no content is `failed`/'empty'.
+export function linkedDataState(linkedData: LinkedData): {
+  state: CompatibilityState;
+  reason?: LinkedDataFailureReason;
+} {
+  if (linkedData.hasContent) {
+    return linkedData.conformant ? { state: 'met' } : { state: 'warning' };
+  }
+  if (!linkedData.declared) {
+    return { state: 'failed', reason: 'no-linked-data' };
+  }
+  if (!linkedData.hasVoidDataset) {
+    return { state: 'unmet' };
+  }
+  return { state: 'failed', reason: 'empty' };
 }
 
 export function iiifState(manifests: IiifManifests): CompatibilityState {
@@ -179,16 +235,16 @@ export function iiifState(manifests: IiifManifests): CompatibilityState {
 }
 
 // Builds the list of NDE criteria for a dataset. The registration row leads — it
-// applies to any dataset, so it anchors the section; the schema-ap-nde row
-// follows, matching the usual order in NDE communication, then IIIF. Criteria
-// that depend on the dataset’s analysis are dropped when the dataset has not
-// been analyzed; the detail page shows the section whenever any criterion
-// remains.
+// applies to any dataset, so it anchors the section; the linked-data row follows,
+// matching the usual order in NDE communication, then IIIF. Both registration
+// and linked data are foundational and always shown; the analysis-dependent IIIF
+// row is dropped when the dataset has not been analyzed. The detail page shows
+// the section whenever any criterion remains.
 export function compatibilityCriteria(
   input: CompatibilityInput,
 ): CompatibilityCriterion[] {
   const registration = registrationState(input.registration);
-  const schemaApNde = schemaApNdeState(input.schemaApNde);
+  const linkedData = linkedDataState(input.linkedData);
   const criteria: CompatibilityCriterion[] = [
     {
       key: 'registration',
@@ -197,10 +253,10 @@ export function compatibilityCriteria(
       reason: registration.reason,
     },
     {
-      key: 'schema-ap-nde',
-      state: schemaApNde.state,
-      count: 0,
-      reason: schemaApNde.reason,
+      key: 'linked-data',
+      state: linkedData.state,
+      count: input.linkedData.triples ?? 0,
+      reason: linkedData.reason,
     },
     {
       key: 'iiif',

--- a/apps/browser/src/lib/utils/distribution.test.ts
+++ b/apps/browser/src/lib/utils/distribution.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isRdfDistribution,
+  isSparqlDistribution,
+  offersLinkedData,
+  SPARQL_PROTOCOL,
+} from './distribution';
+
+describe('isSparqlDistribution', () => {
+  it('is true when conformsTo lists the SPARQL 1.1 Protocol', () => {
+    expect(isSparqlDistribution({ conformsTo: [SPARQL_PROTOCOL] })).toBe(true);
+    // The protocol URI may sit alongside other conformance claims.
+    expect(
+      isSparqlDistribution({
+        conformsTo: [
+          'https://www.w3.org/TR/rdf-sparql-query/',
+          SPARQL_PROTOCOL,
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('is false without the protocol or without conformsTo', () => {
+    expect(isSparqlDistribution({ conformsTo: ['http://example.org/x'] })).toBe(
+      false,
+    );
+    expect(isSparqlDistribution({})).toBe(false);
+  });
+});
+
+describe('isRdfDistribution', () => {
+  it('is true for a bare RDF media type', () => {
+    expect(isRdfDistribution({ mediaType: 'text/turtle' })).toBe(true);
+    expect(isRdfDistribution({ mediaType: 'application/ld+json' })).toBe(true);
+    expect(isRdfDistribution({ mediaType: 'application/n-triples+gzip' })).toBe(
+      true,
+    );
+  });
+
+  it('is false for a non-RDF media type or none', () => {
+    expect(isRdfDistribution({ mediaType: 'text/xml' })).toBe(false);
+    expect(isRdfDistribution({ mediaType: null })).toBe(false);
+    expect(isRdfDistribution({})).toBe(false);
+  });
+
+  it('expects normalized media types, not raw IANA IRIs', () => {
+    // Media types are normalized to their bare form upstream by the card and
+    // detail SPARQL queries (normalizeMediaType), so the helper deliberately
+    // matches only bare types. A raw IANA IRI here means normalization was
+    // skipped — which is the bug this contract guards against.
+    expect(
+      isRdfDistribution({
+        mediaType: 'https://www.iana.org/assignments/media-types/text/turtle',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('offersLinkedData', () => {
+  it('is true when any distribution is a SPARQL endpoint or RDF download', () => {
+    expect(
+      offersLinkedData([
+        { mediaType: 'text/csv' },
+        { mediaType: 'text/turtle' },
+      ]),
+    ).toBe(true);
+    expect(
+      offersLinkedData([
+        { mediaType: 'application/zip' },
+        { conformsTo: [SPARQL_PROTOCOL] },
+      ]),
+    ).toBe(true);
+  });
+
+  it('is false when no distribution offers linked data', () => {
+    expect(
+      offersLinkedData([
+        { mediaType: 'text/csv' },
+        { mediaType: 'application/zip' },
+      ]),
+    ).toBe(false);
+    expect(offersLinkedData([])).toBe(false);
+  });
+});

--- a/apps/browser/src/lib/utils/distribution.ts
+++ b/apps/browser/src/lib/utils/distribution.ts
@@ -1,0 +1,42 @@
+import { RDF_MEDIA_TYPES } from '$lib/constants';
+
+// A SPARQL endpoint declares the SPARQL 1.1 Protocol via dct:conformsTo. The
+// dataset detail page and the Dataset Knowledge Graph selector use the same URI.
+export const SPARQL_PROTOCOL = 'https://www.w3.org/TR/sparql11-protocol/';
+
+// The fields shared by the card and detail distribution schemas that determine
+// whether a distribution offers linked data. Kept structural so both the
+// (limited) detail distributions and any other distribution shape can be tested.
+export interface DistributionLike {
+  mediaType?: string | null;
+  conformsTo?: readonly string[];
+}
+
+// Whether the distribution is a SPARQL endpoint.
+export function isSparqlDistribution(distribution: DistributionLike): boolean {
+  return distribution.conformsTo?.includes(SPARQL_PROTOCOL) ?? false;
+}
+
+// Whether the distribution is an RDF download, by its media type. Mirrors the
+// RDF grouping used by the search facet and the dataset card.
+export function isRdfDistribution(distribution: DistributionLike): boolean {
+  return (
+    distribution.mediaType != null &&
+    RDF_MEDIA_TYPES.includes(
+      distribution.mediaType as (typeof RDF_MEDIA_TYPES)[number],
+    )
+  );
+}
+
+// Whether the dataset offers any linked-data distribution — a SPARQL endpoint or
+// an RDF download. This is the “declared” signal for the Linked data
+// compatibility criterion, reusing the same notion of RDF the rest of the app
+// applies rather than re-deriving the Knowledge Graph’s selection query.
+export function offersLinkedData(
+  distributions: readonly DistributionLike[],
+): boolean {
+  return distributions.some(
+    (distribution) =>
+      isSparqlDistribution(distribution) || isRdfDistribution(distribution),
+  );
+}

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -6,7 +6,10 @@
   import * as m from '$lib/paraglide/messages';
   import { getLocale } from '$lib/paraglide/runtime';
   import { page } from '$app/state';
-  import { RDF_MEDIA_TYPES } from '$lib/constants.js';
+  import {
+    isRdfDistribution,
+    isSparqlDistribution,
+  } from '$lib/utils/distribution';
   import {
     getLocalizedValue,
     getLocalizedArray,
@@ -53,7 +56,7 @@
   const linksets = $derived(data.linksets);
   const temporalCoverages = $derived(data.temporalCoverages);
   const iiifManifests = $derived(data.iiifManifests);
-  const schemaApNde = $derived(data.schemaApNde);
+  const linkedData = $derived(data.linkedData);
 
   // SEO: canonical and hreflang URLs
   const datasetPath = $derived(datasetDetailHref(dataset.$id));
@@ -63,21 +66,6 @@
   const enUrl = $derived(
     `${page.url.origin}${localizeHref(datasetPath, { locale: 'en' })}`,
   );
-
-  function isSparqlDistribution(distribution: DistributionDetail) {
-    return distribution.conformsTo?.includes(
-      'https://www.w3.org/TR/sparql11-protocol/',
-    );
-  }
-
-  function isRdfDistribution(distribution: DistributionDetail) {
-    return (
-      distribution.mediaType &&
-      RDF_MEDIA_TYPES.includes(
-        distribution.mediaType as (typeof RDF_MEDIA_TYPES)[number],
-      )
-    );
-  }
 
   function isGzipDistribution(distribution: DistributionDetail) {
     return (
@@ -1274,7 +1262,7 @@
     isAnalyzed={isAnalyzed(summary)}
     {registrationStatus}
     {iiifManifests}
-    {schemaApNde}
+    {linkedData}
   />
 
   <!-- VoID Summary Section -->


### PR DESCRIPTION
Replaces the binary SCHEMA-AP-NDE detail row with the **Linked data** criterion from the NDE compatibility framework (#1222 §3).

## What changed

Linked data is a **foundational** criterion, so it is always shown (no longer gated on Knowledge Graph analysis). Its state is derived from three signals — **declared** (the register lists an RDF distribution), **confirmed** (the Knowledge Graph produced a `void:Dataset` with content), and **SCHEMA-AP-NDE conformance**:

| Situation | State |
| --- | --- |
| content, conforms to SCHEMA-AP-NDE | 🟢 met |
| content, not (yet) conforming | 🟠 warning |
| no content, nothing declared | 🔴 “biedt geen linked data” |
| declared, not yet analyzed | ⚪ “nog niet beoordeeld” (pending) |
| declared + analyzed, no content | 🔴 “kon geen linked data ophalen” |

- Adds a **warning** (🟠) assessment tier alongside met/failed/unmet, rendered as an orange box with an exclamation icon.
- Extracted content is **authoritative**: a dataset the Knowledge Graph extracted content from provides linked data whatever the register lists. Uses a composite content test (`void:triples`, `classPartition` or `distinctSubjects`) to guard against missing aggregates on large datasets.
- The fact count (“n feiten”) is shown only when `void:triples > 0`.

## Notes

- Rather than replicate the Dataset Knowledge Graph’s `dataset-with-rdf-distribution.rq` selector, the “declared” signal reuses the existing RDF notion: `isSparqlDistribution`/`isRdfDistribution` (previously inline in the detail page) are extracted into a shared `lib/utils/distribution.ts` (`offersLinkedData`) and reused, over the already-loaded distributions.
- The conformance fetch is simplified to the `conformant` boolean (the now-unused `declaresProfile`/`quads-validated` lookups are dropped from the detail path).
- The dataset card SCHEMA-AP-NDE badge is unchanged.
- `schema_ap_nde` messages replaced with `linked_data` messages (NL + EN).

Part of #1222.
