### PR TITLE
feat(browser): add term usage NDE compatibility item

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -295,6 +295,23 @@
       }
     }
   ],
+  "nde_compat_terms_heading_uses": "Uses terms from the Network of Terms",
+  "nde_compat_terms_heading_not_uses": "Does not use terms from the Network of Terms",
+  "nde_compat_terms_explanation": "Objects in this dataset link to shared terms from terminology sources in the Network of Terms, which makes the data interoperable and easier to find.",
+  "nde_compat_terms_count": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "contains {display} link to terms",
+        "countPlural=other": "contains {display} links to terms"
+      }
+    }
+  ],
   "nde_compat_learn_more": "Learn more",
   "validate_page_title": "Validate a dataset description",
   "validate_page_intro_before": "Have you created and published your dataset description? And do you want to know if it meets the ",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -295,6 +295,23 @@
       }
     }
   ],
+  "nde_compat_terms_heading_uses": "Gebruikt termen uit het Termennetwerk",
+  "nde_compat_terms_heading_not_uses": "Gebruikt geen termen uit het Termennetwerk",
+  "nde_compat_terms_explanation": "Objecten in deze dataset linken naar gedeelde termen uit terminologiebronnen in het Termennetwerk, waardoor de data interoperabel en beter vindbaar wordt.",
+  "nde_compat_terms_count": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "bevat {display} link naar termen",
+        "countPlural=other": "bevat {display} links naar termen"
+      }
+    }
+  ],
   "nde_compat_learn_more": "Meer informatie",
   "validate_page_title": "Controleer een datasetbeschrijving",
   "validate_page_intro_before": "Heb je je datasetbeschrijving gemaakt en gepubliceerd? En wil je weten of deze voldoet aan de ",

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -13,16 +13,19 @@
     type IiifManifests,
     type RegistrationFailureReason,
     type SchemaApNdeConformance,
+    type TermLinks,
   } from '$lib/services/nde-compatibility';
 
   let {
     isAnalyzed,
     registrationStatus,
+    terms,
     iiifManifests,
     schemaApNde,
   }: {
     isAnalyzed: boolean;
     registrationStatus: RegistrationFailureReason | null;
+    terms: TermLinks | null;
     iiifManifests: IiifManifests;
     schemaApNde: SchemaApNdeConformance;
   } = $props();
@@ -32,6 +35,7 @@
       isAnalyzed,
       registration: registrationStatus,
       schemaApNde,
+      terms,
       iiif: iiifManifests,
     }),
   );
@@ -59,7 +63,12 @@
           case 'unmet':
             return m.nde_compat_schema_ap_nde_heading_not_applicable();
         }
+      // The terms criterion is binary: met (green) or failed (red).
       // eslint-disable-next-line no-fallthrough
+      case 'terms':
+        return criterion.state === 'met'
+          ? m.nde_compat_terms_heading_uses()
+          : m.nde_compat_terms_heading_not_uses();
       case 'iiif':
         switch (criterion.state) {
           case 'met':
@@ -94,7 +103,10 @@
           case 'unmet':
             return m.nde_compat_schema_ap_nde_explanation_not_applicable();
         }
+      // A single explanation regardless of state, following the IIIF pattern.
       // eslint-disable-next-line no-fallthrough
+      case 'terms':
+        return m.nde_compat_terms_explanation();
       case 'iiif':
         return m.nde_compat_iiif_explanation();
     }
@@ -115,6 +127,13 @@
       case 'schema-ap-nde':
         // No raw counts for the profile criterion in this version.
         return null;
+      case 'terms':
+        // The count line reports how many links to terms were found; it is
+        // shown only when met and links down to the Terminology Sources section
+        // (see sectionAnchor).
+        return criterion.state === 'met'
+          ? m.nde_compat_terms_count({ count, display })
+          : null;
       case 'iiif':
         switch (criterion.state) {
           case 'met':
@@ -133,16 +152,27 @@
         return NDE_VINKJES_URL;
       case 'schema-ap-nde':
         return SCHEMA_AP_NDE_PROFILE;
+      case 'terms':
+        return NDE_VINKJES_URL;
       case 'iiif':
         return NDE_VINKJES_URL;
     }
   }
 
-  // The registration criterion links to the Registration section further down
-  // the same page, where the registration URL, status and date are listed. Other
-  // criteria have no such in-page counterpart.
-  function detailsAnchor(criterion: CompatibilityCriterion): string | null {
-    return criterion.key === 'registration' ? '#registration' : null;
+  // In-page anchor to the criterion’s evidence section further down the page, or
+  // null when it has none. Registration points to its Registration section; the
+  // terms criterion (when met) to the Terminology Sources section. The template
+  // attaches this to the count line when there is one, otherwise renders a
+  // dedicated link.
+  function sectionAnchor(criterion: CompatibilityCriterion): string | null {
+    switch (criterion.key) {
+      case 'registration':
+        return '#registration';
+      case 'terms':
+        return criterion.state === 'met' ? '#terminology-sources' : null;
+      default:
+        return null;
+    }
   }
 </script>
 
@@ -169,6 +199,8 @@
     >
       <ul class="divide-y divide-gray-200 dark:divide-gray-700">
         {#each criteria as criterion (criterion.key)}
+          {@const detailText = detail(criterion)}
+          {@const sectionHref = sectionAnchor(criterion)}
           <li class="flex items-start gap-3 px-4 py-3">
             <!-- Status box. Green tick = met, red cross = declared but broken,
                neutral empty = not provided (a legitimate, non-failure state).
@@ -205,20 +237,32 @@
                   {m.nde_compat_learn_more()}
                   <span class="sr-only"> ({m.opens_in_new_tab()})</span>
                 </a>
-                {#if detailsAnchor(criterion)}
+                <!-- A criterion with an evidence section but no count line (e.g.
+                     registration) gets a dedicated in-page link here; one with a
+                     count line carries the link on that line instead. -->
+                {#if sectionHref && !detailText}
                   <a
-                    href={detailsAnchor(criterion)}
+                    href={sectionHref}
                     class="text-blue-600 hover:underline dark:text-blue-400"
                   >
                     {m.nde_compat_registration_view_details()}
                   </a>
                 {/if}
               </p>
-              {#if detail(criterion)}
+              {#if detailText}
                 <p
                   class="mt-1 text-sm font-medium text-gray-700 dark:text-gray-300"
                 >
-                  {detail(criterion)}
+                  {#if sectionHref}
+                    <a
+                      href={sectionHref}
+                      class="text-blue-600 hover:underline dark:text-blue-400"
+                    >
+                      {detailText}
+                    </a>
+                  {:else}
+                    {detailText}
+                  {/if}
                 </p>
               {/if}
             </div>

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -18,6 +18,7 @@ import {
   SCHEMA_AP_NDE_PROFILE,
   type IiifManifests,
   type SchemaApNdeConformance,
+  type TermLinks,
 } from './nde-compatibility.js';
 import { getLocale } from '$lib/paraglide/runtime';
 import { REGISTRATION_STATUS_BASE_URI } from '@dataset-register/core/constants';
@@ -384,6 +385,7 @@ export interface DatasetDetailResult {
   temporalCoverages: TemporalCoverage[];
   iiifManifests: IiifManifests;
   schemaApNde: SchemaApNdeConformance;
+  terms: TermLinks | null;
   resolvedTerms: Promise<Record<string, string>>;
 }
 
@@ -744,7 +746,19 @@ export async function fetchDatasetDetail(
       );
       return null;
     }),
-    linksLens.find({ where: { subjectsTarget: datasetUri } }),
+    // The terms criterion depends on the linksets, so a Knowledge Graph failure
+    // here must not fail the whole page. Catch it and treat the result as
+    // unavailable (null), distinct from an empty result: the terms criterion is
+    // then left indeterminate rather than read as “no links to terms”.
+    linksLens
+      .find({ where: { subjectsTarget: datasetUri } })
+      .catch((e: unknown) => {
+        console.error(
+          'Linkset query failed:',
+          e instanceof Error ? e.message : e,
+        );
+        return null;
+      }),
     classPartitionLens.findByIri(datasetUri),
     fetchTemporalCoverage(datasetUri),
     fetchIiifManifests(datasetUri),
@@ -763,6 +777,24 @@ export async function fetchDatasetDetail(
         classPartition: classPartitionResult?.classPartition ?? null,
       }
     : null;
+
+  // Term-usage figures for the NDE compatibility criterion, reusing the data
+  // already fetched: `links` is the client-side sum of the linksets’
+  // void:triples, `distinctObjectsUri` the top-level VoID’s distinct-URI-objects
+  // count. The criterion is left indeterminate (null) — and so omitted, never
+  // rendered red — when there is no top-level VoID or the linksets could not be
+  // retrieved.
+  const terms: TermLinks | null =
+    summaryWithClassPartition === null || linksets === null
+      ? null
+      : {
+          links: linksets.reduce(
+            (total, linkset) => total + linkset.triples,
+            0,
+          ),
+          distinctObjectsUri:
+            summaryWithClassPartition.distinctObjectsURI ?? null,
+        };
 
   // Resolve term URIs (e.g. spatial/temporal) to human-readable labels
   // via the Network of Terms API. Returned as an unawaited promise so
@@ -787,10 +819,11 @@ export async function fetchDatasetDetail(
     distributions,
     totalDistributions,
     summary: summaryWithClassPartition,
-    linksets,
+    linksets: linksets ?? [],
     temporalCoverages,
     iiifManifests,
     schemaApNde,
+    terms,
     resolvedTerms,
   };
 }

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -4,6 +4,7 @@ import {
   iiifState,
   registrationState,
   schemaApNdeState,
+  termsState,
   type SchemaApNdeConformance,
 } from './nde-compatibility';
 
@@ -137,12 +138,34 @@ describe('registrationState', () => {
   });
 });
 
+describe('termsState', () => {
+  it('is met when the dataset has links to terms', () => {
+    expect(termsState({ links: 42, distinctObjectsUri: 1000 })).toBe('met');
+    // Met even with no distinct-URI count, since links alone prove term usage.
+    expect(termsState({ links: 1, distinctObjectsUri: null })).toBe('met');
+  });
+
+  it('is failed when it links out to URIs but to no terms', () => {
+    expect(termsState({ links: 0, distinctObjectsUri: 500 })).toBe('failed');
+  });
+
+  it('is omitted (null) when there are no outgoing URI links to assess', () => {
+    expect(termsState({ links: 0, distinctObjectsUri: 0 })).toBeNull();
+    expect(termsState({ links: 0, distinctObjectsUri: null })).toBeNull();
+  });
+
+  it('is omitted (null) when there is no top-level VoID', () => {
+    expect(termsState(null)).toBeNull();
+  });
+});
+
 describe('compatibilityCriteria', () => {
   it('exposes the declared count and computed state for IIIF', () => {
     const [, , iiif] = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
       schemaApNde: noSchemaApNde,
+      terms: null,
       iiif: { declared: 4152, sampled: 10, validated: 0 },
     });
     expect(iiif.key).toBe('iiif');
@@ -155,6 +178,7 @@ describe('compatibilityCriteria', () => {
       isAnalyzed: true,
       registration: 'gone',
       schemaApNde: noSchemaApNde,
+      terms: null,
       iiif: { declared: 0, sampled: null, validated: null },
     });
     expect(registration.key).toBe('registration');
@@ -171,6 +195,7 @@ describe('compatibilityCriteria', () => {
         conformant: false,
         declaresProfile: true,
       },
+      terms: null,
       iiif: { declared: 0, sampled: null, validated: null },
     });
     expect(schemaApNde.key).toBe('schema-ap-nde');
@@ -184,9 +209,55 @@ describe('compatibilityCriteria', () => {
         isAnalyzed: true,
         registration: null,
         schemaApNde: noSchemaApNde,
+        terms: null,
         iiif: { declared: 0, sampled: null, validated: null },
       }),
     ).toHaveLength(3);
+  });
+
+  it('places the terms criterion after schema-ap-nde and before iiif when present', () => {
+    const keys = compatibilityCriteria({
+      isAnalyzed: true,
+      registration: null,
+      schemaApNde: noSchemaApNde,
+      terms: { links: 42, distinctObjectsUri: 1000 },
+      iiif: { declared: 0, sampled: null, validated: null },
+    }).map((criterion) => criterion.key);
+    expect(keys).toEqual(['registration', 'schema-ap-nde', 'terms', 'iiif']);
+  });
+
+  it('exposes the links count and met state for the terms criterion', () => {
+    const terms = compatibilityCriteria({
+      isAnalyzed: true,
+      registration: null,
+      schemaApNde: noSchemaApNde,
+      terms: { links: 42, distinctObjectsUri: 1000 },
+      iiif: { declared: 0, sampled: null, validated: null },
+    }).find((criterion) => criterion.key === 'terms');
+    expect(terms?.state).toBe('met');
+    expect(terms?.count).toBe(42);
+  });
+
+  it('marks the terms criterion failed when it links out but to no terms', () => {
+    const terms = compatibilityCriteria({
+      isAnalyzed: true,
+      registration: null,
+      schemaApNde: noSchemaApNde,
+      terms: { links: 0, distinctObjectsUri: 500 },
+      iiif: { declared: 0, sampled: null, validated: null },
+    }).find((criterion) => criterion.key === 'terms');
+    expect(terms?.state).toBe('failed');
+  });
+
+  it('omits the terms criterion when it cannot be assessed', () => {
+    const keys = compatibilityCriteria({
+      isAnalyzed: true,
+      registration: null,
+      schemaApNde: noSchemaApNde,
+      terms: { links: 0, distinctObjectsUri: 0 },
+      iiif: { declared: 0, sampled: null, validated: null },
+    }).map((criterion) => criterion.key);
+    expect(keys).not.toContain('terms');
   });
 
   it('keeps the registration criterion when the dataset is not analyzed', () => {
@@ -201,6 +272,7 @@ describe('compatibilityCriteria', () => {
           conformant: true,
           declaresProfile: true,
         },
+        terms: { links: 42, distinctObjectsUri: 1000 },
         iiif: { declared: 4152, sampled: 10, validated: 8 },
       }).map((criterion) => criterion.key),
     ).toEqual(['registration']);

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -37,11 +37,12 @@ export const QUADS_VALIDATED_METRIC =
   'https://def.nde.nl/metric#quads-validated';
 
 // The registration criterion leads — every registered dataset has it, so it
-// anchors the section regardless of analysis. The schema-ap-nde criterion is
-// ordered before iiif, matching the usual order in NDE communication.
+// anchors the section regardless of analysis. The schema-ap-nde and terms
+// criteria follow, then iiif, matching the order in NDE communication.
 export type CompatibilityCriterionKey =
   | 'registration'
   | 'schema-ap-nde'
+  | 'terms'
   | 'iiif';
 
 // Criteria that can only be assessed from the dataset’s analysis in the Dataset
@@ -49,7 +50,7 @@ export type CompatibilityCriterionKey =
 // is left out: it applies to any dataset, is always shown, and so keeps the
 // section visible even for a dataset that has not been analyzed.
 const ANALYSIS_DEPENDENT_CRITERIA: ReadonlySet<CompatibilityCriterionKey> =
-  new Set(['schema-ap-nde', 'iiif']);
+  new Set(['schema-ap-nde', 'terms', 'iiif']);
 
 // 'met'    — the dataset provides working media (validated, or declared with no
 //            evidence of failure).
@@ -97,6 +98,19 @@ export interface SchemaApNdeConformance {
   declaresProfile: boolean;
 }
 
+// Term-usage figures for a dataset. `links` is the total number of link
+// statements from the dataset’s contents to terms (the sum of `void:triples`
+// across the dataset’s linksets). `distinctObjectsUri` is the dataset’s count of
+// distinct URI-valued objects, taken from the top-level VoID — how many outgoing
+// URI links there are to match against. The whole object is null when the
+// criterion cannot be assessed: there is no top-level VoID (the dataset is not
+// `isAnalyzed`: non-RDF or not yet analyzed by the Dataset Knowledge Graph), or
+// the linkset data could not be retrieved.
+export interface TermLinks {
+  links: number;
+  distinctObjectsUri: number | null;
+}
+
 export interface CompatibilityCriterion {
   key: CompatibilityCriterionKey;
   state: CompatibilityState;
@@ -112,6 +126,7 @@ export interface CompatibilityInput {
   // failure reason when the registration is gone or invalid.
   registration: RegistrationFailureReason | null;
   schemaApNde: SchemaApNdeConformance;
+  terms: TermLinks | null;
   iiif: IiifManifests;
 }
 
@@ -178,17 +193,42 @@ export function iiifState(manifests: IiifManifests): CompatibilityState {
   return 'met';
 }
 
+// Derives the term-usage state, or `null` when the criterion cannot be assessed
+// and so must be omitted (it has no neutral grey state). The Dataset Knowledge
+// Graph emits no positive “terms analysis ran” measurement, so assessability is
+// inferred from the signals it does emit: a top-level VoID with a count of
+// outgoing URI links to match against. Unlike the other criteria, not using
+// terms is treated as a gap (red), not a neutral choice — hence the binary
+// green/red with no `unmet`.
+export function termsState(terms: TermLinks | null): CompatibilityState | null {
+  if (terms === null) {
+    // No top-level VoID (non-RDF, not yet analyzed, or linksets unavailable):
+    // cannot assess, so omit.
+    return null;
+  }
+  if (terms.links > 0) {
+    return 'met';
+  }
+  if ((terms.distinctObjectsUri ?? 0) > 0) {
+    // Analyzed and links out to URIs, but none of them to terms: a genuine gap.
+    return 'failed';
+  }
+  // No outgoing URI links to match against, so there is nothing to assess.
+  return null;
+}
+
 // Builds the list of NDE criteria for a dataset. The registration row leads — it
-// applies to any dataset, so it anchors the section; the schema-ap-nde row
-// follows, matching the usual order in NDE communication, then IIIF. Criteria
-// that depend on the dataset’s analysis are dropped when the dataset has not
-// been analyzed; the detail page shows the section whenever any criterion
-// remains.
+// applies to any dataset, so it anchors the section; schema-ap-nde and terms
+// follow, then IIIF, matching the order in NDE communication. The terms row is
+// omitted when it cannot be assessed. Criteria that depend on the dataset’s
+// analysis are dropped when the dataset has not been analyzed; the detail page
+// shows the section whenever any criterion remains.
 export function compatibilityCriteria(
   input: CompatibilityInput,
 ): CompatibilityCriterion[] {
   const registration = registrationState(input.registration);
   const schemaApNde = schemaApNdeState(input.schemaApNde);
+  const terms = termsState(input.terms);
   const criteria: CompatibilityCriterion[] = [
     {
       key: 'registration',
@@ -202,6 +242,15 @@ export function compatibilityCriteria(
       count: 0,
       reason: schemaApNde.reason,
     },
+    ...(terms !== null
+      ? [
+          {
+            key: 'terms' as const,
+            state: terms,
+            count: input.terms?.links ?? 0,
+          },
+        ]
+      : []),
     {
       key: 'iiif',
       state: iiifState(input.iiif),

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -54,6 +54,7 @@
   const temporalCoverages = $derived(data.temporalCoverages);
   const iiifManifests = $derived(data.iiifManifests);
   const schemaApNde = $derived(data.schemaApNde);
+  const terms = $derived(data.terms);
 
   // SEO: canonical and hreflang URLs
   const datasetPath = $derived(datasetDetailHref(dataset.$id));
@@ -1273,6 +1274,7 @@
   <NdeCompatibility
     isAnalyzed={isAnalyzed(summary)}
     {registrationStatus}
+    {terms}
     {iiifManifests}
     {schemaApNde}
   />
@@ -1496,7 +1498,7 @@
 
       <!-- Terminology Sources Section -->
       {#if linksets.length > 0}
-        <div class="mt-6">
+        <div id="terminology-sources" class="mt-6">
           <h3
             class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
           >


### PR DESCRIPTION
## Summary

Adds a third NDE compatibility criterion (“vinkje”) to the dataset detail page: **whether the dataset’s contents link to terms from the Network of Terms**. This consolidates a signal that was previously only visible lower down in the Terminology Sources section.

The criterion is rendered between the SCHEMA-AP-NDE and IIIF rows, following the criterion order in the parent compatibility framework (#1222).

## Behaviour

- **Green (met)** – the dataset’s contents link to at least one term.
- **Red (failed)** – the dataset was analyzed and links out to URIs, but none of them to terms (a genuine gap).
- **Omitted** – the criterion cannot be assessed: no top-level VoID (non-RDF or not yet analyzed), no outgoing URI links to match against, or the linkset data could not be retrieved.

When met, the row shows how many links to terms were found, as a link down to the Terminology Sources section (a `#terminology-sources` anchor was added there).

## Implementation

- Extends the locale-independent compatibility module with a `terms` criterion key and a `termsState` derivation (binary green/red, no neutral state), kept fully unit-tested.
- Derives assessability from the `distinctObjectsURI` proxy, since the Dataset Knowledge Graph emits no positive “terms analysis ran” measurement.
- Reuses data the page already fetches – `links` is the client-side sum of the linksets’ `void:triples`; `distinctObjectsUri` comes from the top-level VoID. **No new Knowledge Graph query.**
- Wraps the linkset query so a Knowledge Graph failure no longer fails the whole page and is treated as indeterminate rather than red.
- Adds English and Dutch labels.

## Consolidation with #2039

#2039 (just merged) added an in-page section link for the registration criterion via a `detailsAnchor()` helper. To avoid two near-identical helpers, this PR folds both into a single `sectionAnchor()` that resolves a criterion’s evidence-section anchor (registration → `#registration`, terms → `#terminology-sources`). The template attaches it to the count line when a criterion has one (terms), or renders a dedicated link otherwise (registration).

## Note on ordering

Issue #2030 was written before the registration criterion (#2038) merged and asked for terms to be inserted first. Following the canonical order in the parent framework (#1222: Datasetregister → … → Terms → IIIF), terms is placed after SCHEMA-AP-NDE and before IIIF instead.

Fix #2030
