### PR TITLE
feat: surface registration validation warnings on dataset detail

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -255,6 +255,22 @@
   "nde_compat_registration_explanation_registered": "This dataset’s description is registered in the Dataset Register, so it can be found and reused.",
   "nde_compat_registration_explanation_gone": "The registration URL is no longer accessible, so the description can no longer be retrieved.",
   "nde_compat_registration_explanation_invalid": "The description no longer conforms to the requirements for datasets.",
+  "nde_compat_registration_heading_warning": "Registered with warnings",
+  "nde_compat_registration_explanation_warning": "This dataset’s description is registered and valid, but it validated with warnings: some recommendations for datasets are not yet met.",
+  "nde_compat_registration_warning_count": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{display} validation warning.",
+        "countPlural=other": "{display} validation warnings."
+      }
+    }
+  ],
   "nde_compat_registration_view_details": "View registration details",
   "nde_compat_linked_data_heading_conforms": "Provides linked data conforming to the NDE Application Profile",
   "nde_compat_linked_data_heading_not_conforms": "Provides linked data",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -255,6 +255,22 @@
   "nde_compat_registration_explanation_registered": "De beschrijving van deze dataset is geregistreerd in het Datasetregister, zodat de dataset vindbaar en herbruikbaar is.",
   "nde_compat_registration_explanation_gone": "De registratie-URL is niet meer toegankelijk, dus de beschrijving kan niet meer worden opgehaald.",
   "nde_compat_registration_explanation_invalid": "De beschrijving voldoet niet meer aan de eisen voor datasets.",
+  "nde_compat_registration_heading_warning": "Geregistreerd met waarschuwingen",
+  "nde_compat_registration_explanation_warning": "De beschrijving van deze dataset is geregistreerd en geldig, maar bij de validatie zijn waarschuwingen gegeven: aan sommige aanbevelingen voor datasets wordt nog niet voldaan.",
+  "nde_compat_registration_warning_count": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{display} validatiewaarschuwing.",
+        "countPlural=other": "{display} validatiewaarschuwingen."
+      }
+    }
+  ],
   "nde_compat_registration_view_details": "Bekijk registratiegegevens",
   "nde_compat_linked_data_heading_conforms": "Biedt linked data volgens het NDE-applicatieprofiel",
   "nde_compat_linked_data_heading_not_conforms": "Biedt linked data",

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -20,12 +20,14 @@
   let {
     isAnalyzed,
     registrationStatus,
+    registrationWarnings,
     terms,
     iiifManifests,
     linkedData,
   }: {
     isAnalyzed: boolean;
     registrationStatus: RegistrationFailureReason | null;
+    registrationWarnings: number;
     terms: TermLinks | null;
     iiifManifests: IiifManifests;
     linkedData: LinkedData;
@@ -35,6 +37,7 @@
     compatibilityCriteria({
       isAnalyzed,
       registration: registrationStatus,
+      registrationWarnings,
       linkedData,
       terms,
       iiif: iiifManifests,
@@ -47,6 +50,9 @@
   function heading(criterion: CompatibilityCriterion): string {
     switch (criterion.key) {
       case 'registration':
+        if (criterion.state === 'warning') {
+          return m.nde_compat_registration_heading_warning();
+        }
         switch (criterion.reason) {
           case 'gone':
             return m.nde_compat_registration_heading_gone();
@@ -90,6 +96,9 @@
   function explanation(criterion: CompatibilityCriterion): string {
     switch (criterion.key) {
       case 'registration':
+        if (criterion.state === 'warning') {
+          return m.nde_compat_registration_explanation_warning();
+        }
         switch (criterion.reason) {
           case 'gone':
             return m.nde_compat_registration_explanation_gone();
@@ -130,8 +139,11 @@
     const display = count.toLocaleString(getLocale());
     switch (criterion.key) {
       case 'registration':
-        // The registration criterion carries no count.
-        return null;
+        // In the warning tier, report how many validation warnings the
+        // description has; otherwise the criterion carries no count.
+        return criterion.state === 'warning' && count > 0
+          ? m.nde_compat_registration_warning_count({ count, display })
+          : null;
       case 'linked-data':
         // The fact count (void:triples) is shown only when the dataset actually
         // has linked data with a known triple count.

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -22,7 +22,10 @@ import {
 import { offersLinkedData } from '$lib/utils/distribution';
 import { normalizeMediaType } from '$lib/utils/sparql';
 import { getLocale } from '$lib/paraglide/runtime';
-import { REGISTRATION_STATUS_BASE_URI } from '@dataset-register/core/constants';
+import {
+  REGISTRATION_STATUS_BASE_URI,
+  VALIDATION_WARNINGS_RATING_TYPE,
+} from '@dataset-register/core/constants';
 import {
   PUBLIC_SPARQL_ENDPOINT,
   PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
@@ -388,6 +391,9 @@ export interface DatasetDetailResult {
   linkedData: LinkedData;
   terms: TermLinks | null;
   resolvedTerms: Promise<Record<string, string>>;
+  // Per-dataset SHACL warning count, feeding the registration criterion's
+  // warning tier. 0 when the description validated cleanly or predates the count.
+  warningCount: number;
 }
 
 const fetcher = new SparqlEndpointFetcher();
@@ -510,6 +516,42 @@ async function fetchDistributionCount(query: string): Promise<number> {
   return 0;
 }
 
+// Reads the per-dataset validation-warnings count from its schema:Rating (the
+// one marked with the validation-warnings additionalType). Drives the
+// registration criterion's warning tier: how far the description is from full
+// validity. Returns 0 when no warnings rating exists yet (e.g. not re-crawled).
+async function fetchWarningCount(datasetUri: string): Promise<number> {
+  const query = `
+    PREFIX schema: <https://schema.org/>
+    SELECT ?warningCount WHERE {
+      GRAPH ?g {
+        <${datasetUri}> schema:contentRating ?rating .
+        ?rating schema:additionalType <${VALIDATION_WARNINGS_RATING_TYPE}> ;
+          schema:ratingValue ?warningCount .
+      }
+    }
+    LIMIT 1
+  `;
+  try {
+    const bindingsStream = await fetcher.fetchBindings(
+      PUBLIC_SPARQL_ENDPOINT,
+      query,
+    );
+    for await (const raw of bindingsStream) {
+      const binding = raw as unknown as { warningCount?: { value: string } };
+      if (binding.warningCount?.value) {
+        return parseInt(binding.warningCount.value, 10);
+      }
+    }
+  } catch (e: unknown) {
+    console.error(
+      'Warning count query failed:',
+      e instanceof Error ? e.message : e,
+    );
+  }
+  return 0;
+}
+
 async function fetchTemporalCoverage(
   datasetUri: string,
 ): Promise<TemporalCoverage[]> {
@@ -626,7 +668,12 @@ export async function fetchDatasetDetail(
           ?subjectOf ?p ?o .
           BIND(?subjectOf AS ?s)
         } UNION {
+          # Only the completeness rating, not the validation-warnings rating
+          # (read separately), so the single-valued contentRating lens stays correct.
           <${datasetUri}> schema:contentRating ?contentRating .
+          FILTER NOT EXISTS {
+            ?contentRating schema:additionalType <${VALIDATION_WARNINGS_RATING_TYPE}> .
+          }
           ?contentRating ?p ?o .
           BIND(?contentRating AS ?s)
         } UNION {
@@ -697,6 +744,7 @@ export async function fetchDatasetDetail(
     temporalCoverages,
     iiifManifests,
     schemaApNdeConformant,
+    warningCount,
   ] = await Promise.all([
     detailLens.query(datasetQuery),
     distributionLens.query(distributionQuery),
@@ -725,6 +773,7 @@ export async function fetchDatasetDetail(
     fetchTemporalCoverage(datasetUri),
     fetchIiifManifests(datasetUri),
     fetchSchemaApNdeConformant(datasetUri),
+    fetchWarningCount(datasetUri),
   ]);
 
   const dataset = datasets.find((d) => d.$id === datasetUri) ?? datasets[0];
@@ -799,6 +848,7 @@ export async function fetchDatasetDetail(
     linkedData,
     terms,
     resolvedTerms,
+    warningCount,
   };
 }
 

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -227,6 +227,26 @@ describe('registrationState', () => {
       reason: 'invalid',
     });
   });
+
+  it('is warning when registered and valid but the description has warnings', () => {
+    expect(registrationState(null, 3)).toEqual({ state: 'warning' });
+    expect(registrationState(undefined, 1)).toEqual({ state: 'warning' });
+  });
+
+  it('is met when registered and valid with no warnings', () => {
+    expect(registrationState(null, 0)).toEqual({ state: 'met' });
+  });
+
+  it('stays failed despite warnings when the registration is gone or invalid', () => {
+    expect(registrationState('gone', 5)).toEqual({
+      state: 'failed',
+      reason: 'gone',
+    });
+    expect(registrationState('invalid', 5)).toEqual({
+      state: 'failed',
+      reason: 'invalid',
+    });
+  });
 });
 
 describe('termsState', () => {
@@ -275,6 +295,20 @@ describe('compatibilityCriteria', () => {
     expect(registration.key).toBe('registration');
     expect(registration.state).toBe('failed');
     expect(registration.reason).toBe('gone');
+  });
+
+  it('surfaces the registration warning tier with the warning count', () => {
+    const [registration] = compatibilityCriteria({
+      isAnalyzed: true,
+      registration: null,
+      registrationWarnings: 3,
+      linkedData: noLinkedData,
+      terms: null,
+      iiif: { declared: 0, sampled: null, validated: null },
+    });
+    expect(registration.key).toBe('registration');
+    expect(registration.state).toBe('warning');
+    expect(registration.count).toBe(3);
   });
 
   it('exposes the linked-data state and fact count on the second criterion', () => {

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -160,6 +160,10 @@ export interface CompatibilityInput {
   // The dataset’s registration status: null when registered and valid, or the
   // failure reason when the registration is gone or invalid.
   registration: RegistrationFailureReason | null;
+  // The number of validation warnings on the dataset’s description. A registered,
+  // valid description with warnings is surfaced as `warning` rather than `met`.
+  // Optional: absent is treated as no warnings.
+  registrationWarnings?: number;
   linkedData: LinkedData;
   terms: TermLinks | null;
   iiif: IiifManifests;
@@ -168,16 +172,20 @@ export interface CompatibilityInput {
 // Derives the registration state. Being on the detail page means the dataset is
 // registered, so the criterion is `met` unless the register flags its
 // registration as gone (URL no longer accessible) or invalid (description no
-// longer conforms) — both surfaced as `failed` with the status as the reason.
+// longer conforms) — both surfaced as `failed` with the status as the reason —
+// or the description validated with warnings (`warning`): registered and valid,
+// but not yet up to the recommended standard. The warning count says how far off.
 export function registrationState(
   status: RegistrationFailureReason | null | undefined,
+  warningCount = 0,
 ): {
   state: CompatibilityState;
   reason?: CompatibilityFailureReason;
 } {
-  return status === 'gone' || status === 'invalid'
-    ? { state: 'failed', reason: status }
-    : { state: 'met' };
+  if (status === 'gone' || status === 'invalid') {
+    return { state: 'failed', reason: status };
+  }
+  return warningCount > 0 ? { state: 'warning' } : { state: 'met' };
 }
 
 // Derives the SCHEMA-AP-NDE conformance state. The measurement is authoritative
@@ -286,14 +294,18 @@ export function termsState(terms: TermLinks | null): CompatibilityState | null {
 export function compatibilityCriteria(
   input: CompatibilityInput,
 ): CompatibilityCriterion[] {
-  const registration = registrationState(input.registration);
+  const registration = registrationState(
+    input.registration,
+    input.registrationWarnings,
+  );
   const linkedData = linkedDataState(input.linkedData);
   const terms = termsState(input.terms);
   const criteria: CompatibilityCriterion[] = [
     {
       key: 'registration',
       state: registration.state,
-      count: 0,
+      // The warning count, shown when the criterion is in its warning tier.
+      count: input.registrationWarnings ?? 0,
       reason: registration.reason,
     },
     {

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -58,6 +58,7 @@
   const iiifManifests = $derived(data.iiifManifests);
   const linkedData = $derived(data.linkedData);
   const terms = $derived(data.terms);
+  const registrationWarnings = $derived(data.warningCount);
 
   // SEO: canonical and hreflang URLs
   const datasetPath = $derived(datasetDetailHref(dataset.$id));
@@ -1262,6 +1263,7 @@
   <NdeCompatibility
     isAnalyzed={isAnalyzed(summary)}
     {registrationStatus}
+    {registrationWarnings}
     {terms}
     {iiifManifests}
     {linkedData}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,6 +1,12 @@
 export const REGISTRATION_STATUS_BASE_URI =
   'https://data.netwerkdigitaalerfgoed.nl/registry/';
 
+// schema:additionalType IRI that marks a dataset's schema:Rating as the
+// validation-warnings rating (warning count) rather than the completeness
+// rating. Lets the two ratings, both linked by schema:contentRating, be told
+// apart. The completeness rating carries no additionalType.
+export const VALIDATION_WARNINGS_RATING_TYPE = `${REGISTRATION_STATUS_BASE_URI}validation-warnings`;
+
 export const ALLOWED_DOMAIN_NAME_PREDICATE =
   'https://data.netwerkdigitaalerfgoed.nl/allowed_domain_names/def/domain_name';
 

--- a/packages/core/src/rate.ts
+++ b/packages/core/src/rate.ts
@@ -52,7 +52,17 @@ export function rate(validationResult: Valid): Rating {
     new Array<Penalty>(),
   );
 
-  return new Rating(appliedPenalties, worstRating);
+  // How far the description is from full validity: the number of
+  // sh:Warning-severity results in the report (SHACL warnings and probe-emitted
+  // warnings alike). Counted from the same per-dataset report the penalties use,
+  // so it reflects this dataset only — not its catalogue siblings.
+  const warningCount = validationResult.errors.match(
+    undefined,
+    shacl('resultSeverity'),
+    shacl('Warning'),
+  ).size;
+
+  return new Rating(appliedPenalties, worstRating, warningCount);
 }
 
 export class Penalty {
@@ -71,14 +81,21 @@ export class Rating {
   readonly penalties: Penalty[];
   public readonly worstRating: number;
   public readonly bestRating: number;
+  /**
+   * Number of sh:Warning-severity validation results for the dataset: how far the
+   * description is from full validity, separate from the completeness score.
+   */
+  public readonly warningCount: number;
 
   public constructor(
     penalties: Penalty[],
     worstRating: number,
+    warningCount = 0,
     bestRating = 100,
   ) {
     this.penalties = penalties;
     this.worstRating = worstRating;
+    this.warningCount = warningCount;
     this.bestRating = bestRating;
     this.score = penalties.reduce(
       (score, penalty) => score - penalty.score,

--- a/packages/core/src/sparql.ts
+++ b/packages/core/src/sparql.ts
@@ -10,7 +10,10 @@ import {
 } from './registration.js';
 import { Rating, RatingStore } from './rate.js';
 import { SparqlDistributionHealthStore } from './distribution-health-store.js';
-import { ALLOWED_DOMAIN_NAME_PREDICATE } from './constants.js';
+import {
+  ALLOWED_DOMAIN_NAME_PREDICATE,
+  VALIDATION_WARNINGS_RATING_TYPE,
+} from './constants.js';
 import type { DatasetCore, Quad } from '@rdfjs/types';
 import { URL } from 'node:url';
 
@@ -271,6 +274,10 @@ export class SparqlRatingStore implements RatingStore {
             schema:worstRating ${rating.worstRating} ;
             schema:ratingValue ${rating.score} ;
             schema:ratingExplanation "${rating.explanation}" ;
+          ] , [
+            schema:additionalType <${VALIDATION_WARNINGS_RATING_TYPE}> ;
+            schema:bestRating 0 ;
+            schema:ratingValue ${rating.warningCount} ;
           ]
         }
       }

--- a/packages/core/test/rate.test.ts
+++ b/packages/core/test/rate.test.ts
@@ -1,6 +1,7 @@
 import { rate } from '../src/rate.js';
 import type { Valid } from '../src/validator.js';
 import { validate } from './validator.test.js';
+import { StreamParser } from 'n3';
 
 describe('Rate', () => {
   it('rates minimal dataset description', async () => {
@@ -18,5 +19,29 @@ describe('Rate', () => {
     const rating = rate(validationResult);
     expect(rating.score).toBe(100);
     expect(rating.explanation).toBe('');
+  });
+
+  it('reports no warnings for a description that validates cleanly', async () => {
+    const validationResult = (await validate(
+      '../../../../requirements/examples/dataset-schema-org-valid.jsonld',
+    )) as Valid;
+    expect(rate(validationResult).warningCount).toBe(0);
+  });
+
+  it('counts the validation warnings on a description', async () => {
+    const validationResult = (await validate(
+      'dataset-schema-org-genre-deprecated.jsonld',
+    )) as Valid;
+    expect(rate(validationResult).warningCount).toBe(6);
+  });
+
+  it('counts every warning in a description with several', async () => {
+    // The Gouda Tijdmachine fixture validates with seven sh:Warning results
+    // (and two sh:Info, which do not count) — see validator.test.ts snapshot.
+    const validationResult = (await validate(
+      'dataset-schema-org-gouda-tijdmachine.ttl',
+      new StreamParser(),
+    )) as Valid;
+    expect(rate(validationResult).warningCount).toBe(7);
   });
 });

--- a/packages/core/test/sparql.test.ts
+++ b/packages/core/test/sparql.test.ts
@@ -19,6 +19,7 @@ import {
 } from './fixtures/test-datasets.js';
 import { dereference } from '../src/test-utils.js';
 import { Penalty, Rating } from '../src/index.js';
+import { VALIDATION_WARNINGS_RATING_TYPE } from '../src/constants.js';
 
 const registrationsGraphIri = 'http://example.org/registrations';
 const allowedDomainsGraphIri = 'http://example.org/allowed-domains';
@@ -398,8 +399,25 @@ describe('SPARQL', () => {
       `);
       expect(await ratings.toArray()).toHaveLength(0);
 
-      const rating = new Rating([new Penalty('test/path', 5)], 1);
+      const rating = new Rating([new Penalty('test/path', 5)], 1, 3);
       await ratingStore.store(new URL(TEST_DATASET_IRIS.DATASET_1), rating);
+
+      // The warning count is stored as a second schema:Rating, discriminated by
+      // the validation-warnings additionalType, with schema:bestRating 0.
+      const warnings = await sparqlClient.query(`
+        PREFIX schema: <https://schema.org/>
+
+        SELECT ?warningCount WHERE {
+          GRAPH <${ratingsGraphIri}> {
+            <${TEST_DATASET_IRIS.DATASET_1}> schema:contentRating ?rating .
+            ?rating schema:additionalType <${VALIDATION_WARNINGS_RATING_TYPE}> ;
+              schema:ratingValue ?warningCount .
+          }
+        }
+      `);
+      const warningRows = await warnings.toArray();
+      expect(warningRows).toHaveLength(1);
+      expect(warningRows[0]!.get('warningCount')!.value).toBe('3');
     });
 
     it('deletes ratings', async () => {
@@ -407,7 +425,8 @@ describe('SPARQL', () => {
       const rating = new Rating([new Penalty('test/path', 5)], 1);
       await ratingStore.store(datasetUri, rating);
 
-      // Verify rating exists
+      // Verify both ratings exist: the completeness rating and the
+      // validation-warnings rating.
       const before = await sparqlClient.query(`
         PREFIX schema: <https://schema.org/>
         SELECT * WHERE {
@@ -416,7 +435,7 @@ describe('SPARQL', () => {
           }
         }
       `);
-      expect(await before.toArray()).toHaveLength(1);
+      expect(await before.toArray()).toHaveLength(2);
 
       // Delete
       await ratingStore.delete(datasetUri);

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 96.94,
+        lines: 96.96,
         functions: 95.34,
-        branches: 89.15,
-        statements: 96.43,
+        branches: 89.18,
+        statements: 96.44,
       },
     },
   },


### PR DESCRIPTION
## Why

The registration NDE compatibility criterion on the dataset detail page showed green even when a dataset’s description validated **with warnings**. The cause: validation warnings were computed during crawling but never persisted — only a single valid/invalid/gone status was stored — so the UI had no way to know about them.

## What

Capture a per-dataset validation-warning count at crawl time, persist it, and surface it as an orange **warning** tier on the registration criterion.

### Data model (`@dataset-register/core`)
- `rate()` counts `sh:Warning`-severity results from the per-dataset SHACL report it already receives (covers SHACL and probe warnings alike), exposed as `Rating.warningCount`.
- `SparqlRatingStore` persists this as a **second `schema:Rating`** linked by `schema:contentRating`, discriminated from the completeness rating by `schema:additionalType <…/registry/validation-warnings>`, with `schema:bestRating 0` (zero warnings is best) and `schema:ratingValue` = the count. Pure schema.org predicates.
- Counting comes from the **per-dataset** validation result, so it stays correct for datasets that share a registration (a catalogue), not the catalogue-wide report.
- The crawler needs no change — it already rates and stores per dataset.

### Browser
- The completeness rating display is provably unaffected: a `FILTER NOT EXISTS` excludes the warnings rating from the graph the completeness lens reads, and the count is read via a dedicated query.
- `registrationState()` returns `warning` when the registration is valid but has warnings; the criterion shows the warning count. `gone`/`invalid` stay `failed`.
- New English and Dutch translations for the warning heading, explanation and count.

## Notes
- Existing ratings turn orange only after the crawler re-runs and writes the warnings rating; until then the count reads 0 and the criterion stays green (graceful default).
- The consumer-facing data model doc (`schema:Rating`) is updated in the `docs` repository (separate PR).
