### PR TITLE
fix(browser): gate Linked data conformance on validated quads

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -462,19 +462,28 @@ async function fetchIiifManifests(datasetUri: string): Promise<IiifManifests> {
   return none;
 }
 
-// Reads the SCHEMA-AP-NDE sample conformance boolean for a dataset from the
-// Knowledge Graph. This co-emitted measurement decides whether a dataset that
-// provides linked data conforms to the profile (🟢) or only warns (🟠). Returns
-// null when no conformance measurement exists yet.
-async function fetchSchemaApNdeConformant(
+// Reads the SCHEMA-AP-NDE sample conformance for a dataset from the Knowledge
+// Graph. Both co-emitted measurements are needed: the `conformant` boolean is
+// only conclusive when `quadsValidated` > 0, since a `true` over zero validated
+// quads is vacuous (no resources of the profile’s classes were sampled). The
+// Linked data criterion uses the pair to split a confirmed profile (🟢) from a
+// warning (🟠). Each field is null when its measurement does not exist yet.
+async function fetchSchemaApNdeConformance(
   datasetUri: string,
-): Promise<boolean | null> {
+): Promise<{ conformant: boolean | null; quadsValidated: number | null }> {
+  const none = { conformant: null, quadsValidated: null };
   const query = `
     PREFIX dqv: <http://www.w3.org/ns/dqv#>
     PREFIX nde: <https://def.nde.nl/metric#>
-    SELECT ?conformant WHERE {
-      <${datasetUri}> dqv:hasQualityMeasurement
-        [ dqv:isMeasurementOf nde:schema-ap-nde-sample-conformance ; dqv:value ?conformant ] .
+    SELECT ?conformant ?quadsValidated WHERE {
+      OPTIONAL {
+        <${datasetUri}> dqv:hasQualityMeasurement
+          [ dqv:isMeasurementOf nde:schema-ap-nde-sample-conformance ; dqv:value ?conformant ] .
+      }
+      OPTIONAL {
+        <${datasetUri}> dqv:hasQualityMeasurement
+          [ dqv:isMeasurementOf nde:quads-validated ; dqv:value ?quadsValidated ] .
+      }
     }
     LIMIT 1
   `;
@@ -486,10 +495,16 @@ async function fetchSchemaApNdeConformant(
     for await (const raw of bindingsStream) {
       const binding = raw as unknown as {
         conformant?: { value: string };
+        quadsValidated?: { value: string };
       };
-      return binding.conformant?.value
-        ? binding.conformant.value === 'true'
-        : null;
+      return {
+        conformant: binding.conformant?.value
+          ? binding.conformant.value === 'true'
+          : null,
+        quadsValidated: binding.quadsValidated?.value
+          ? parseInt(binding.quadsValidated.value, 10)
+          : null,
+      };
     }
   } catch (e: unknown) {
     console.error(
@@ -497,7 +512,7 @@ async function fetchSchemaApNdeConformant(
       e instanceof Error ? e.message : e,
     );
   }
-  return null;
+  return none;
 }
 
 async function fetchDistributionCount(query: string): Promise<number> {
@@ -743,7 +758,7 @@ export async function fetchDatasetDetail(
     classPartitionResult,
     temporalCoverages,
     iiifManifests,
-    schemaApNdeConformant,
+    schemaApNdeConformance,
     warningCount,
   ] = await Promise.all([
     detailLens.query(datasetQuery),
@@ -772,7 +787,7 @@ export async function fetchDatasetDetail(
     classPartitionLens.findByIri(datasetUri),
     fetchTemporalCoverage(datasetUri),
     fetchIiifManifests(datasetUri),
-    fetchSchemaApNdeConformant(datasetUri),
+    fetchSchemaApNdeConformance(datasetUri),
     fetchWarningCount(datasetUri),
   ]);
 
@@ -797,7 +812,8 @@ export async function fetchDatasetDetail(
     declared: offersLinkedData(distributions),
     hasVoidDataset: summaryWithClassPartition !== null,
     hasContent: hasLinkedDataContent(summaryWithClassPartition),
-    conformant: schemaApNdeConformant,
+    conformant: schemaApNdeConformance.conformant,
+    quadsValidated: schemaApNdeConformance.quadsValidated,
     triples: summaryWithClassPartition?.triples ?? null,
   };
 

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -445,6 +445,7 @@ describe('compatibilityCriteria', () => {
           hasVoidDataset: false,
           hasContent: false,
           conformant: null,
+          quadsValidated: null,
           triples: null,
         },
         terms: { links: 42, distinctObjectsUri: 1000 },

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -16,6 +16,7 @@ const noLinkedData: LinkedData = {
   hasVoidDataset: false,
   hasContent: false,
   conformant: null,
+  quadsValidated: null,
   triples: null,
 };
 
@@ -129,6 +130,7 @@ describe('linkedDataState', () => {
         hasVoidDataset: true,
         hasContent: true,
         conformant: true,
+        quadsValidated: 200,
         triples: 1000,
       }),
     ).toEqual({ state: 'met' });
@@ -141,6 +143,7 @@ describe('linkedDataState', () => {
         hasVoidDataset: true,
         hasContent: true,
         conformant: false,
+        quadsValidated: 200,
         triples: 1000,
       }),
     ).toEqual({ state: 'warning' });
@@ -152,6 +155,23 @@ describe('linkedDataState', () => {
         hasVoidDataset: true,
         hasContent: true,
         conformant: null,
+        quadsValidated: null,
+        triples: 1000,
+      }),
+    ).toEqual({ state: 'warning' });
+  });
+
+  it('is a warning when conformance is vacuous: conformant but zero quads validated', () => {
+    // The Knowledge Graph co-emits `conformant: true` with `quadsValidated: 0`
+    // when nothing of the profile’s classes was sampled. That `true` is vacuous,
+    // not real conformance, so it must warn rather than confirm the profile.
+    expect(
+      linkedDataState({
+        declared: true,
+        hasVoidDataset: true,
+        hasContent: true,
+        conformant: true,
+        quadsValidated: 0,
         triples: 1000,
       }),
     ).toEqual({ state: 'warning' });
@@ -166,6 +186,7 @@ describe('linkedDataState', () => {
         hasVoidDataset: true,
         hasContent: true,
         conformant: true,
+        quadsValidated: 200,
         triples: 1000,
       }),
     ).toEqual({ state: 'met' });
@@ -178,6 +199,7 @@ describe('linkedDataState', () => {
         hasVoidDataset: false,
         hasContent: false,
         conformant: null,
+        quadsValidated: null,
         triples: null,
       }),
     ).toEqual({ state: 'failed', reason: 'no-linked-data' });
@@ -190,6 +212,7 @@ describe('linkedDataState', () => {
         hasVoidDataset: false,
         hasContent: false,
         conformant: null,
+        quadsValidated: null,
         triples: null,
       }),
     ).toEqual({ state: 'unmet' });
@@ -202,6 +225,7 @@ describe('linkedDataState', () => {
         hasVoidDataset: true,
         hasContent: false,
         conformant: null,
+        quadsValidated: null,
         triples: null,
       }),
     ).toEqual({ state: 'failed', reason: 'empty' });
@@ -320,6 +344,7 @@ describe('compatibilityCriteria', () => {
         hasVoidDataset: true,
         hasContent: true,
         conformant: true,
+        quadsValidated: 200,
         triples: 1234,
       },
       terms: null,
@@ -339,6 +364,7 @@ describe('compatibilityCriteria', () => {
         hasVoidDataset: true,
         hasContent: false,
         conformant: null,
+        quadsValidated: null,
         triples: null,
       },
       terms: null,

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -124,12 +124,20 @@ export interface SchemaApNdeConformance {
 //                    void:triples aggregate.
 // 'conformant'     — whether a sampled set of resources conforms to
 //                    SCHEMA-AP-NDE; null when no conformance measurement exists.
+//                    Only conclusive together with 'quadsValidated' > 0: a
+//                    `true` over zero validated quads is vacuous, not real
+//                    conformance.
+// 'quadsValidated' — how many quads the conformance sample actually validated
+//                    against the profile; null when no measurement exists. Zero
+//                    means nothing of the profile’s classes was sampled, so the
+//                    co-emitted 'conformant' carries no evidence.
 // 'triples'        — void:triples, for the “n feiten” count; null when absent.
 export interface LinkedData {
   declared: boolean;
   hasVoidDataset: boolean;
   hasContent: boolean;
   conformant: boolean | null;
+  quadsValidated: number | null;
   triples: number | null;
 }
 
@@ -224,17 +232,23 @@ export function schemaApNdeState(
 // Derives the Linked data state. Content is the strongest signal: a dataset the
 // Knowledge Graph extracted content from provides linked data whatever the
 // register lists, so conformance to SCHEMA-AP-NDE then splits good (🟢, `met`)
-// from a warning (🟠, content that does not — or does not yet — conform). With no
-// content the criterion is judged from what is declared: nothing declared is a
-// plain `failed`/'no-linked-data'; a declared distribution awaiting analysis is
-// neutral pending (⚪, `unmet`); a declared distribution that was analyzed but
-// yielded no content is `failed`/'empty'.
+// from a warning (🟠, content that does not — or does not yet — conform).
+// Conformance counts only when the sample actually validated quads against the
+// profile (`quadsValidated` > 0); a `conformant: true` over zero validated quads
+// is vacuous (no resources of the profile’s classes were sampled), so it warns
+// rather than confirming the profile. With no content the criterion is judged
+// from what is declared: nothing declared is a plain `failed`/'no-linked-data';
+// a declared distribution awaiting analysis is neutral pending (⚪, `unmet`); a
+// declared distribution that was analyzed but yielded no content is
+// `failed`/'empty'.
 export function linkedDataState(linkedData: LinkedData): {
   state: CompatibilityState;
   reason?: LinkedDataFailureReason;
 } {
   if (linkedData.hasContent) {
-    return linkedData.conformant ? { state: 'met' } : { state: 'warning' };
+    const conformanceProven =
+      linkedData.conformant === true && (linkedData.quadsValidated ?? 0) > 0;
+    return conformanceProven ? { state: 'met' } : { state: 'warning' };
   }
   if (!linkedData.declared) {
     return { state: 'failed', reason: 'no-linked-data' };


### PR DESCRIPTION
## Problem

The Linked data NDE compatibility item on the dataset detail page showed the green **“Provides linked data conforming to the NDE Application Profile”** (`met`) state for datasets whose SCHEMA-AP-NDE sample conformance is only vacuously true.

For [`openarchieven.nl/id/dataset_frl`](https://datasetregister.netwerkdigitaalerfgoed.nl/en/dataset?uri=https://www.openarchieven.nl/id/dataset_frl) the Knowledge Graph co-emits:

| metric | value |
|---|---|
| `schema-ap-nde-sample-conformance` | `true` |
| `quads-validated` | `0` |

`conformant: true` over `quads-validated: 0` means nothing of the profile’s classes was sampled, so the `true` is vacuous – not real conformance. The dataset does not declare `dct:conformsTo` either, so there is no evidence it conforms.

## Cause

`#2040` introduced the Linked data criterion and simplified the conformance fetch to just the `conformant` boolean, dropping the `quads-validated > 0` gate that the previous binary SCHEMA-AP-NDE row had via `schemaApNdeState`. `linkedDataState` then trusted `conformant` at face value, so `hasContent && conformant=true` rendered as `met`.

## Fix

- Require `quadsValidated > 0` for the `met` state in `linkedDataState`; a `conformant: true` with zero validated quads now warns (🟠) instead.
- `fetchSchemaApNdeConformance` reads the co-emitted `nde:quads-validated` measurement alongside the conformant boolean and returns both.
- Add `quadsValidated` to the `LinkedData` interface and thread it through the dataset detail loader.
- Add a regression test for the vacuous-conformance case.

This brings the detail criterion in line with the dataset card’s SCHEMA-AP-NDE badge, which already gates on `schemaApNdeQuadsValidated`.
