### PR TITLE
feat(browser): link Linked data fact count to its summary section

### DIFF
--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -186,13 +186,22 @@
 
   // In-page anchor to the criterion’s evidence section further down the page, or
   // null when it has none. Registration points to its Registration section; the
-  // terms criterion (when met) to the Terminology Sources section. The template
-  // attaches this to the count line when there is one, otherwise renders a
-  // dedicated link.
+  // linked-data criterion (when it reports a fact count) to the Linked Data
+  // Summary section; the terms criterion (when met) to the Terminology Sources
+  // section. The template attaches this to the count line when there is one,
+  // otherwise renders a dedicated link.
   function sectionAnchor(criterion: CompatibilityCriterion): string | null {
     switch (criterion.key) {
       case 'registration':
         return '#registration';
+      case 'linked-data':
+        // Link the fact count down to the Linked Data Summary section; gated to
+        // match the count line in detail() so the anchor only appears alongside
+        // it, never as a standalone link.
+        return (criterion.state === 'met' || criterion.state === 'warning') &&
+          criterion.count > 0
+          ? '#linked-data-summary'
+          : null;
       case 'terms':
         return criterion.state === 'met' ? '#terminology-sources' : null;
       default:

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -1273,7 +1273,8 @@
   {#if summary && hasVoidStats}
     <div class="mb-8">
       <h2
-        class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
+        id="linked-data-summary"
+        class="mb-4 flex scroll-mt-4 items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
       >
         {m.detail_linked_data_summary()}
         <span id="tooltip-linked-data-summary" class="cursor-pointer">


### PR DESCRIPTION
For the Linked data NDE compatibility item, links the “facts found” count down to the Linked Data Summary section on the dataset detail page.

## Changes

- **`NdeCompatibility.svelte`**: add a `linked-data` case to `sectionAnchor()` returning `#linked-data-summary`. It is gated on the same `met`/`warning` + `count > 0` condition as the count line in `detail()`, so the anchor only ever rides on that line and never renders as a standalone link.
- **`dataset/+page.svelte`**: add `id="linked-data-summary"` and `scroll-mt-4` to the Linked Data Summary heading so it serves as the scroll target, matching the existing `#registration` pattern.
