### PR TITLE
feat(browser): revise NDE compatibility section intro and links

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -330,7 +330,9 @@
   ],
   "nde_compat_terms_heading_uses": "Uses terms from the Network of Terms",
   "nde_compat_terms_heading_not_uses": "Does not use terms from the Network of Terms",
-  "nde_compat_terms_explanation": "Objects in this dataset link to shared terms from terminology sources in the Network of Terms, which makes the data interoperable and easier to find.",
+  "nde_compat_terms_explanation_before": "Objects in this dataset link to shared terms from terminology sources in the ",
+  "nde_compat_terms_explanation_after": ", which makes the data interoperable and easier to find.",
+  "network_of_terms": "Network of Terms",
   "nde_compat_terms_count": [
     {
       "declarations": [

--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -248,7 +248,7 @@
   ],
   "dataset_schema_ap_nde": "Conforms to the NDE Schema.org Application Profile (sampled)",
   "nde_compatibility": "NDE compatibility",
-  "nde_compatibility_description": "Shows which NDE criteria this dataset meets.",
+  "nde_compatibility_description": "These checks run automatically against the current NDE criteria. They give an up-to-date picture and help you improve the findability and reusability of your dataset.",
   "nde_compat_registration_heading_registered": "Registered in the Dataset Register",
   "nde_compat_registration_heading_gone": "Registration no longer accessible",
   "nde_compat_registration_heading_invalid": "Registration no longer valid",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -248,7 +248,7 @@
   ],
   "dataset_schema_ap_nde": "Voldoet aan het NDE Schema.org-applicatieprofiel (steekproef)",
   "nde_compatibility": "NDE-compatibiliteit",
-  "nde_compatibility_description": "Laat zien aan welke NDE-criteria deze dataset voldoet.",
+  "nde_compatibility_description": "Deze controles worden automatisch uitgevoerd op basis van de huidige NDE-criteria. Ze geven een actueel beeld en helpen je de vindbaarheid en herbruikbaarheid van je dataset te vergroten.",
   "nde_compat_registration_heading_registered": "Geregistreerd in het Datasetregister",
   "nde_compat_registration_heading_gone": "Registratie niet meer toegankelijk",
   "nde_compat_registration_heading_invalid": "Registratie niet meer geldig",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -330,7 +330,9 @@
   ],
   "nde_compat_terms_heading_uses": "Gebruikt termen uit het Termennetwerk",
   "nde_compat_terms_heading_not_uses": "Gebruikt geen termen uit het Termennetwerk",
-  "nde_compat_terms_explanation": "Objecten in deze dataset linken naar gedeelde termen uit terminologiebronnen in het Termennetwerk, waardoor de data interoperabel en beter vindbaar wordt.",
+  "nde_compat_terms_explanation_before": "Objecten in deze dataset linken naar gedeelde termen uit terminologiebronnen in het ",
+  "nde_compat_terms_explanation_after": ", waardoor de data interoperabel en beter vindbaar wordt.",
+  "network_of_terms": "Termennetwerk",
   "nde_compat_terms_count": [
     {
       "declarations": [

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
   import * as m from '$lib/paraglide/messages';
   import { getLocale } from '$lib/paraglide/runtime';
-  import { Tooltip } from 'flowbite-svelte';
   import CheckOutline from 'flowbite-svelte-icons/CheckOutline.svelte';
   import CloseOutline from 'flowbite-svelte-icons/CloseOutline.svelte';
   import ExclamationCircleOutline from 'flowbite-svelte-icons/ExclamationCircleOutline.svelte';
-  import InfoCircleSolid from 'flowbite-svelte-icons/InfoCircleSolid.svelte';
   import {
     compatibilityCriteria,
     NDE_VINKJES_URL,
-    SCHEMA_AP_NDE_PROFILE,
+    NETWORK_OF_TERMS_URL,
     type CompatibilityCriterion,
     type IiifManifests,
     type LinkedData,
@@ -121,9 +119,15 @@
               : m.nde_compat_linked_data_explanation_none();
         }
       // A single explanation regardless of state, following the IIIF pattern.
+      // The template renders this with “Network of Terms” as an inline link;
+      // the two halves are joined here as the plain-text fallback.
       // eslint-disable-next-line no-fallthrough
       case 'terms':
-        return m.nde_compat_terms_explanation();
+        return (
+          m.nde_compat_terms_explanation_before() +
+          m.network_of_terms() +
+          m.nde_compat_terms_explanation_after()
+        );
       case 'iiif':
         return m.nde_compat_iiif_explanation();
     }
@@ -171,19 +175,6 @@
     }
   }
 
-  function learnMoreHref(criterion: CompatibilityCriterion): string {
-    switch (criterion.key) {
-      case 'registration':
-        return NDE_VINKJES_URL;
-      case 'linked-data':
-        return SCHEMA_AP_NDE_PROFILE;
-      case 'terms':
-        return NDE_VINKJES_URL;
-      case 'iiif':
-        return NDE_VINKJES_URL;
-    }
-  }
-
   // In-page anchor to the criterion’s evidence section further down the page, or
   // null when it has none. Registration points to its Registration section; the
   // linked-data criterion (when it reports a fact count) to the Linked Data
@@ -216,18 +207,22 @@
   <section class="mb-8" aria-labelledby="nde-compatibility-heading">
     <h2
       id="nde-compatibility-heading"
-      class="mb-4 flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
+      class="mb-2 text-xl font-semibold text-gray-900 dark:text-white"
     >
       {m.nde_compatibility()}
-      <span id="tooltip-nde-compatibility" class="cursor-pointer">
-        <InfoCircleSolid
-          class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
-        />
-      </span>
-      <Tooltip triggeredBy="#tooltip-nde-compatibility"
-        >{m.nde_compatibility_description()}</Tooltip
-      >
     </h2>
+    <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
+      {m.nde_compatibility_description()}
+      <a
+        href={NDE_VINKJES_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-blue-600 hover:underline dark:text-blue-400"
+      >
+        {m.nde_compat_learn_more()}
+        <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+      </a>
+    </p>
     <div
       class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
     >
@@ -265,16 +260,20 @@
                 {heading(criterion)}
               </h3>
               <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                {explanation(criterion)}
-                <a
-                  href={learnMoreHref(criterion)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="text-blue-600 hover:underline dark:text-blue-400"
-                >
-                  {m.nde_compat_learn_more()}
-                  <span class="sr-only"> ({m.opens_in_new_tab()})</span>
-                </a>
+                <!-- The terms explanation links “Network of Terms” to the
+                     Termennetwerk browser in the current locale; other criteria
+                     render their explanation as plain text. -->
+                {#if criterion.key === 'terms'}{m.nde_compat_terms_explanation_before()}<a
+                    href={`${NETWORK_OF_TERMS_URL}/${getLocale()}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-blue-600 hover:underline dark:text-blue-400"
+                    >{m.network_of_terms()}<span class="sr-only">
+                      ({m.opens_in_new_tab()})</span
+                    ></a
+                  >{m.nde_compat_terms_explanation_after()}{:else}{explanation(
+                    criterion,
+                  )}{/if}
                 <!-- A criterion with an evidence section but no count line (e.g.
                      registration) gets a dedicated in-page link here; one with a
                      count line carries the link on that line instead. -->

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -8,16 +8,15 @@
 // Dataset Knowledge Graph.
 export const IIIF_PRESENTATION_API = 'http://iiif.io/api/presentation/';
 
-// NDE’s documentation on the criteria (“vinkjes”). The registration and IIIF
-// criteria both link here.
+// NDE’s documentation on the criteria (“vinkjes”). The NDE compatibility section
+// links here from its introduction.
 export const NDE_VINKJES_URL =
   'https://netwerkdigitaalerfgoed.nl/aanpak/bruikbaar/#vinkjes';
 
-// The NDE Schema.org Application Profile. A distribution declares compliance with
-// `dct:conformsTo` pointing here (the register’s internal model is DCAT, so the
-// publisher-facing schema:usageInfo is normalised to dct:conformsTo at ingest).
-// Also linked from the detail page as the criterion’s documentation.
-export const SCHEMA_AP_NDE_PROFILE = 'https://docs.nde.nl/schema-profile/';
+// The Network of Terms (“Termennetwerk”) browser. The request locale is appended
+// as a path segment (e.g. `/en`, `/nl`) when linking from the terms criterion.
+export const NETWORK_OF_TERMS_URL =
+  'https://termennetwerk.netwerkdigitaalerfgoed.nl';
 
 // DQV metric IRIs for the IIIF manifest validation measurements recorded by the
 // Dataset Knowledge Graph.


### PR DESCRIPTION
## Summary

Reworks the **NDE compatibility** section on the dataset detail page so the explanation of what is being checked lives in one place, and links the Network of Terms to its public browser.

## Changes

- **Section intro + single Learn more link.** The description of what the section checks moves out of the heading’s info‑icon tooltip into a visible intro sentence below the heading, followed by one generic “Learn more” link to the NDE criteria documentation (`https://netwerkdigitaalerfgoed.nl/aanpak/bruikbaar/#vinkjes`).
- **Removed the per‑criterion Learn more links.** Each criterion no longer carries its own “Learn more” link; the single generic link in the intro replaces them. The now‑unused `learnMoreHref` helper and the `SCHEMA_AP_NDE_PROFILE` export are removed.
- **Linked “Network of Terms”.** In the terms criterion explanation, “Network of Terms” (NL: “Termennetwerk”) is now a link to the Network of Terms browser in the current locale (`https://termennetwerk.netwerkdigitaalerfgoed.nl/<lang>`). The explanation message is split into before/after parts plus a reusable `network_of_terms` label so the link sits inline with correct EN/NL word order.

The per‑criterion in‑page evidence links (e.g. “View registration details”, fact/term/IIIF count links) are unchanged.
