### PR TITLE
feat(browser): rename NDE compatibility section to Automated checks

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -247,7 +247,7 @@
     }
   ],
   "dataset_schema_ap_nde": "Conforms to the NDE Schema.org Application Profile (sampled)",
-  "nde_compatibility": "NDE compatibility",
+  "nde_compatibility": "Automated checks",
   "nde_compatibility_description": "These checks run automatically against the current NDE criteria. They give an up-to-date picture and help you improve the findability and reusability of your dataset.",
   "nde_compat_registration_heading_registered": "Registered in the Dataset Register",
   "nde_compat_registration_heading_gone": "Registration no longer accessible",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -247,7 +247,7 @@
     }
   ],
   "dataset_schema_ap_nde": "Voldoet aan het NDE Schema.org-applicatieprofiel (steekproef)",
-  "nde_compatibility": "NDE-compatibiliteit",
+  "nde_compatibility": "Automatische controles",
   "nde_compatibility_description": "Deze controles worden automatisch uitgevoerd op basis van de huidige NDE-criteria. Ze geven een actueel beeld en helpen je de vindbaarheid en herbruikbaarheid van je dataset te vergroten.",
   "nde_compat_registration_heading_registered": "Geregistreerd in het Datasetregister",
   "nde_compat_registration_heading_gone": "Registratie niet meer toegankelijk",


### PR DESCRIPTION
Renames the dataset detail section previously titled “NDE compatibility” to better describe what it is: a set of checks that run automatically against the current NDE criteria.

## Changes

- `apps/browser/messages/en.json`: `nde_compatibility` → “Automated checks”
- `apps/browser/messages/nl.json`: `nde_compatibility` → “Automatische controles”

The descriptive subtext (`nde_compatibility_description`) already reads naturally under the new heading and is left unchanged. Message keys and component/service identifiers keep their existing `nde_compatibility` naming to keep the diff minimal.
