### PR TITLE
feat(browser): rename ‘facts found’ to ‘triples found’ in automated checks

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -291,8 +291,8 @@
       ],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "{display} fact found.",
-        "countPlural=other": "{display} facts found."
+        "countPlural=one": "{display} triple found.",
+        "countPlural=other": "{display} triples found."
       }
     }
   ],


### PR DESCRIPTION
## Summary

Renames the linked-data count in the automated checks (NDE compatibility) section from “n facts found” to “n triples found”, so it matches the “triples” terminology used elsewhere on the page.

## Changes

- `apps/browser/messages/en.json`: change the `nde_compat_linked_data_count` strings from “fact/facts found” to “triple/triples found”.
- The Dutch translation already uses “feiten”, which is the Dutch term for triples, so no translation change was needed.
