### PR TITLE
build(deps): bump @lde packages (empty-distribution detection)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14679,13 +14679,13 @@
       }
     },
     "node_modules/@lde/distribution-probe": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@lde/distribution-probe/-/distribution-probe-0.1.5.tgz",
-      "integrity": "sha512-JLKVcCSf59Kt4yGDgP7zECytO2+v+VVGZQPlWZDB6YW31+6TogUbRAxLrCQH96F9H1aQQdviFeww/olK7Bj7jw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@lde/distribution-probe/-/distribution-probe-0.1.7.tgz",
+      "integrity": "sha512-XuF5/m0pnd5nl8tnG1CH3iT7BVBCDRloQncYG/wu2Ax02c+GYX3ucPYjGm7qOs9HLYAjDs4Gcj/UcHSg56rEwA==",
       "license": "MIT",
       "dependencies": {
         "@lde/dataset": "0.7.4",
-        "n3": "^2.0.1",
+        "rdf-parse": "^5.0.0",
         "tslib": "^2.3.0"
       }
     },
@@ -32231,8 +32231,8 @@
       "dependencies": {
         "@comunica/query-sparql": "^5.2.3",
         "@comunica/types": "^5.2.3",
-        "@lde/dataset": "^0.7.3",
-        "@lde/distribution-probe": "^0.1.4",
+        "@lde/dataset": "^0.7.4",
+        "@lde/distribution-probe": "^0.1.7",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-metrics-otlp-proto": "^0.218.0",
         "@opentelemetry/resources": "^2.7.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "@comunica/query-sparql": "^5.2.3",
     "@comunica/types": "^5.2.3",
-    "@lde/dataset": "^0.7.3",
-    "@lde/distribution-probe": "^0.1.4",
+    "@lde/dataset": "^0.7.4",
+    "@lde/distribution-probe": "^0.1.7",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-proto": "^0.218.0",
     "@opentelemetry/resources": "^2.7.0",


### PR DESCRIPTION
## What

Bumps the `@lde/*` dependencies to their latest published versions:

- `@lde/distribution-probe` `^0.1.4` → `^0.1.7`
- `@lde/dataset` `^0.7.3` → `^0.7.4`

`@lde/dataset-registry-client` (`^0.8.0`) and `@lde/fastify-rdf` (`^0.4.4`) are already at their latest published versions, so they are unchanged.

## Behavioral impact

`@lde/distribution-probe` 0.1.7 ([#441](https://github.com/ldelements/lde/pull/441), [#442](https://github.com/ldelements/lde/pull/442)) now detects **empty** RDF distributions across all serializations — JSON-LD `{}`, empty RDF/XML, prefix-only N3, TriG — not just Turtle/N-Triples/N-Quads, and matches content types case-insensitively. A remote JSON-LD `@context` is fetched (bounded by the probe timeout) and resolves on the first triple; a timeout or unreachable context is treated as inconclusive rather than faulty.

As a result the probe now flags distributions that serve an empty graph in those formats. On the registration (strict) path this means such a distribution invalidates the dataset; in the crawler it surfaces as a warning after the failure streak threshold.
