### PR TITLE
fix: accept dct:temporal as a dct:PeriodOfTime in temporal warning

### DIFF
--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -307,6 +307,38 @@ describe('Validator', () => {
     expect(temporalResults.size).toEqual(0);
   });
 
+  it('accepts dct:temporal as a dct:PeriodOfTime structured value', async () => {
+    // The register rewrites ISO 8601 dct:temporal literals into dct:PeriodOfTime
+    // blank nodes (see normalizeTemporalCoverage), which is the canonical DCAT
+    // form rendered on the dataset page. The warning shape must treat that
+    // structured value as valid; otherwise the crawler flags a spurious warning
+    // that the /validate endpoint (which sees the raw literal) never reports.
+    const dcatValid = await file('dataset-dcat-valid.jsonld');
+    const withPeriod = dcatValid.replace(
+      '"dct:temporal": "1939/1945",',
+      `"dct:temporal": {
+        "@type": "dct:PeriodOfTime",
+        "dcat:startDate": { "@value": "1939", "@type": "http://www.w3.org/2001/XMLSchema#gYear" },
+        "dcat:endDate": { "@value": "1945", "@type": "http://www.w3.org/2001/XMLSchema#gYear" }
+      },`,
+    );
+    const input = (await rdf
+      .dataset()
+      .import(
+        Readable.from(withPeriod).pipe(
+          new JsonLdParser() as unknown as Transform,
+        ),
+      )) as unknown as Dataset;
+    const report = (await validator.validate(input)) as Valid;
+    expect(report.state).toEqual('valid');
+    const temporalResults = report.errors.match(
+      null,
+      shacl('resultPath'),
+      rdf.namedNode('http://purl.org/dc/terms/temporal'),
+    );
+    expect(temporalResults.size).toEqual(0);
+  });
+
   it('warns that schema:genre is deprecated', async () => {
     const report = (await validate(
       'dataset-schema-org-genre-deprecated.jsonld',

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -1374,6 +1374,7 @@ dcat:DatasetShape
         sh:or (
             [ sh:nodeKind sh:IRI ; sh:pattern "^https?://" ]
             [ sh:pattern "^(-?\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}:\\d{2}(:\\d{2})?)?)?)?|\\.\\.)(/(-?\\d{4}(-\\d{2}(-\\d{2}(T\\d{2}:\\d{2}(:\\d{2})?)?)?)?|\\d{2}(-\\d{2})?|\\.\\.))?$" ]
+            [ sh:class dc:PeriodOfTime ]
         ) ;
         sh:severity sh:Warning ;
         nde:futureChange [


### PR DESCRIPTION
## Problem

The dataset detail page showed "Registered with warnings – 1 validation warning" for datasets whose `/validate` result reports **no** warnings (e.g. [Gouda Tijdmachine](https://datasetregister.netwerkdigitaalerfgoed.nl/en/dataset?uri=https://n2t.net/ark:/60537/bD64Hu)).

The crawler rewrites ISO 8601 `dct:temporal` literals (e.g. `1300/2020`) into the canonical DCAT `dct:PeriodOfTime` form – a blank node with `dcat:startDate` / `dcat:endDate` – via `normalizeTemporalCoverage`. The `dc:temporal` warning shape only accepted **a web URI or an ISO 8601 literal**, so the structured period matched neither `sh:or` branch and produced a spurious "Use an ISO 8601 date or time interval … or a web URI" warning. `/validate`, which sees the publisher's raw literal, never reported it.

This also matters beyond the warning: the shape's `nde:futureChange` escalates it to `sh:Violation` at profile v2.0, so without this fix every dataset with a normalized temporal period would have become **invalid** at 2.0.

## Change

- Add an `[ sh:class dc:PeriodOfTime ]` branch to the `dc:temporal` warning `sh:or`, so the structured DCAT period the register itself produces (and that a publisher may submit directly) validates cleanly.
- Add a regression test validating a `dct:Dataset` whose `dct:temporal` is a `dct:PeriodOfTime` node and asserting zero temporal results.

Scope: only the DCAT `dc:temporal` shape is touched; the parallel `schema:temporalCoverage` shape is left as‑is, since schema.org input is validated as a raw literal that already matches the pattern.

> Note: this is the standalone shape fix. The broader change to compute the dataset page's warning state from the registration's raw‑data validation (instead of the per‑dataset DCAT projection) is tracked separately.
