### PR TITLE
feat: show when the Knowledge Graph last updated the summary

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -178,6 +178,7 @@
   "detail_object_types_description": "Shows the distribution between literal values and URI references in the dataset's object positions.",
   "detail_about": "About",
   "detail_linked_data_summary_description": "Statistical information about this dataset retrieved from the Knowledge Graph, including the number of triples, entities, properties, and class distribution.",
+  "detail_summary_updated": "Last updated {time}",
   "detail_registered_url": "Registered URL",
   "detail_registered_url_description": "URL where the dataset is described.",
   "detail_validate": "Validate",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -178,6 +178,7 @@
   "detail_object_types_description": "Toont de verdeling tussen literale waarden en URI-verwijzingen in de objectposities van de dataset.",
   "detail_about": "Onderwerp",
   "detail_linked_data_summary_description": "Statistische informatie over deze dataset opgehaald uit de Dataset Knowledge Graph, inclusief het aantal feiten, entiteiten, eigenschappen en typeverdeling.",
+  "detail_summary_updated": "{time} bijgewerkt",
   "detail_registered_url": "Geregistreerde URL",
   "detail_registered_url_description": "URL waar de dataset wordt beschreven.",
   "detail_validate": "Controleren",

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -394,6 +394,9 @@ export interface DatasetDetailResult {
   distributions: DistributionDetail[];
   totalDistributions: number;
   summary: DatasetSummary | null;
+  // When the Knowledge Graph last generated the summary (ISO dateTime from the
+  // DKG's PROV-O provenance), or null when no provenance has been recorded.
+  summaryGeneratedAt: string | null;
   linksets: Linkset[];
   temporalCoverages: TemporalCoverage[];
   iiifManifests: IiifManifests;
@@ -522,6 +525,41 @@ async function fetchSchemaApNdeConformance(
     );
   }
   return none;
+}
+
+// Reads when the Knowledge Graph last generated this dataset's summary, from the
+// PROV-O provenance the DKG records. The DKG runs many analysis steps, each
+// emitting its own prov:Activity (linked via prov:wasGeneratedBy) with a
+// prov:endedAtTime; the latest of those marks the most recent generation. Returns
+// null when no provenance has been recorded yet.
+async function fetchSummaryGeneratedAt(
+  datasetUri: string,
+): Promise<string | null> {
+  const query = `
+    PREFIX prov: <http://www.w3.org/ns/prov#>
+    SELECT (MAX(?ended) AS ?generatedAt) WHERE {
+      <${datasetUri}> prov:wasGeneratedBy ?activity .
+      ?activity prov:endedAtTime ?ended .
+    }
+  `;
+  try {
+    const bindingsStream = await fetcher.fetchBindings(
+      PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+      query,
+    );
+    for await (const raw of bindingsStream) {
+      const binding = raw as unknown as {
+        generatedAt?: { value: string };
+      };
+      return binding.generatedAt?.value ?? null;
+    }
+  } catch (e: unknown) {
+    console.error(
+      'Summary generated-at query failed:',
+      e instanceof Error ? e.message : e,
+    );
+  }
+  return null;
 }
 
 async function fetchDistributionCount(query: string): Promise<number> {
@@ -729,6 +767,7 @@ export async function fetchDatasetDetail(
     summary,
     linksets,
     classPartitionResult,
+    summaryGeneratedAt,
     temporalCoverages,
     iiifManifests,
     schemaApNdeConformance,
@@ -757,6 +796,7 @@ export async function fetchDatasetDetail(
         return null;
       }),
     classPartitionLens.findByIri(datasetUri),
+    fetchSummaryGeneratedAt(datasetUri),
     fetchTemporalCoverage(datasetUri),
     fetchIiifManifests(datasetUri),
     fetchSchemaApNdeConformance(datasetUri),
@@ -829,6 +869,7 @@ export async function fetchDatasetDetail(
     distributions,
     totalDistributions,
     summary: summaryWithClassPartition,
+    summaryGeneratedAt,
     linksets: linksets ?? [],
     temporalCoverages,
     iiifManifests,

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -53,6 +53,7 @@
   const distributions = $derived(data.distributions);
   const totalDistributions = $derived(data.totalDistributions);
   const summary = $derived(data.summary);
+  const summaryGeneratedAt = $derived(data.summaryGeneratedAt);
   const linksets = $derived(data.linksets);
   const temporalCoverages = $derived(data.temporalCoverages);
   const iiifManifests = $derived(data.iiifManifests);
@@ -1274,7 +1275,7 @@
     <div class="mb-8">
       <h2
         id="linked-data-summary"
-        class="mb-4 flex scroll-mt-4 items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
+        class="mb-4 flex scroll-mt-4 flex-wrap items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
       >
         {m.detail_linked_data_summary()}
         <span id="tooltip-linked-data-summary" class="cursor-pointer">
@@ -1285,6 +1286,25 @@
         <Tooltip triggeredBy="#tooltip-linked-data-summary"
           >{m.detail_linked_data_summary_description()}</Tooltip
         >
+        {#if summaryGeneratedAt}
+          <span
+            id="summary-generated-relative"
+            class="ml-auto cursor-default text-sm font-normal text-gray-600 dark:text-gray-400"
+          >
+            {m.detail_summary_updated({
+              time: getRelativeTimeString(new Date(summaryGeneratedAt)),
+            })}
+          </span>
+          <Tooltip triggeredBy="#summary-generated-relative">
+            {new Date(summaryGeneratedAt).toLocaleDateString(getLocale(), {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
+          </Tooltip>
+        {/if}
       </h2>
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <!-- Merged: Triples + Subjects + Avg Triples Per Subject -->


### PR DESCRIPTION
## Summary

On the dataset detail page, the Linked Data Summary now shows when the Knowledge Graph last generated it, read from the DKG’s PROV-O provenance.

It renders at the right of the “Linked Data Summary” heading as relative time, with the exact timestamp on hover:

- EN: `Last updated 12 hours ago`
- NL: `12 uur geleden bijgewerkt`

## Changes

- **`dataset-detail.ts`** – add `fetchSummaryGeneratedAt`, querying `MAX(prov:endedAtTime)` over the dataset’s `prov:wasGeneratedBy` activities in the Knowledge Graph. The DKG emits one `prov:Activity` per analysis step, so the latest end time marks the most recent generation. Returns `null` (and logs) on failure, so a Knowledge Graph hiccup never breaks the page. Surfaced as `summaryGeneratedAt` on `DatasetDetailResult`.
- **`+page.svelte`** – display the timestamp at the right of the summary heading via relative time, with the full date/time in a hover tooltip.
- **`messages/{en,nl}.json`** – add a parameterized `detail_summary_updated` message with a `{time}` placeholder, so each locale controls its own word order (English can’t go time-first, Dutch reads more naturally that way).

## Notes

- There is no `prov:generatedAtTime` in the graph; the only provenance timestamps are `prov:startedAtTime` / `prov:endedAtTime` on the activities. `endedAtTime` (when generation finished) is used.
- UI-only addition reading existing data; no API or data-model change.
