### PR TITLE
fix(browser): prevent horizontal scrollbar in distribution dropdowns

### DIFF
--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -1220,7 +1220,7 @@
           <Dropdown
             simple
             triggeredBy="#btn-query-dropdown"
-            class="w-96 max-h-96 overflow-y-auto border border-gray-200 shadow-lg dark:border-gray-600"
+            class="max-h-96 w-max min-w-72 max-w-[28rem] overflow-y-auto overflow-x-hidden border border-gray-200 shadow-lg dark:border-gray-600"
           >
             {#each sparqlDistributions as distribution, distIndex (distribution.$id)}
               <DropdownItem
@@ -1299,7 +1299,7 @@
           <Dropdown
             simple
             triggeredBy="#btn-download-dropdown"
-            class="w-[28rem] max-h-96 overflow-y-auto border border-gray-200 shadow-lg dark:border-gray-600"
+            class="max-h-96 w-max min-w-72 max-w-[28rem] overflow-y-auto overflow-x-hidden border border-gray-200 shadow-lg dark:border-gray-600"
           >
             {#each rdfDownloads as distribution, distIndex (distribution.$id)}
               {@render downloadDropdownItem(distribution, 'rdf', distIndex)}


### PR DESCRIPTION
The query and download dropdowns on the dataset detail page used a fixed `w-96` together with `overflow-y-auto`. Long access URLs overflowed that width, and because `overflow-y-auto` makes `overflow-x` compute to `auto`, the dropdown showed a **horizontal scrollbar** — visible on Windows/Chrome, where scrollbars take layout space (see #1994).

Fix #1994.

## Change

Replace the fixed `w-96` on both dropdowns with a content-based width clamped to a `min-w-72 … max-w-[28rem]` range, and clip the x-axis with `overflow-x-hidden`:

- short content no longer wastes a fixed 24rem of width (matches the cleaner look suggested in the issue);
- long URLs truncate with an ellipsis (their existing `truncate` now takes effect at the capped width) instead of forcing overflow;
- no horizontal scrollbar can appear on any platform;
- the cap keeps a very wide URL or description from blowing the dropdown out, addressing the overflow concern raised in the issue.

`max-h-96 overflow-y-auto` is unchanged, so a tall list still scrolls vertically.

## Verification

Reproduced locally on the dataset from the issue (van Abbe single-channel artworks): before, the dropdown measured `clientWidth 382` vs `scrollWidth 446` (64px of horizontal overflow, `overflow-x: auto`). After the change it measures `446 === 446` with `overflow-x: hidden` and the URL truncating with an ellipsis — no horizontal scrollbar.

## Note

This touches the same dropdowns as #2068 (distribution availability). Whichever merges first, the other will need a trivial rebase on these two class lines.
