### PR TITLE
feat: add persistent HTTP URIs compatibility criterion

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -259,6 +259,30 @@
   "nde_compat_registration_heading_warning": "Registered with warnings",
   "nde_compat_registration_explanation_warning": "This dataset’s description is registered and valid, but it validated with warnings: some recommendations for datasets are not yet met.",
   "nde_compat_registration_view_details": "View registration details",
+  "nde_compat_persistent_heading_persistent": "Uses persistent URIs",
+  "nde_compat_persistent_heading_resolves": "Uses a non-persistent domain name",
+  "nde_compat_persistent_heading_unresolved": "Some URIs are not reachable",
+  "nde_compat_persistent_heading_pending": "Persistent URIs not yet assessed",
+  "nde_compat_persistent_explanation_persistent": "This dataset’s URIs resolve to a landing page.",
+  "nde_compat_persistent_explanation_resolves": "This dataset’s URIs use a non-persistent domain name, for example one from a software vendor.",
+  "nde_compat_persistent_explanation_unresolved": "Some of this dataset’s sampled URIs do not resolve to a landing page.",
+  "nde_compat_persistent_explanation_pending": "This dataset’s URIs have not been checked for persistence yet.",
+  "nde_compat_persistent_count_unresolved": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "input unresolved",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{unresolved} of {display} sampled URIs does not resolve.",
+        "countPlural=other": "{unresolved} of {display} sampled URIs do not resolve."
+      }
+    }
+  ],
+  "nde_compat_persistent_issued_by": "Issued by {publisher}.",
   "nde_compat_linked_data_heading_conforms": "Provides linked data conforming to the NDE Application Profile",
   "nde_compat_linked_data_heading_not_conforms": "Provides linked data",
   "nde_compat_linked_data_heading_pending": "Linked data not yet assessed",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -259,6 +259,30 @@
   "nde_compat_registration_heading_warning": "Geregistreerd met waarschuwingen",
   "nde_compat_registration_explanation_warning": "De beschrijving van deze dataset is geregistreerd en geldig, maar bij de validatie zijn waarschuwingen gegeven: aan sommige aanbevelingen voor datasets wordt nog niet voldaan.",
   "nde_compat_registration_view_details": "Bekijk registratiegegevens",
+  "nde_compat_persistent_heading_persistent": "Gebruikt persistente URI’s",
+  "nde_compat_persistent_heading_resolves": "Gebruikt een niet-persistente domeinnaam",
+  "nde_compat_persistent_heading_unresolved": "Sommige URI’s zijn niet bereikbaar",
+  "nde_compat_persistent_heading_pending": "Persistente URI’s nog niet beoordeeld",
+  "nde_compat_persistent_explanation_persistent": "De persistente URI’s van deze dataset leiden naar een landingspagina.",
+  "nde_compat_persistent_explanation_resolves": "De URI’s van deze dataset gebruiken een niet-persistente domeinnaam, bijvoorbeeld die van een software-leverancier.",
+  "nde_compat_persistent_explanation_unresolved": "Sommige van de getoetste URI’s van deze dataset leiden niet naar een landingspagina.",
+  "nde_compat_persistent_explanation_pending": "De URI’s van deze dataset zijn nog niet op persistentie gecontroleerd.",
+  "nde_compat_persistent_count_unresolved": [
+    {
+      "declarations": [
+        "input count",
+        "input display",
+        "input unresolved",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{unresolved} van {display} getoetste URI’s leidt niet naar een landingspagina.",
+        "countPlural=other": "{unresolved} van {display} getoetste URI’s leiden niet naar een landingspagina."
+      }
+    }
+  ],
+  "nde_compat_persistent_issued_by": "Uitgegeven door {publisher}.",
   "nde_compat_linked_data_heading_conforms": "Biedt linked data volgens het NDE-applicatieprofiel",
   "nde_compat_linked_data_heading_not_conforms": "Biedt linked data",
   "nde_compat_linked_data_heading_pending": "Linked data nog niet beoordeeld",

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -11,6 +11,7 @@
     type CompatibilityCriterion,
     type IiifManifests,
     type LinkedData,
+    type PersistentUris,
     type RegistrationFailureReason,
     type TermLinks,
   } from '$lib/services/nde-compatibility';
@@ -19,6 +20,7 @@
     isAnalyzed,
     registrationStatus,
     registrationHasWarnings,
+    persistentUris,
     terms,
     iiifManifests,
     linkedData,
@@ -26,6 +28,7 @@
     isAnalyzed: boolean;
     registrationStatus: RegistrationFailureReason | null;
     registrationHasWarnings: boolean;
+    persistentUris: PersistentUris;
     terms: TermLinks | null;
     iiifManifests: IiifManifests;
     linkedData: LinkedData;
@@ -36,6 +39,7 @@
       isAnalyzed,
       registration: registrationStatus,
       registrationHasWarnings,
+      persistent: persistentUris,
       linkedData,
       terms,
       iiif: iiifManifests,
@@ -58,6 +62,18 @@
             return m.nde_compat_registration_heading_invalid();
           default:
             return m.nde_compat_registration_heading_registered();
+        }
+      case 'persistent':
+        switch (criterion.state) {
+          case 'met':
+            return m.nde_compat_persistent_heading_persistent();
+          case 'warning':
+            return m.nde_compat_persistent_heading_resolves();
+          case 'failed':
+            return m.nde_compat_persistent_heading_unresolved();
+          // Neutral: analyzed, but resolution has not been measured yet.
+          default:
+            return m.nde_compat_persistent_heading_pending();
         }
       case 'linked-data':
         switch (criterion.state) {
@@ -105,6 +121,17 @@
           default:
             return m.nde_compat_registration_explanation_registered();
         }
+      case 'persistent':
+        switch (criterion.state) {
+          case 'met':
+            return m.nde_compat_persistent_explanation_persistent();
+          case 'warning':
+            return m.nde_compat_persistent_explanation_resolves();
+          case 'failed':
+            return m.nde_compat_persistent_explanation_unresolved();
+          default:
+            return m.nde_compat_persistent_explanation_pending();
+        }
       case 'linked-data':
         switch (criterion.state) {
           case 'met':
@@ -147,6 +174,31 @@
         // only the warning state and a link to the registration’s details
         // (rendered separately); it carries no count line.
         return null;
+      case 'persistent':
+        // When some sampled URIs failed to resolve, report the ratio as
+        // evidence; when persistent and issued by a known organisation (ARK),
+        // name it. Other states carry no count line.
+        switch (criterion.state) {
+          case 'failed': {
+            const sampled = persistentUris.sampled ?? 0;
+            // Report the failures directly, matching the red state: how many of
+            // the sampled URIs did not resolve. Plurals key on this count.
+            const unresolved = sampled - (persistentUris.resolved ?? 0);
+            return m.nde_compat_persistent_count_unresolved({
+              count: unresolved,
+              unresolved: unresolved.toLocaleString(getLocale()),
+              display: sampled.toLocaleString(getLocale()),
+            });
+          }
+          case 'met':
+            return persistentUris.publisher
+              ? m.nde_compat_persistent_issued_by({
+                  publisher: persistentUris.publisher,
+                })
+              : null;
+          default:
+            return null;
+        }
       case 'linked-data':
         // The fact count (void:triples) is shown only when the dataset actually
         // has linked data with a known triple count.

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -15,8 +15,11 @@ import { shortenUri } from '$lib/utils/prefix';
 import { isUri, lookupTermLabels } from './network-of-terms.js';
 import {
   IIIF_PRESENTATION_API,
+  PID_SCHEME_BASE_URI,
   type IiifManifests,
   type LinkedData,
+  type PersistentUris,
+  type PidScheme,
   type TermLinks,
 } from './nde-compatibility.js';
 import { offersLinkedData } from '$lib/utils/distribution';
@@ -400,6 +403,7 @@ export interface DatasetDetailResult {
   linksets: Linkset[];
   temporalCoverages: TemporalCoverage[];
   iiifManifests: IiifManifests;
+  persistentUris: PersistentUris;
   linkedData: LinkedData;
   terms: TermLinks | null;
   resolvedTerms: Promise<Record<string, string>>;
@@ -472,6 +476,110 @@ async function fetchIiifManifests(datasetUri: string): Promise<IiifManifests> {
     );
   }
   return none;
+}
+
+// Reads the persistent-URI figures from the Knowledge Graph for the dataset’s
+// most common self-minted subject namespace. The DKG records the resolution
+// measurements (`subject-uris-sampled`/`subject-uris-resolved`) on a `void:subset`
+// scoped to that namespace, plus a recognised PID scheme (`dcterms:conformsTo`)
+// and its issuing `dcterms:publisher` (ARK) as positive embellishments, and a
+// `subject-uris-persistent` boolean flag (`false`) when the namespace is on the
+// disallow list. The sampled measurement keys the join, so the right subset is
+// selected even when the dataset has other subsets (e.g. IIIF). Every field is
+// null/false when no such subset has been recorded yet.
+async function fetchPersistentUris(
+  datasetUri: string,
+): Promise<PersistentUris> {
+  const none: PersistentUris = {
+    uriSpace: null,
+    scheme: null,
+    publisher: null,
+    sampled: null,
+    resolved: null,
+    onDisallowList: false,
+  };
+  const query = `
+    PREFIX void: <http://rdfs.org/ns/void#>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX dqv: <http://www.w3.org/ns/dqv#>
+    PREFIX nde: <https://def.nde.nl/metric#>
+    SELECT ?uriSpace ?scheme ?publisher ?sampled ?resolved ?persistent WHERE {
+      <${datasetUri}> void:subset ?ns .
+      ?ns void:uriSpace ?uriSpace ;
+        dqv:hasQualityMeasurement [
+          dqv:isMeasurementOf nde:subject-uris-sampled ;
+          dqv:value ?sampled
+        ] .
+      OPTIONAL {
+        ?ns dqv:hasQualityMeasurement [
+          dqv:isMeasurementOf nde:subject-uris-resolved ;
+          dqv:value ?resolved
+        ]
+      }
+      OPTIONAL {
+        ?ns dqv:hasQualityMeasurement [
+          dqv:isMeasurementOf nde:subject-uris-persistent ;
+          dqv:value ?persistent
+        ]
+      }
+      OPTIONAL {
+        ?ns dct:conformsTo ?scheme .
+        FILTER(STRSTARTS(STR(?scheme), "${PID_SCHEME_BASE_URI}"))
+      }
+      OPTIONAL { ?ns dct:publisher ?publisher }
+    }
+    LIMIT 1
+  `;
+  try {
+    const bindingsStream = await fetcher.fetchBindings(
+      PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+      query,
+    );
+    for await (const raw of bindingsStream) {
+      const binding = raw as unknown as {
+        uriSpace?: { value: string };
+        scheme?: { value: string };
+        publisher?: { value: string };
+        sampled?: { value: string };
+        resolved?: { value: string };
+        persistent?: { value: string };
+      };
+      return {
+        uriSpace: binding.uriSpace?.value ?? null,
+        scheme: parsePidScheme(binding.scheme?.value),
+        publisher: binding.publisher?.value ?? null,
+        sampled: binding.sampled?.value
+          ? parseInt(binding.sampled.value, 10)
+          : null,
+        resolved: binding.resolved?.value
+          ? parseInt(binding.resolved.value, 10)
+          : null,
+        // The DKG emits the persistent flag as `false` only for a namespace on
+        // its disallow list; absence means unflagged. Dormant until the DKG ships
+        // the measurement (see dataset-knowledge-graph).
+        onDisallowList: binding.persistent?.value === 'false',
+      };
+    }
+  } catch (e: unknown) {
+    console.error(
+      'Persistent URIs query failed:',
+      e instanceof Error ? e.message : e,
+    );
+  }
+  return none;
+}
+
+// Maps a `https://def.nde.nl/pid-scheme#…` IRI to its recognised scheme, or null
+// when there is no scheme or it is one we do not recognise.
+function parsePidScheme(schemeIri: string | undefined): PidScheme | null {
+  switch (schemeIri) {
+    case `${PID_SCHEME_BASE_URI}ark`:
+      return 'ark';
+    case `${PID_SCHEME_BASE_URI}handle`:
+      return 'handle';
+    default:
+      return null;
+  }
 }
 
 // Reads the SCHEMA-AP-NDE sample conformance for a dataset from the Knowledge
@@ -770,6 +878,7 @@ export async function fetchDatasetDetail(
     summaryGeneratedAt,
     temporalCoverages,
     iiifManifests,
+    persistentUris,
     schemaApNdeConformance,
   ] = await Promise.all([
     detailLens.query(datasetQuery),
@@ -799,6 +908,7 @@ export async function fetchDatasetDetail(
     fetchSummaryGeneratedAt(datasetUri),
     fetchTemporalCoverage(datasetUri),
     fetchIiifManifests(datasetUri),
+    fetchPersistentUris(datasetUri),
     fetchSchemaApNdeConformance(datasetUri),
   ]);
 
@@ -873,6 +983,7 @@ export async function fetchDatasetDetail(
     linksets: linksets ?? [],
     temporalCoverages,
     iiifManifests,
+    persistentUris,
     linkedData,
     terms,
     resolvedTerms,

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -3,10 +3,12 @@ import {
   compatibilityCriteria,
   iiifState,
   linkedDataState,
+  persistentUrisState,
   registrationState,
   schemaApNdeState,
   termsState,
   type LinkedData,
+  type PersistentUris,
 } from './nde-compatibility';
 
 // A neutral linked-data fixture for tests that focus on another criterion: no
@@ -18,6 +20,17 @@ const noLinkedData: LinkedData = {
   conformant: null,
   quadsValidated: null,
   triples: null,
+};
+
+// A pending persistent-URI fixture for tests that focus on another criterion:
+// analyzed, but no subject-URI resolution measurement recorded yet.
+const pendingPersistent: PersistentUris = {
+  uriSpace: null,
+  scheme: null,
+  publisher: null,
+  sampled: null,
+  resolved: null,
+  onDisallowList: false,
 };
 
 describe('iiifState', () => {
@@ -42,6 +55,110 @@ describe('iiifState', () => {
       'met',
     );
     expect(iiifState({ declared: 5, sampled: 0, validated: 0 })).toBe('met');
+  });
+});
+
+describe('persistentUrisState', () => {
+  it('is met when all sampled URIs resolve, for a recognised PID scheme', () => {
+    expect(
+      persistentUrisState({
+        uriSpace: 'https://n2t.net/ark:/22921/',
+        scheme: 'ark',
+        publisher: 'Gemeentemuseum Het Hannemahuis',
+        sampled: 10,
+        resolved: 10,
+        onDisallowList: false,
+      }),
+    ).toBe('met');
+  });
+
+  it('is met when all sampled URIs resolve from a self-minted HTTP namespace (no PID scheme required)', () => {
+    expect(
+      persistentUrisState({
+        uriSpace: 'http://data.beeldengeluid.nl/id/program/',
+        scheme: null,
+        publisher: null,
+        sampled: 10,
+        resolved: 10,
+        onDisallowList: false,
+      }),
+    ).toBe('met');
+  });
+
+  it('is a warning when all sampled URIs resolve but the namespace is on the disallow list', () => {
+    expect(
+      persistentUrisState({
+        uriSpace: 'https://vendor.example/cms/',
+        scheme: null,
+        publisher: null,
+        sampled: 10,
+        resolved: 10,
+        onDisallowList: true,
+      }),
+    ).toBe('warning');
+  });
+
+  it('is failed when at least one sampled URI does not resolve, even for a recognised scheme', () => {
+    expect(
+      persistentUrisState({
+        uriSpace: 'https://n2t.net/ark:/53016/',
+        scheme: 'ark',
+        publisher: 'Stichting Erfgoedpark Batavialand',
+        sampled: 10,
+        resolved: 0,
+        onDisallowList: false,
+      }),
+    ).toBe('failed');
+    expect(
+      persistentUrisState({
+        uriSpace: 'https://n2t.net/ark:/32154/',
+        scheme: 'ark',
+        publisher: 'Hunebedcentrum',
+        sampled: 10,
+        resolved: 2,
+        onDisallowList: false,
+      }),
+    ).toBe('failed');
+  });
+
+  it('prefers the failed state over the disallow-list warning when resolution also fails', () => {
+    expect(
+      persistentUrisState({
+        uriSpace: 'https://vendor.example/cms/',
+        scheme: null,
+        publisher: null,
+        sampled: 10,
+        resolved: 3,
+        onDisallowList: true,
+      }),
+    ).toBe('failed');
+  });
+
+  it('is unmet (pending) when no resolution measurement has been recorded yet', () => {
+    expect(persistentUrisState(pendingPersistent)).toBe('unmet');
+    expect(
+      persistentUrisState({
+        uriSpace: 'https://example.org/id/',
+        scheme: null,
+        publisher: null,
+        sampled: 0,
+        resolved: 0,
+        onDisallowList: false,
+      }),
+    ).toBe('unmet');
+  });
+
+  it('treats a missing resolved measurement as zero resolved (failed)', () => {
+    expect(
+      persistentUrisState({
+        uriSpace: 'https://example.org/id/',
+        scheme: null,
+        publisher: null,
+        sampled: 10,
+        resolved: null,
+        onDisallowList: false,
+      }),
+    ).toBe('failed');
   });
 });
 
@@ -296,22 +413,23 @@ describe('termsState', () => {
 
 describe('compatibilityCriteria', () => {
   it('exposes the declared count and computed state for IIIF', () => {
-    const [, , iiif] = compatibilityCriteria({
+    const iiif = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
+      persistent: pendingPersistent,
       linkedData: noLinkedData,
       terms: null,
       iiif: { declared: 4152, sampled: 10, validated: 0 },
-    });
-    expect(iiif.key).toBe('iiif');
-    expect(iiif.state).toBe('failed');
-    expect(iiif.count).toBe(4152);
+    }).find((criterion) => criterion.key === 'iiif');
+    expect(iiif?.state).toBe('failed');
+    expect(iiif?.count).toBe(4152);
   });
 
   it('leads with the registration criterion', () => {
     const [registration] = compatibilityCriteria({
       isAnalyzed: true,
       registration: 'gone',
+      persistent: pendingPersistent,
       linkedData: noLinkedData,
       terms: null,
       iiif: { declared: 0, sampled: null, validated: null },
@@ -321,11 +439,32 @@ describe('compatibilityCriteria', () => {
     expect(registration.reason).toBe('gone');
   });
 
+  it('places the persistent criterion second and exposes its state', () => {
+    const [, persistent] = compatibilityCriteria({
+      isAnalyzed: true,
+      registration: null,
+      persistent: {
+        uriSpace: 'https://n2t.net/ark:/22921/',
+        scheme: 'ark',
+        publisher: 'Gemeentemuseum Het Hannemahuis',
+        sampled: 10,
+        resolved: 10,
+        onDisallowList: false,
+      },
+      linkedData: noLinkedData,
+      terms: null,
+      iiif: { declared: 0, sampled: null, validated: null },
+    });
+    expect(persistent.key).toBe('persistent');
+    expect(persistent.state).toBe('met');
+  });
+
   it('surfaces the registration warning tier without a count', () => {
     const [registration] = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
       registrationHasWarnings: true,
+      persistent: pendingPersistent,
       linkedData: noLinkedData,
       terms: null,
       iiif: { declared: 0, sampled: null, validated: null },
@@ -337,10 +476,11 @@ describe('compatibilityCriteria', () => {
     expect(registration.count).toBe(0);
   });
 
-  it('exposes the linked-data state and fact count on the second criterion', () => {
-    const [, linkedData] = compatibilityCriteria({
+  it('exposes the linked-data state and fact count', () => {
+    const linkedData = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
+      persistent: pendingPersistent,
       linkedData: {
         declared: true,
         hasVoidDataset: true,
@@ -351,16 +491,16 @@ describe('compatibilityCriteria', () => {
       },
       terms: null,
       iiif: { declared: 0, sampled: null, validated: null },
-    });
-    expect(linkedData.key).toBe('linked-data');
-    expect(linkedData.state).toBe('met');
-    expect(linkedData.count).toBe(1234);
+    }).find((criterion) => criterion.key === 'linked-data');
+    expect(linkedData?.state).toBe('met');
+    expect(linkedData?.count).toBe(1234);
   });
 
-  it('carries the linked-data failure reason on the second criterion', () => {
-    const [, linkedData] = compatibilityCriteria({
+  it('carries the linked-data failure reason', () => {
+    const linkedData = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
+      persistent: pendingPersistent,
       linkedData: {
         declared: true,
         hasVoidDataset: true,
@@ -371,39 +511,47 @@ describe('compatibilityCriteria', () => {
       },
       terms: null,
       iiif: { declared: 0, sampled: null, validated: null },
-    });
-    expect(linkedData.key).toBe('linked-data');
-    expect(linkedData.state).toBe('failed');
-    expect(linkedData.reason).toBe('empty');
+    }).find((criterion) => criterion.key === 'linked-data');
+    expect(linkedData?.state).toBe('failed');
+    expect(linkedData?.reason).toBe('empty');
   });
 
-  it('renders all three criteria regardless of state for an analyzed dataset', () => {
+  it('renders registration, persistent, linked data and iiif for an analyzed dataset', () => {
     expect(
       compatibilityCriteria({
         isAnalyzed: true,
         registration: null,
+        persistent: pendingPersistent,
         linkedData: noLinkedData,
         terms: null,
         iiif: { declared: 0, sampled: null, validated: null },
-      }),
-    ).toHaveLength(3);
+      }).map((criterion) => criterion.key),
+    ).toEqual(['registration', 'persistent', 'linked-data', 'iiif']);
   });
 
-  it('places the terms criterion after linked-data and before iiif when present', () => {
+  it('orders the criteria registration, persistent, linked-data, terms, iiif when all present', () => {
     const keys = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
+      persistent: pendingPersistent,
       linkedData: noLinkedData,
       terms: { links: 42, distinctObjectsUri: 1000 },
       iiif: { declared: 0, sampled: null, validated: null },
     }).map((criterion) => criterion.key);
-    expect(keys).toEqual(['registration', 'linked-data', 'terms', 'iiif']);
+    expect(keys).toEqual([
+      'registration',
+      'persistent',
+      'linked-data',
+      'terms',
+      'iiif',
+    ]);
   });
 
   it('exposes the links count and met state for the terms criterion', () => {
     const terms = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
+      persistent: pendingPersistent,
       linkedData: noLinkedData,
       terms: { links: 42, distinctObjectsUri: 1000 },
       iiif: { declared: 0, sampled: null, validated: null },
@@ -416,6 +564,7 @@ describe('compatibilityCriteria', () => {
     const terms = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
+      persistent: pendingPersistent,
       linkedData: noLinkedData,
       terms: { links: 0, distinctObjectsUri: 500 },
       iiif: { declared: 0, sampled: null, validated: null },
@@ -427,6 +576,7 @@ describe('compatibilityCriteria', () => {
     const keys = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
+      persistent: pendingPersistent,
       linkedData: noLinkedData,
       terms: { links: 0, distinctObjectsUri: 0 },
       iiif: { declared: 0, sampled: null, validated: null },
@@ -435,13 +585,20 @@ describe('compatibilityCriteria', () => {
   });
 
   it('keeps the foundational criteria when the dataset is not analyzed', () => {
-    // The analysis-dependent criteria (terms, IIIF) are dropped, but registration
-    // and linked data are foundational, so they remain and keep the section
-    // visible.
+    // The analysis-dependent criteria (persistent, terms, IIIF) are dropped, but
+    // registration and linked data are foundational, so they remain and keep the
+    // section visible.
     expect(
       compatibilityCriteria({
         isAnalyzed: false,
         registration: null,
+        persistent: {
+          uriSpace: 'https://n2t.net/ark:/22921/',
+          scheme: 'ark',
+          publisher: 'Gemeentemuseum Het Hannemahuis',
+          sampled: 10,
+          resolved: 10,
+        },
         linkedData: {
           declared: true,
           hasVoidDataset: false,

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -598,6 +598,7 @@ describe('compatibilityCriteria', () => {
           publisher: 'Gemeentemuseum Het Hannemahuis',
           sampled: 10,
           resolved: 10,
+          onDisallowList: false,
         },
         linkedData: {
           declared: true,

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -35,11 +35,37 @@ export const SCHEMA_AP_NDE_CONFORMANCE_METRIC =
 export const QUADS_VALIDATED_METRIC =
   'https://def.nde.nl/metric#quads-validated';
 
+// DQV metric IRIs for the persistent-URI (subject-URI resolution) measurements
+// recorded by the Dataset Knowledge Graph on the dataset’s self-minted subject
+// namespace. `subject-uris-sampled` is the denominator (how many subject URIs
+// were sampled), `subject-uris-resolved` the numerator (how many of those
+// resolved to an HTML landing page).
+export const SUBJECT_URIS_SAMPLED_METRIC =
+  'https://def.nde.nl/metric#subject-uris-sampled';
+export const SUBJECT_URIS_RESOLVED_METRIC =
+  'https://def.nde.nl/metric#subject-uris-resolved';
+
+// Boolean DQV metric flagging the subject namespace as non-durable: emitted with
+// value `false` when the namespace is on the Dataset Knowledge Graph’s disallow
+// list of known non-persistent vendor namespaces. Absent for an unflagged
+// namespace. The register reads it to demote an otherwise-green namespace that
+// resolves to a 🟠 warning. Proposed contract — see the dataset-knowledge-graph
+// issue; the orange tier stays dormant until the DKG emits this.
+export const SUBJECT_URIS_PERSISTENT_METRIC =
+  'https://def.nde.nl/metric#subject-uris-persistent';
+
+// Namespace of the recognised persistent-identifier schemes the Knowledge Graph
+// attaches to a subject namespace via `dcterms:conformsTo` (e.g.
+// `https://def.nde.nl/pid-scheme#ark`). Its presence is the green/orange
+// discriminator for the persistent criterion.
+export const PID_SCHEME_BASE_URI = 'https://def.nde.nl/pid-scheme#';
+
 // The registration criterion leads — every registered dataset has it, so it
-// anchors the section regardless of analysis. The linked-data and terms criteria
-// follow, then iiif, matching the order in NDE communication.
+// anchors the section regardless of analysis. Persistent identifiers follow, then
+// linked data and terms, then iiif, matching the order in NDE communication.
 export type CompatibilityCriterionKey =
   | 'registration'
+  | 'persistent'
   | 'linked-data'
   | 'terms'
   | 'iiif';
@@ -50,7 +76,7 @@ export type CompatibilityCriterionKey =
 // any dataset, are always shown, and so keep the section visible even for a
 // dataset that has not been analyzed.
 const ANALYSIS_DEPENDENT_CRITERIA: ReadonlySet<CompatibilityCriterionKey> =
-  new Set(['terms', 'iiif']);
+  new Set(['persistent', 'terms', 'iiif']);
 
 // The four assessment tiers a criterion can take. Not every criterion uses all
 // of them (IIIF, for instance, has no 'warning'):
@@ -100,6 +126,41 @@ export interface IiifManifests {
   declared: number;
   sampled: number | null;
   validated: number | null;
+}
+
+// The recognised persistent-identifier schemes the Knowledge Graph detects on a
+// subject namespace. A recognised scheme is not what makes a namespace persistent
+// — a self-minted HTTP namespace that resolves is persistent too — but it is a
+// positive signal worth surfacing (the indirection survives a domain move).
+export type PidScheme = 'ark' | 'handle';
+
+// Persistent-URI figures from the Knowledge Graph for the dataset’s most common
+// self-minted subject namespace. The DKG samples subject URIs from that namespace
+// and dereferences them. Persistence is judged by resolution: every sampled URI
+// reaching an HTML landing page is the bar. A recognised PID scheme and its
+// issuing organisation are surfaced as positive embellishments, not as a gate.
+// 'uriSpace'      — the namespace that was assessed, or null when the DKG found no
+//                   self-minted namespace to sample (nothing to assess yet).
+// 'scheme'        — the recognised PID scheme (ARK or Handle), or null. Shown as a
+//                   bonus on an otherwise-green row; it does not change the state.
+// 'publisher'     — the issuing organisation, resolved from the PID registry (ARK
+//                   only); null for Handle or when the lookup found none.
+// 'sampled'       — how many subject URIs were sampled (the denominator), or null
+//                   when no resolution measurement has been recorded yet.
+// 'resolved'      — how many of the sampled URIs resolved to an HTML landing page
+//                   (the numerator); null when no measurement exists.
+// 'onDisallowList' — whether the namespace is on the DKG’s disallow list of known
+//                   non-durable vendor namespaces: it resolves today but is not a
+//                   durable home for the identifiers, so it warns rather than
+//                   passing. False until the DKG emits the marker (see
+//                   dataset-knowledge-graph): the orange tier is dormant until then.
+export interface PersistentUris {
+  uriSpace: string | null;
+  scheme: PidScheme | null;
+  publisher: string | null;
+  sampled: number | null;
+  resolved: number | null;
+  onDisallowList: boolean;
 }
 
 // SCHEMA-AP-NDE sample-conformance figures from the Knowledge Graph plus whether
@@ -173,6 +234,7 @@ export interface CompatibilityInput {
   // dataset or many), so only the state is shown, not a per-dataset count.
   // Optional: absent is treated as no warnings.
   registrationHasWarnings?: boolean;
+  persistent: PersistentUris;
   linkedData: LinkedData;
   terms: TermLinks | null;
   iiif: IiifManifests;
@@ -275,6 +337,30 @@ export function iiifState(manifests: IiifManifests): CompatibilityState {
   return 'met';
 }
 
+// Derives the persistent-URI state from the subject-URI resolution measurement.
+// Persistence is judged by resolution, not by the identifier scheme: a self-minted
+// HTTP namespace that resolves to an HTML landing page is just as persistent as an
+// ARK or Handle, so it is `met` (🟢). If any sampled URI fails to resolve
+// (`resolved` < `sampled`), the criterion is `failed` (🔴). A namespace that fully
+// resolves but is on the DKG’s disallow list of known non-durable vendor
+// namespaces is a `warning` (🟠): it works today but is not a durable home for the
+// identifiers. With no measurement yet — the resolution step has not run, or the
+// DKG found no self-minted namespace to sample — the criterion is neutral
+// pending (⚪): a grey row signalling “this will still be checked”, unlike terms
+// it keeps its place rather than being omitted.
+export function persistentUrisState(
+  persistent: PersistentUris,
+): CompatibilityState {
+  if (persistent.sampled === null || persistent.sampled <= 0) {
+    return 'unmet';
+  }
+  const resolved = persistent.resolved ?? 0;
+  if (resolved < persistent.sampled) {
+    return 'failed';
+  }
+  return persistent.onDisallowList ? 'warning' : 'met';
+}
+
 // Derives the term-usage state, or `null` when the criterion cannot be assessed
 // and so must be omitted (it has no neutral grey state). The Dataset Knowledge
 // Graph emits no positive “terms analysis ran” measurement, so assessability is
@@ -300,12 +386,12 @@ export function termsState(terms: TermLinks | null): CompatibilityState | null {
 }
 
 // Builds the list of NDE criteria for a dataset. The registration row leads — it
-// applies to any dataset, so it anchors the section; the linked-data row follows,
-// then terms, then IIIF, matching the order in NDE communication. Registration
-// and linked data are foundational and always shown; the terms row is omitted
-// when it cannot be assessed, and the analysis-dependent rows (terms, IIIF) are
-// dropped when the dataset has not been analyzed. The detail page shows the
-// section whenever any criterion remains.
+// applies to any dataset, so it anchors the section; the persistent-identifier
+// row follows, then linked data, then terms, then IIIF, matching the order in NDE
+// communication. Registration and linked data are foundational and always shown;
+// the terms row is omitted when it cannot be assessed, and the analysis-dependent
+// rows (persistent, terms, IIIF) are dropped when the dataset has not been
+// analyzed. The detail page shows the section whenever any criterion remains.
 export function compatibilityCriteria(
   input: CompatibilityInput,
 ): CompatibilityCriterion[] {
@@ -323,6 +409,13 @@ export function compatibilityCriteria(
       // carries no per-dataset count — the warning state is shown on its own.
       count: 0,
       reason: registration.reason,
+    },
+    {
+      key: 'persistent',
+      state: persistentUrisState(input.persistent),
+      // The persistent criterion shows the resolution figures (resolved of
+      // sampled) from the prop, not a single count.
+      count: input.persistent.sampled ?? 0,
     },
     {
       key: 'linked-data',

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -57,6 +57,7 @@
   const linksets = $derived(data.linksets);
   const temporalCoverages = $derived(data.temporalCoverages);
   const iiifManifests = $derived(data.iiifManifests);
+  const persistentUris = $derived(data.persistentUris);
   const linkedData = $derived(data.linkedData);
   const terms = $derived(data.terms);
   const registrationHasWarnings = $derived(data.warningCount > 0);
@@ -1265,6 +1266,7 @@
     isAnalyzed={isAnalyzed(summary)}
     {registrationStatus}
     {registrationHasWarnings}
+    {persistentUris}
     {terms}
     {iiifManifests}
     {linkedData}


### PR DESCRIPTION
Adds the **Persistent** criterion to the NDE compatibility section on the dataset
detail page (second, after Datasetregister), consuming the subject-URI resolution
data model from the Dataset Knowledge Graph (dataset-knowledge-graph#316).

Fix #2036

## What it shows

Persistence is judged by **resolution**, not by the identifier scheme: a self-minted
HTTP namespace whose sampled subject URIs resolve to an HTML landing page is just as
persistent as an ARK or Handle. A recognised PID scheme and its issuing organisation
are surfaced as positive embellishments, not as a gate.

| Condition | State |
| --- | --- |
| sample fully resolves, not on the disallow list | 🟢 met (PID scheme/org shown when present) |
| sample fully resolves, on the disallow list | 🟠 warning (dormant — see below) |
| at least one sampled URI does not resolve | 🔴 failed (shows how many) |
| no measurement yet | ⚪ pending |
| dataset not analyzed | hidden (analysis-dependent) |

## Disallow list (dormant)

The 🟠 warning tier is reserved for namespaces that resolve today but are known to be
non-durable (e.g. a vendor domain). That signal comes from a `subject-uris-persistent`
boolean flag the Knowledge Graph does not emit yet, so the tier is **wired but
dormant**: until dataset-knowledge-graph#330 ships the disallow list + flag, every
resolving namespace is green and only non-resolving ones are red.

## Changes

- `nde-compatibility.ts` – `PersistentUris` type, `persistentUrisState()`, the new
  criterion key (second) and its analysis-dependent gating, and metric constants.
- `dataset-detail.ts` – `fetchPersistentUris()` SPARQL query against the Knowledge
  Graph (resolution measurements + PID scheme/publisher + the dormant flag), wired
  through the detail loader.
- `NdeCompatibility.svelte` – the new row: headings, explanations, the negative
  "N of M do not resolve" count, and the ARK issuing-organisation line.
- `messages/{en,nl}.json` – Dutch and English copy for all four states.
- `nde-compatibility.test.ts` – `persistentUrisState` suite plus updated
  `compatibilityCriteria` ordering/state coverage.

## Notes

- Verified live against the production Knowledge Graph: ARK (green + publisher),
  self-minted resolving namespaces (green), and non-resolving namespaces (red).
- The shared docs (`docs/services/dataset-knowledge-graph`) describing the producer
  measurement are updated in the `docs` repo separately.
