### PR TITLE
feat: read subject-namespace-durable metric for the persistent criterion

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -489,7 +489,7 @@ async function fetchIiifManifests(datasetUri: string): Promise<IiifManifests> {
 // measurements (`subject-uris-sampled`/`subject-uris-resolved`) on a `void:subset`
 // scoped to that namespace, plus a recognised PID scheme (`dcterms:conformsTo`)
 // and its issuing `dcterms:publisher` (ARK) as positive embellishments, and a
-// `subject-uris-persistent` boolean flag (`false`) when the namespace is on the
+// `subject-namespace-durable` boolean flag (`false`) when the namespace is on the
 // disallow list. The sampled measurement keys the join, so the right subset is
 // selected even when the dataset has other subsets (e.g. IIIF). Every field is
 // null/false when no such subset has been recorded yet.
@@ -509,7 +509,7 @@ async function fetchPersistentUris(
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX dqv: <http://www.w3.org/ns/dqv#>
     PREFIX nde: <https://def.nde.nl/metric#>
-    SELECT ?uriSpace ?scheme ?publisher ?sampled ?resolved ?persistent WHERE {
+    SELECT ?uriSpace ?scheme ?publisher ?sampled ?resolved ?durable WHERE {
       <${datasetUri}> void:subset ?ns .
       ?ns void:uriSpace ?uriSpace ;
         dqv:hasQualityMeasurement [
@@ -524,8 +524,8 @@ async function fetchPersistentUris(
       }
       OPTIONAL {
         ?ns dqv:hasQualityMeasurement [
-          dqv:isMeasurementOf nde:subject-uris-persistent ;
-          dqv:value ?persistent
+          dqv:isMeasurementOf nde:subject-namespace-durable ;
+          dqv:value ?durable
         ]
       }
       OPTIONAL {
@@ -548,7 +548,7 @@ async function fetchPersistentUris(
         publisher?: { value: string };
         sampled?: { value: string };
         resolved?: { value: string };
-        persistent?: { value: string };
+        durable?: { value: string };
       };
       return {
         uriSpace: binding.uriSpace?.value ?? null,
@@ -560,10 +560,10 @@ async function fetchPersistentUris(
         resolved: binding.resolved?.value
           ? parseInt(binding.resolved.value, 10)
           : null,
-        // The DKG emits the persistent flag as `false` only for a namespace on
+        // The DKG emits the durability flag as `false` only for a namespace on
         // its disallow list; absence means unflagged. Dormant until the DKG ships
         // the measurement (see dataset-knowledge-graph).
-        onDisallowList: binding.persistent?.value === 'false',
+        onDisallowList: binding.durable?.value === 'false',
       };
     }
   } catch (e: unknown) {

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -47,12 +47,12 @@ export const SUBJECT_URIS_RESOLVED_METRIC =
 
 // Boolean DQV metric flagging the subject namespace as non-durable: emitted with
 // value `false` when the namespace is on the Dataset Knowledge Graph’s disallow
-// list of known non-persistent vendor namespaces. Absent for an unflagged
+// list of known non-durable vendor namespaces. Absent for an unflagged
 // namespace. The register reads it to demote an otherwise-green namespace that
-// resolves to a 🟠 warning. Proposed contract — see the dataset-knowledge-graph
-// issue; the orange tier stays dormant until the DKG emits this.
-export const SUBJECT_URIS_PERSISTENT_METRIC =
-  'https://def.nde.nl/metric#subject-uris-persistent';
+// resolves to a 🟠 warning. It is namespace-scoped (a verdict on the namespace as
+// a durable home), orthogonal to the per-URI `subject-uris-*` resolution axis.
+export const SUBJECT_NAMESPACE_DURABLE_METRIC =
+  'https://def.nde.nl/metric#subject-namespace-durable';
 
 // Namespace of the recognised persistent-identifier schemes the Knowledge Graph
 // attaches to a subject namespace via `dcterms:conformsTo` (e.g.


### PR DESCRIPTION
## Summary

Renames the dormant non-durable-namespace matcher from `subject-uris-persistent`
to `subject-namespace-durable`, matching the metric the Dataset Knowledge Graph
actually emits (netwerk-digitaal-erfgoed/dataset-knowledge-graph#330).

The verdict is about the *namespace as a durable home*, not the per-URI sample,
so it is namespace-scoped and orthogonal to the `subject-uris-*` resolution axis –
hence the rename. Without this, the 🟠 (warning) tier of the Persistent criterion
never lights up.

## Changes

- `nde-compatibility.ts` – rename the metric constant + IRI to
  `SUBJECT_NAMESPACE_DURABLE_METRIC` / `…/metric#subject-namespace-durable`.
- `dataset-detail.ts` – read `nde:subject-namespace-durable` in the subject-URI
  query (variable `?durable`), still inside an `OPTIONAL` block so the query keeps
  working while no values exist yet.

## Pairing

This is the register half of a pair:

- DKG: netwerk-digitaal-erfgoed/dataset-knowledge-graph#330 emits the flag.
- Register (this PR): reads it.

The register change is inert until the DKG ships the measurement; the flag stays
`OPTIONAL`, so nothing breaks in the meantime.

## Testing

- `npm run check` – 0 errors, 0 warnings.
- `nde-compatibility.test.ts` – 47 passing (state-derivation logic unchanged;
  only the metric IRI moved).
