### PR TITLE
fix(browser): restore dep pre-bundling in nx dev under Vite 8

### DIFF
--- a/apps/browser/vite.config.ts
+++ b/apps/browser/vite.config.ts
@@ -19,6 +19,20 @@ export default defineConfig({
     // named exports (compressToEncodedURIComponent, …) resolve under Vite 8.
     noExternal: ['lz-string'],
   },
+  optimizeDeps: {
+    // flowbite-svelte-icons exposes each icon as a deep .svelte subpath whose
+    // export only declares a `svelte` condition. Vite 8’s Rolldown dependency
+    // scanner doesn’t apply that condition, so it failed to resolve the imports
+    // (“Package subpath is not defined by exports”), aborted the scan, and
+    // skipped pre-bundling for every dependency. Excluding the package keeps
+    // its .svelte components out of the scan (they can’t be pre-bundled anyway);
+    // teaching the scanner the `svelte` condition lets it resolve the imports it
+    // still walks past.
+    exclude: ['flowbite-svelte-icons'],
+    esbuildOptions: {
+      conditions: ['svelte', 'browser'],
+    },
+  },
   test: {
     passWithNoTests: true,
     expect: { requireAssertions: true },


### PR DESCRIPTION
## Problem

`nx dev browser` printed a wall of `[RESOLVE_ERROR] … Package subpath is not defined by exports` for `flowbite-svelte-icons/*.svelte`, followed by `Failed to run dependency scan. Skipping dependency pre-bundling`. The server still served (SSR rendered icons), but pre-bundling was skipped for **every** dependency.

Each icon is a deep `.svelte` subpath whose package export only declares a `svelte` condition (no `import`/`default`). SSR works because vite-plugin-svelte teaches the main resolver that condition, but Vite 8’s Rolldown dependency scanner doesn’t apply it, so the scan aborted. The deep-import style is original (since #1432); it surfaced as a failure when #2025 moved to Vite 8 / Rolldown — vite remains deliberately pinned `^8.0.16`, this is not a re-upgrade.

## Fix

Add `optimizeDeps` to `apps/browser/vite.config.ts`:

- `exclude: ['flowbite-svelte-icons']` keeps its `.svelte` components out of the scan (they can’t be pre-bundled anyway).
- `esbuildOptions.conditions: ['svelte', 'browser']` gives the scanner the `svelte` condition it needs to resolve the imports it still walks past. `exclude` alone is insufficient.

## Verification

- `nx dev browser`: 0 scan errors; pre-bundling runs again (`Forced re-optimization` instead of `Skipping`).
- `/datasets` returns 200 with rendered SVG icons; no client console errors on hydration.
- `nx build browser` passes.
