### PR TITLE
feat(browser): treat content-type mismatch as unavailable and prefer compressed downloads

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -127,6 +127,8 @@
   "detail_probe_empty_body": "This download currently returns no data.",
   "detail_probe_sparql_failed": "This SPARQL endpoint did not answer a test query.",
   "detail_probe_rdf_parse_failed": "This distribution returned data that could not be parsed.",
+  "detail_probe_content_type_mismatch": "This distribution serves a different format than it declares.",
+  "detail_probe_content_type_missing": "This distribution did not declare the format it serves.",
   "detail_probe_unavailable_generic": "This distribution is currently unavailable.",
   "detail_download_none_available": "No working download available",
   "detail_download_none_available_tooltip": "None of this dataset’s downloads currently return data, according to the register’s latest check.",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -127,6 +127,8 @@
   "detail_probe_empty_body": "Deze download geeft op dit moment geen gegevens terug.",
   "detail_probe_sparql_failed": "Dit SPARQL-endpoint beantwoordde een testquery niet.",
   "detail_probe_rdf_parse_failed": "Deze distributie gaf gegevens terug die niet konden worden verwerkt.",
+  "detail_probe_content_type_mismatch": "Deze distributie levert een ander formaat dan opgegeven.",
+  "detail_probe_content_type_missing": "Deze distributie geeft geen formaat op.",
   "detail_probe_unavailable_generic": "Deze distributie is op dit moment niet beschikbaar.",
   "detail_download_none_available": "Geen werkende download beschikbaar",
   "detail_download_none_available_tooltip": "Geen van de downloads van deze dataset geeft op dit moment gegevens terug, volgens de meest recente controle van het register.",

--- a/apps/browser/src/lib/services/distribution-health.test.ts
+++ b/apps/browser/src/lib/services/distribution-health.test.ts
@@ -44,7 +44,7 @@ describe('distributionAvailability', () => {
     expect(distributionAvailability(health, now)).toBe('unavailable');
   });
 
-  it('stays reachable for content-type outcomes regardless of age', () => {
+  it('is unavailable for a persistent content-type failure (wrong or missing format)', () => {
     for (const outcome of ['ContentTypeMismatch', 'ContentTypeMissing']) {
       const health: DistributionHealth = {
         lastOutcome: `https://def.nde.nl/probe#${outcome}`,
@@ -53,8 +53,19 @@ describe('distributionAvailability', () => {
         firstFailureAt: new Date('2026-01-01T12:00:00Z'), // months old
         consecutiveFailures: 99,
       };
-      expect(distributionAvailability(health, now)).toBe('reachable');
+      expect(distributionAvailability(health, now)).toBe('unavailable');
     }
+  });
+
+  it('stays reachable for a content-type failure within the threshold window', () => {
+    const health: DistributionHealth = {
+      lastOutcome: 'https://def.nde.nl/probe#ContentTypeMismatch',
+      lastProbedAt: now,
+      lastSuccessAt: null,
+      firstFailureAt: new Date('2026-06-08T12:00:00Z'), // 2 days before now
+      consecutiveFailures: 3,
+    };
+    expect(distributionAvailability(health, now)).toBe('reachable');
   });
 
   it('is reachable when the last probe succeeded (no outcome)', () => {

--- a/apps/browser/src/lib/services/distribution-health.ts
+++ b/apps/browser/src/lib/services/distribution-health.ts
@@ -1,4 +1,4 @@
-import { REACHABILITY_FAILURE_OUTCOMES } from '@dataset-register/core/constants';
+import { UNAVAILABILITY_OUTCOMES } from '@dataset-register/core/constants';
 
 // A distribution's current availability, derived from the register's own
 // distribution health probe rather than the Dataset Knowledge Graph's
@@ -16,12 +16,13 @@ export interface DistributionHealth {
   consecutiveFailures: number;
 }
 
-// The reachability outcomes that, once persistent, flip a distribution to
-// unavailable, sourced from the register so the vocabulary stays in one place.
-// Content-type outcomes (ContentTypeMismatch, ContentTypeMissing) are excluded
-// upstream: they are a separate quality concern and never affect availability.
-const REACHABILITY_FAILURES: ReadonlySet<string> = new Set(
-  REACHABILITY_FAILURE_OUTCOMES,
+// The probe outcomes that, once persistent, flip a distribution to unavailable,
+// sourced from the register so the vocabulary stays in one place. Covers both
+// unreachable distributions and ones that serve a different format than they
+// declare (ContentTypeMismatch, ContentTypeMissing): a client that asked for the
+// declared format cannot use either, so both count as unavailable.
+const UNAVAILABILITY_FAILURES: ReadonlySet<string> = new Set(
+  UNAVAILABILITY_OUTCOMES,
 );
 
 // Mirrors the crawler's failure-streak suppression window so the badge stays
@@ -35,7 +36,7 @@ export function distributionAvailability(
 ): DistributionAvailability {
   if (health === null) return 'unknown';
   if (health.lastOutcome === null) return 'reachable';
-  if (!REACHABILITY_FAILURES.has(health.lastOutcome)) return 'reachable';
+  if (!UNAVAILABILITY_FAILURES.has(health.lastOutcome)) return 'reachable';
   if (health.firstFailureAt === null) return 'reachable';
 
   const streakAgeMs = now.getTime() - health.firstFailureAt.getTime();

--- a/apps/browser/src/lib/utils/distribution-ranking.test.ts
+++ b/apps/browser/src/lib/utils/distribution-ranking.test.ts
@@ -135,4 +135,70 @@ describe('sortDistributionsByAvailability', () => {
       sortDistributionsByAvailability([unavailable, noRecord], health, now),
     ).toEqual([noRecord, unavailable]);
   });
+
+  it('puts compressed downloads first (smaller to transfer), then the format preference', () => {
+    const turtle = {
+      accessURL: 'https://example.org/data.ttl',
+      mediaType: 'text/turtle',
+    };
+    const jsonLd = {
+      accessURL: 'https://example.org/data.jsonld',
+      mediaType: 'application/ld+json',
+    };
+    const ntGzip = {
+      accessURL: 'https://example.org/data.nt.gz',
+      mediaType: 'application/n-triples+gzip',
+    };
+    const turtleGzip = {
+      accessURL: 'https://example.org/data.ttl.gz',
+      mediaType: 'text/turtle+gzip',
+    };
+    const health = new Map<string, DistributionHealth>();
+    // Compressed first (N-Triples before Turtle by format preference), then the
+    // uncompressed variants (Turtle before JSON-LD).
+    expect(
+      sortDistributionsByAvailability(
+        [jsonLd, turtle, ntGzip, turtleGzip],
+        health,
+        now,
+      ),
+    ).toEqual([ntGzip, turtleGzip, turtle, jsonLd]);
+  });
+});
+
+describe('selectPreferredDownload matches the topmost dropdown entry', () => {
+  it('points at the compressed N-Triples that also sorts to the top', () => {
+    const jsonLd = {
+      accessURL: 'https://example.org/data.jsonld',
+      mediaType: 'application/ld+json',
+    };
+    const turtle = {
+      accessURL: 'https://example.org/data.ttl',
+      mediaType: 'text/turtle',
+    };
+    const ntGzip = {
+      accessURL: 'https://example.org/data.nt.gz',
+      mediaType: 'application/n-triples+gzip',
+    };
+    const health = new Map<string, DistributionHealth>();
+    const candidates = [jsonLd, turtle, ntGzip];
+    const top = sortDistributionsByAvailability(candidates, health, now)[0];
+    expect(selectPreferredDownload(candidates, health, now)).toBe(top);
+    expect(selectPreferredDownload(candidates, health, now)).toBe(ntGzip);
+  });
+
+  it('skips an unavailable topmost entry and points at the next working one', () => {
+    const ntGzip = {
+      accessURL: 'https://example.org/data.nt.gz',
+      mediaType: 'application/n-triples+gzip',
+    };
+    const turtle = {
+      accessURL: 'https://example.org/data.ttl',
+      mediaType: 'text/turtle',
+    };
+    // The otherwise-preferred compressed download is unavailable, so the button
+    // falls through to the first reachable entry rather than a broken link.
+    const health = new Map([[ntGzip.accessURL, staleFailure]]);
+    expect(selectPreferredDownload([ntGzip, turtle], health, now)).toBe(turtle);
+  });
 });

--- a/apps/browser/src/lib/utils/distribution-ranking.ts
+++ b/apps/browser/src/lib/utils/distribution-ranking.ts
@@ -16,29 +16,53 @@ export interface RankableDistribution {
   conformsTo?: readonly string[];
 }
 
-function isGzip(distribution: RankableDistribution): boolean {
-  return (
-    (distribution.mediaType?.includes('+gzip') ?? false) ||
-    distribution.accessURL.endsWith('.gz')
-  );
+// The label suffix that marks a compressed download, or an empty string when the
+// distribution is not compressed. gzip (`+gzip` media type or a .gz/.tgz URL) and
+// zip (`application/zip` or a .zip URL) are recognised; both are smaller to
+// transfer and so sort to the top. The suffix is reused as the human-facing label
+// so a compressed variant is no longer indistinguishable from its plain sibling.
+export function compressionSuffix(
+  distribution: RankableDistribution,
+): '' | ' (gzip)' | ' (zip)' {
+  const mediaType = distribution.mediaType?.toLowerCase() ?? '';
+  const url = distribution.accessURL.toLowerCase();
+  if (mediaType.includes('gzip') || /\.(gz|gzip|tgz)$/.test(url)) {
+    return ' (gzip)';
+  }
+  if (mediaType.includes('zip') || url.endsWith('.zip')) {
+    return ' (zip)';
+  }
+  return '';
 }
 
-// The established download type priority: gzipped N-Triples first (smallest to
-// transfer, fastest to parse), then any gzipped RDF, then Turtle, then JSON-LD,
-// then any other RDF, falling back to the first candidate.
-function pickByTypePriority<T extends RankableDistribution>(
-  candidates: readonly T[],
-): T | undefined {
-  return (
-    candidates.find(
-      (d) => d.mediaType === 'application/n-triples' && isGzip(d),
-    ) ??
-    candidates.find((d) => isRdfDistribution(d) && isGzip(d)) ??
-    candidates.find((d) => d.mediaType === 'text/turtle') ??
-    candidates.find((d) => d.mediaType === 'application/ld+json') ??
-    candidates.find(isRdfDistribution) ??
-    candidates[0]
-  );
+function isCompressed(distribution: RankableDistribution): boolean {
+  return compressionSuffix(distribution) !== '';
+}
+
+// Media type without a `+gzip` suffix, lower-cased, so a compressed variant ranks
+// by its underlying RDF serialization (e.g. `application/n-triples+gzip` ranks as
+// N-Triples).
+function baseMediaType(distribution: RankableDistribution): string {
+  return (distribution.mediaType ?? '').toLowerCase().replace(/\+gzip$/, '');
+}
+
+// Preference among RDF serializations, smallest/fastest first: N-Triples and
+// N-Quads (line-based, stream-parseable), then Turtle, then JSON-LD, then any
+// other RDF, then non-RDF. Used to order variants within an availability and
+// compression group so the list is deterministic and the best format leads.
+function formatPriority(distribution: RankableDistribution): number {
+  switch (baseMediaType(distribution)) {
+    case 'application/n-triples':
+      return 0;
+    case 'application/n-quads':
+      return 1;
+    case 'text/turtle':
+      return 2;
+    case 'application/ld+json':
+      return 3;
+    default:
+      return isRdfDistribution(distribution) ? 4 : 5;
+  }
 }
 
 function availabilityOf(
@@ -52,21 +76,20 @@ function availabilityOf(
   );
 }
 
-// Select the distribution the default Download action should point at. Reachable
-// (or not-yet-probed) distributions are preferred so the default download always
-// works; among those the existing type priority decides. Returns undefined when
-// every distribution is unavailable, which drives the disabled download state.
+// Select the distribution the default Download action should point at: the first
+// reachable (or not-yet-probed) entry in the same order the dropdown renders, so
+// the primary button always matches the topmost working option and the visitor
+// never has to open the dropdown to find it. Returns undefined when every
+// distribution is unavailable, which drives the disabled download state.
 export function selectPreferredDownload<T extends RankableDistribution>(
   distributions: readonly T[],
   healthByUrl: ReadonlyMap<string, DistributionHealth>,
   now: Date,
 ): T | undefined {
-  const selectable = distributions.filter(
+  return sortDistributionsByAvailability(distributions, healthByUrl, now).find(
     (distribution) =>
       availabilityOf(distribution, healthByUrl, now) !== 'unavailable',
   );
-  if (selectable.length === 0) return undefined;
-  return pickByTypePriority(selectable);
 }
 
 // Coarse type priority used for ordering the full distribution list:
@@ -79,9 +102,11 @@ function typePriority(distribution: RankableDistribution): number {
 
 // Order distributions availability-first: reachable (and not-yet-probed)
 // distributions come before unavailable ones, so a visitor finds a working
-// access point first. Within an availability group the existing type priority
-// (SPARQL > RDF > other) decides. Distributions with no health record group with
-// the reachable ones. Returns a new array; the input is not mutated.
+// access point first. Within an availability group: type priority (SPARQL > RDF >
+// other), then compressed variants first (smaller to transfer, so they make the
+// best default download), then the format preference, then a stable tie-break on
+// the URL. Distributions with no health record group with the reachable ones.
+// Returns a new array; the input is not mutated.
 export function sortDistributionsByAvailability<T extends RankableDistribution>(
   distributions: readonly T[],
   healthByUrl: ReadonlyMap<string, DistributionHealth>,
@@ -93,6 +118,9 @@ export function sortDistributionsByAvailability<T extends RankableDistribution>(
   return [...distributions].sort(
     (a, b) =>
       unavailableRank(a) - unavailableRank(b) ||
-      typePriority(b) - typePriority(a),
+      typePriority(b) - typePriority(a) ||
+      Number(isCompressed(b)) - Number(isCompressed(a)) ||
+      formatPriority(a) - formatPriority(b) ||
+      a.accessURL.localeCompare(b.accessURL),
   );
 }

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -16,6 +16,7 @@
     type DistributionHealth,
   } from '$lib/services/distribution-health';
   import {
+    compressionSuffix,
     selectPreferredDownload,
     sortDistributionsByAvailability,
   } from '$lib/utils/distribution-ranking';
@@ -271,6 +272,10 @@
         return m.detail_probe_sparql_failed();
       case 'RdfParseFailed':
         return m.detail_probe_rdf_parse_failed();
+      case 'ContentTypeMismatch':
+        return m.detail_probe_content_type_mismatch();
+      case 'ContentTypeMissing':
+        return m.detail_probe_content_type_missing();
       default:
         return m.detail_probe_unavailable_generic();
     }
@@ -365,7 +370,9 @@
           class="inline-flex items-center truncate rounded bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-300"
           title={distribution.mediaType}
         >
-          {getMediaTypeLabel(distribution.mediaType)}
+          {getMediaTypeLabel(distribution.mediaType)}{compressionSuffix(
+            distribution,
+          )}
         </span>
       {/if}
       {#if distribution.byteSize}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -24,11 +24,8 @@ export const COULD_NOT_FETCH_URL_PREFIX = 'Could not fetch URL';
 export const PROBE_OUTCOME_BASE_URI = 'https://def.nde.nl/probe#';
 
 // The probe outcomes that mean a distribution is currently unreachable, as
-// opposed to a content-type quality issue (ContentTypeMismatch /
-// ContentTypeMissing), which never affects reachability. The Dataset Register
-// Browser reads this list to classify distribution availability, so the register
-// stays the single source of truth for the vocabulary. Keep in sync with
-// classify() in distribution-probe.
+// distinct from a content-type failure (see CONTENT_TYPE_FAILURE_OUTCOMES). Keep
+// in sync with classify() in distribution-probe.
 export const REACHABILITY_FAILURE_OUTCOMES: readonly string[] = [
   'NetworkError',
   'NotFound',
@@ -39,3 +36,23 @@ export const REACHABILITY_FAILURE_OUTCOMES: readonly string[] = [
   'SparqlProbeFailed',
   'RdfParseFailed',
 ].map((name) => `${PROBE_OUTCOME_BASE_URI}${name}`);
+
+// The probe outcomes that mean a distribution serves the wrong format: it
+// answered with a Content-Type that does not match the declared media type
+// (ContentTypeMismatch) or did not declare one at all (ContentTypeMissing). A
+// client that asked for the declared format cannot use such a distribution, so
+// the browser treats these the same as unreachable.
+export const CONTENT_TYPE_FAILURE_OUTCOMES: readonly string[] = [
+  'ContentTypeMismatch',
+  'ContentTypeMissing',
+].map((name) => `${PROBE_OUTCOME_BASE_URI}${name}`);
+
+// Every probe outcome that, once persistent, makes a distribution unavailable to
+// a client: it is either unreachable or serves a format other than the one it
+// declares. The Dataset Register Browser reads this list to classify
+// distribution availability, so the register stays the single source of truth
+// for the vocabulary.
+export const UNAVAILABILITY_OUTCOMES: readonly string[] = [
+  ...REACHABILITY_FAILURE_OUTCOMES,
+  ...CONTENT_TYPE_FAILURE_OUTCOMES,
+];

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 97.02,
-        functions: 95.53,
+        lines: 97.03,
+        functions: 95.55,
         branches: 89.47,
-        statements: 96.51,
+        statements: 96.53,
       },
     },
   },


### PR DESCRIPTION
## Why

The register's distribution health probe already detects when a server answers with a different `Content-Type` than the distribution declares, but the browser deliberately ignored that outcome: a distribution that serves, say, RDF/XML for a URL declared as JSON-LD still showed a green “reachable” check. For [the Nijmegen LOD Beelddocumenten dataset](https://datasetregister.netwerkdigitaalerfgoed.nl/dataset?uri=https://studiezaal.nijmegen.nl/AtlantisPubliek/data/dataset/LOD%2BBeelddocumenten) the server ignores content negotiation entirely and returns the same RDF/XML dump for every variant, so the JSON-LD, N-Triples and Turtle distributions all resolved to a file that was not in the declared format.

The download dropdown also listed format variants in registration order, so a format and its compressed sibling were scattered and rendered with identical labels (two indistinguishable “N-Triples” entries).

## What

- **Content-type mismatch counts as unavailable.** `distributionAvailability()` now flips a distribution to `unavailable` on `ContentTypeMismatch` / `ContentTypeMissing`, the same way it already treats unreachable distributions (same 7-day staleness window — no new warning tier). It is no longer offered as the default download and shows the amber status badge.
- **Vocabulary lives in core.** Added `CONTENT_TYPE_FAILURE_OUTCOMES` and `UNAVAILABILITY_OUTCOMES` to `@dataset-register/core` so the register stays the single source of truth; the browser consumes the combined list.
- **Compressed-first ordering.** Downloads sort reachable-first → compressed (gzip/zip) first (smaller to transfer) → format preference (N-Triples → N-Quads → Turtle → JSON-LD → other RDF → non-RDF) → stable URL tie-break.
- **Button matches the dropdown.** The default download button now points at the first reachable entry in that exact order, so it never diverges from the topmost option a visitor sees.
- **Distinguishable labels.** Compressed variants get a `(gzip)` / `(zip)` suffix; byte size still shows when available.
- **Tooltip reasons** for content-type mismatch and missing format, in EN and NL.

Scope is browser display + availability classification only; SHACL severity and registration rejection are unchanged.

## Notes

- These distributions turn amber only once the failure streak is ≥ 7 days old, consistent with how reachability failures are surfaced.
- The trade-off in the chosen ordering: all compressed variants float to the top globally, so a format's gzip and plain variants sit in separate blocks rather than adjacent. Swapping the two sort keys would instead group by format with gzip-first within each format.

Ref #2073 