### PR TITLE
fix(browser): merge duplicate class partitions on dataset detail page

### DIFF
--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import {
     type DatasetDetailResult,
+    type DatasetSummary,
     type DistributionDetail,
   } from '$lib/services/dataset-detail';
+  import { SvelteMap } from 'svelte/reactivity';
   import * as m from '$lib/paraglide/messages';
   import { getLocale } from '$lib/paraglide/runtime';
   import { page } from '$app/state';
@@ -189,13 +191,78 @@
     return (m as any)[key]?.() ?? code;
   }
 
+  type ClassPartition = NonNullable<DatasetSummary['classPartition']>[number];
+  type PropertyPartition = NonNullable<
+    ClassPartition['propertyPartition']
+  >[number];
+
+  // Combine property partitions that describe the same property, summing their
+  // entity counts and concatenating their nested partitions (downstream views
+  // re-aggregate those by key, so concatenation is safe).
+  function mergePropertyPartitions(
+    base: PropertyPartition[],
+    addition: PropertyPartition[],
+  ): PropertyPartition[] {
+    const byProperty = new SvelteMap<string, PropertyPartition>();
+    for (const partition of [...base, ...addition]) {
+      const existing = byProperty.get(partition.property);
+      if (!existing) {
+        byProperty.set(partition.property, { ...partition });
+        continue;
+      }
+      existing.entities = (existing.entities || 0) + (partition.entities || 0);
+      existing.distinctObjects =
+        (existing.distinctObjects || 0) + (partition.distinctObjects || 0);
+      existing.datatypePartition = [
+        ...(existing.datatypePartition ?? []),
+        ...(partition.datatypePartition ?? []),
+      ];
+      existing.objectClassPartition = [
+        ...(existing.objectClassPartition ?? []),
+        ...(partition.objectClassPartition ?? []),
+      ];
+      existing.languagePartition = [
+        ...(existing.languagePartition ?? []),
+        ...(partition.languagePartition ?? []),
+      ];
+    }
+    return [...byProperty.values()];
+  }
+
+  // The Knowledge Graph can emit more than one void:classPartition for the same
+  // class (e.g. when that class’s instances are counted over separate subsets).
+  // Collapse them into a single partition per class — summing entities and
+  // merging their property partitions — so each class renders once. Without
+  // this, the keyed {#each} over classes hits a duplicate key and blanks the page.
+  function mergeClassPartitions(
+    partitions: ClassPartition[],
+  ): ClassPartition[] {
+    const byClass = new SvelteMap<string, ClassPartition>();
+    for (const partition of partitions) {
+      const existing = byClass.get(partition.class);
+      if (!existing) {
+        byClass.set(partition.class, {
+          ...partition,
+          propertyPartition: [...(partition.propertyPartition ?? [])],
+        });
+        continue;
+      }
+      existing.entities = (existing.entities || 0) + (partition.entities || 0);
+      existing.propertyPartition = mergePropertyPartitions(
+        existing.propertyPartition ?? [],
+        partition.propertyPartition ?? [],
+      );
+    }
+    return [...byClass.values()];
+  }
+
   // Table data for all class partitions with nested property partitions
   const classPartitionTable = $derived.by(() => {
     if (!summary?.classPartition?.length) return undefined;
 
-    const sorted = summary.classPartition
-      .slice()
-      .sort((a, b) => (b.entities || 0) - (a.entities || 0));
+    const sorted = mergeClassPartitions(summary.classPartition).sort(
+      (a, b) => (b.entities || 0) - (a.entities || 0),
+    );
 
     const total = sorted.reduce((sum, p) => sum + (p.entities || 0), 0);
 


### PR DESCRIPTION
## Problem

The dataset detail page renders as a blank **white page** for some datasets, e.g.:

`/en/dataset?uri=https://collecties.venlo.nl/AtlantisPubliek/data/dataset/Oorlogsdoden+van+en+in+gemeente+Venlo+1940-1949`

The server-rendered HTML is correct, but the page blanks in the browser during hydration.

## Root cause

For these datasets the Knowledge Graph summary contains **more than one `void:classPartition` for the same class**. For the Venlo dataset, `schema:CreativeWork` has two partition nodes:

| partition | entities | properties |
| --- | --- | --- |
| `…/.well-known/void#class-243a…` | 3278 | name, description, genre, isPartOf, … (8) |
| `…/.well-known/void#class-abb8…` | 511 | encodingFormat (2) |

The Linked-data summary widget renders the class list with a keyed block:

```svelte
{#each displayedClasses as row (row.className)}
```

Two rows sharing a class URI produce a duplicate key, and Svelte 5 throws [`each_key_duplicate`](https://svelte.dev/e/each_key_duplicate). That error aborts hydration and clears the DOM, so the populated SSR page is replaced by an empty one. Only datasets where the Knowledge Graph emitted multiple partitions for one class are affected, which is why it is rare.

## Fix

Collapse class partitions that share a class into a single row before building the table – summing their entity counts and merging their property partitions – so each class renders exactly once. This also removes the confusing duplicate class row, and keeps the browser resilient to this upstream data shape rather than trusting the Knowledge Graph to emit one partition per class.

After the fix, `schema:CreativeWork` appears once with the combined **3,789** entities.

## Verification

- Reproduced the crash locally (Svelte reported `each_key_duplicate` at `ClassPropertiesWidget.svelte`), applied the fix, reloaded → page renders, zero console errors, `schema:CreativeWork` listed once at 3,789 entities.
- `nx lint browser` and `nx build @dataset-register/browser` pass.

## Follow-up

The duplicate `void:classPartition` output looks like a Dataset Knowledge Graph issue worth investigating separately (why two partitions are emitted for one class, and whether they should be consolidated at the source). Tracked in netwerk-digitaal-erfgoed/dataset-knowledge-graph.
