### PR TITLE
feat(browser): add state tooltips to NDE compatibility checks

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -268,18 +268,19 @@
   "nde_compat_registration_heading_registered": "Registered in the Dataset Register",
   "nde_compat_registration_heading_gone": "Registration no longer accessible",
   "nde_compat_registration_heading_invalid": "Registration no longer valid",
-  "nde_compat_registration_explanation_registered": "This dataset’s description is registered in the Dataset Register, so it can be found and reused.",
+  "nde_compat_registration_explanation_registered": "Others can now find and reuse this dataset.",
   "nde_compat_registration_explanation_gone": "The registration URL is no longer accessible, so the description can no longer be retrieved.",
   "nde_compat_registration_explanation_invalid": "The description no longer conforms to the requirements for datasets.",
   "nde_compat_registration_heading_warning": "Registered with warnings",
-  "nde_compat_registration_explanation_warning": "This dataset’s description is registered and valid, but it validated with warnings: some recommendations for datasets are not yet met.",
-  "nde_compat_registration_view_details": "View registration details",
+  "nde_compat_registration_explanation_warning": "This dataset is registered and valid, but it raised warnings.",
+  "nde_compat_registration_view_details": "View registration",
   "nde_compat_persistent_heading_persistent": "Uses persistent URIs",
   "nde_compat_persistent_heading_resolves": "Uses a non-persistent domain name",
   "nde_compat_persistent_heading_unresolved": "Some URIs are not reachable",
-  "nde_compat_persistent_heading_pending": "Persistent URIs not yet assessed",
+  "nde_compat_persistent_heading_pending": "Persistent URIs not yet checked",
+  "nde_compat_state_legend_label": "What the colours mean",
   "nde_compat_persistent_explanation_persistent": "This dataset’s URIs resolve to a landing page.",
-  "nde_compat_persistent_explanation_resolves": "This dataset’s URIs use a non-persistent domain name, for example one from a software vendor.",
+  "nde_compat_persistent_explanation_resolves": "The URIs resolve, but on a domain that may change, such as a software vendor’s.",
   "nde_compat_persistent_explanation_unresolved": "Some of this dataset’s sampled URIs do not resolve to a landing page.",
   "nde_compat_persistent_explanation_pending": "This dataset’s URIs have not been checked for persistence yet.",
   "nde_compat_persistent_count_unresolved": [
@@ -298,6 +299,8 @@
     }
   ],
   "nde_compat_persistent_issued_by": "Issued by {publisher}.",
+  "nde_compat_persistent_uses_scheme": "Uses {scheme} identifiers.",
+  "nde_compat_persistent_scheme_issued_by": "{scheme}, issued by {publisher}.",
   "nde_compat_linked_data_heading_conforms": "Provides linked data conforming to the NDE Application Profile",
   "nde_compat_linked_data_heading_not_conforms": "Provides linked data",
   "nde_compat_linked_data_heading_pending": "Linked data not yet assessed",
@@ -317,15 +320,19 @@
       ],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "{display} triple found.",
-        "countPlural=other": "{display} triples found."
+        "countPlural=one": "{display} triple found",
+        "countPlural=other": "{display} triples found"
       }
     }
   ],
   "nde_compat_iiif_heading_provided": "Provides IIIF media",
   "nde_compat_iiif_heading_not_provided": "Does not provide IIIF media",
   "nde_compat_iiif_heading_unavailable": "IIIF media unavailable",
-  "nde_compat_iiif_explanation": "With IIIF, the images in a dataset can be viewed in any IIIF viewer.",
+  "nde_compat_iiif_explanation_before": "With ",
+  "nde_compat_iiif_explanation_after": ", the dataset’s images can be flexibly viewed in other websites and services.",
+  "nde_compat_iiif_explanation_unavailable": "This dataset declares IIIF media, but the sampled manifests are invalid",
+  "nde_compat_iiif_explanation_not_provided": "This dataset provides no IIIF media, so its images can’t be flexibly viewed in other websites and services.",
+  "iiif": "IIIF",
   "nde_compat_iiif_count": [
     {
       "declarations": [
@@ -335,8 +342,8 @@
       ],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "{display} manifest found.",
-        "countPlural=other": "{display} manifests found."
+        "countPlural=one": "{display} manifest found",
+        "countPlural=other": "{display} manifests found"
       }
     }
   ],
@@ -356,8 +363,10 @@
   ],
   "nde_compat_terms_heading_uses": "Uses terms from the Network of Terms",
   "nde_compat_terms_heading_not_uses": "Does not use terms from the Network of Terms",
-  "nde_compat_terms_explanation_before": "Objects in this dataset link to shared terms from terminology sources in the ",
-  "nde_compat_terms_explanation_after": ", which makes the data interoperable and easier to find.",
+  "nde_compat_terms_explanation_not_before": "Objects in this dataset don’t link to shared terms in the ",
+  "nde_compat_terms_explanation_not_after": ", which makes them harder to link to other datasets.",
+  "nde_compat_terms_explanation_before": "Objects in this dataset link to shared terms in the ",
+  "nde_compat_terms_explanation_after": ", which makes them easier to link to other datasets.",
   "network_of_terms": "Network of Terms",
   "nde_compat_terms_count": [
     {
@@ -368,8 +377,8 @@
       ],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "contains {display} link to terms",
-        "countPlural=other": "contains {display} links to terms"
+        "countPlural=one": "{display} link to terms found",
+        "countPlural=other": "{display} links to terms found"
       }
     }
   ],

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -268,19 +268,20 @@
   "nde_compat_registration_heading_registered": "Geregistreerd in het Datasetregister",
   "nde_compat_registration_heading_gone": "Registratie niet meer toegankelijk",
   "nde_compat_registration_heading_invalid": "Registratie niet meer geldig",
-  "nde_compat_registration_explanation_registered": "De beschrijving van deze dataset is geregistreerd in het Datasetregister, zodat de dataset vindbaar en herbruikbaar is.",
+  "nde_compat_registration_explanation_registered": "Anderen kunnen de dataset nu vinden en hergebruiken.",
   "nde_compat_registration_explanation_gone": "De registratie-URL is niet meer toegankelijk, dus de beschrijving kan niet meer worden opgehaald.",
   "nde_compat_registration_explanation_invalid": "De beschrijving voldoet niet meer aan de eisen voor datasets.",
   "nde_compat_registration_heading_warning": "Geregistreerd met waarschuwingen",
-  "nde_compat_registration_explanation_warning": "De beschrijving van deze dataset is geregistreerd en geldig, maar bij de validatie zijn waarschuwingen gegeven: aan sommige aanbevelingen voor datasets wordt nog niet voldaan.",
-  "nde_compat_registration_view_details": "Bekijk registratiegegevens",
+  "nde_compat_registration_explanation_warning": "Deze dataset is geregistreerd en geldig, maar geeft waarschuwingen.",
+  "nde_compat_registration_view_details": "Bekijk registratie",
   "nde_compat_persistent_heading_persistent": "Gebruikt persistente URI’s",
   "nde_compat_persistent_heading_resolves": "Gebruikt een niet-persistente domeinnaam",
   "nde_compat_persistent_heading_unresolved": "Sommige URI’s zijn niet bereikbaar",
-  "nde_compat_persistent_heading_pending": "Persistente URI’s nog niet beoordeeld",
+  "nde_compat_persistent_heading_pending": "Persistente URI’s nog niet gecontroleerd",
+  "nde_compat_state_legend_label": "Wat de kleuren betekenen",
   "nde_compat_persistent_explanation_persistent": "De persistente URI’s van deze dataset leiden naar een landingspagina.",
-  "nde_compat_persistent_explanation_resolves": "De URI’s van deze dataset gebruiken een niet-persistente domeinnaam, bijvoorbeeld die van een software-leverancier.",
-  "nde_compat_persistent_explanation_unresolved": "Sommige van de getoetste URI’s van deze dataset leiden niet naar een landingspagina.",
+  "nde_compat_persistent_explanation_resolves": "De URI’s werken nu, maar gebruiken een domein dat kan veranderen, bijvoorbeeld dat van een software-leverancier.",
+  "nde_compat_persistent_explanation_unresolved": "Sommige URI’s uit de steekproef leiden niet naar een landingspagina.",
   "nde_compat_persistent_explanation_pending": "De URI’s van deze dataset zijn nog niet op persistentie gecontroleerd.",
   "nde_compat_persistent_count_unresolved": [
     {
@@ -292,12 +293,14 @@
       ],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "{unresolved} van {display} getoetste URI’s leidt niet naar een landingspagina.",
-        "countPlural=other": "{unresolved} van {display} getoetste URI’s leiden niet naar een landingspagina."
+        "countPlural=one": "{unresolved} van {display} URI’s uit de steekproef leidt niet naar een landingspagina.",
+        "countPlural=other": "{unresolved} van {display} URI’s uit de steekproef leiden niet naar een landingspagina."
       }
     }
   ],
   "nde_compat_persistent_issued_by": "Uitgegeven door {publisher}.",
+  "nde_compat_persistent_uses_scheme": "Gebruikt {scheme}-identifiers.",
+  "nde_compat_persistent_scheme_issued_by": "{scheme}, uitgegeven door {publisher}.",
   "nde_compat_linked_data_heading_conforms": "Biedt linked data volgens het NDE-applicatieprofiel",
   "nde_compat_linked_data_heading_not_conforms": "Biedt linked data",
   "nde_compat_linked_data_heading_pending": "Linked data nog niet beoordeeld",
@@ -317,15 +320,19 @@
       ],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "{display} feit gevonden.",
-        "countPlural=other": "{display} feiten gevonden."
+        "countPlural=one": "{display} feit gevonden",
+        "countPlural=other": "{display} feiten gevonden"
       }
     }
   ],
   "nde_compat_iiif_heading_provided": "Biedt IIIF-media",
   "nde_compat_iiif_heading_not_provided": "Biedt geen IIIF-media",
   "nde_compat_iiif_heading_unavailable": "IIIF-media niet beschikbaar",
-  "nde_compat_iiif_explanation": "Met IIIF zijn de afbeeldingen in een dataset in elke IIIF-viewer te bekijken.",
+  "nde_compat_iiif_explanation_before": "Met ",
+  "nde_compat_iiif_explanation_after": " zijn de afbeeldingen in de dataset flexibel te bekijken in andere websites en diensten.",
+  "nde_compat_iiif_explanation_unavailable": "Deze dataset geeft IIIF-media op, maar de manifesten uit de steekproef zijn ongeldig.",
+  "nde_compat_iiif_explanation_not_provided": "Deze dataset biedt geen IIIF-media, waardoor de afbeeldingen niet flexibel te bekijken zijn in andere websites en diensten.",
+  "iiif": "IIIF",
   "nde_compat_iiif_count": [
     {
       "declarations": [
@@ -335,8 +342,8 @@
       ],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "{display} manifest gevonden.",
-        "countPlural=other": "{display} manifesten gevonden."
+        "countPlural=one": "{display} manifest gevonden",
+        "countPlural=other": "{display} manifesten gevonden"
       }
     }
   ],
@@ -349,15 +356,17 @@
       ],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "{display} manifest opgegeven, maar deze kon niet worden gevalideerd.",
-        "countPlural=other": "{display} manifesten opgegeven, maar geen van de gecontroleerde manifesten kon worden gevalideerd."
+        "countPlural=one": "{display} IIIF-manifest opgegeven, maar deze kon niet worden gevalideerd.",
+        "countPlural=other": "{display} IIIF-manifesten opgegeven, maar geen daarvan kon worden gevalideerd."
       }
     }
   ],
   "nde_compat_terms_heading_uses": "Gebruikt termen uit het Termennetwerk",
   "nde_compat_terms_heading_not_uses": "Gebruikt geen termen uit het Termennetwerk",
-  "nde_compat_terms_explanation_before": "Objecten in deze dataset linken naar gedeelde termen uit terminologiebronnen in het ",
-  "nde_compat_terms_explanation_after": ", waardoor de data interoperabel en beter vindbaar wordt.",
+  "nde_compat_terms_explanation_not_before": "Objecten in deze dataset linken niet naar gedeelde termen uit het ",
+  "nde_compat_terms_explanation_not_after": ", waardoor ze moeilijker te koppelen zijn aan andere datasets.",
+  "nde_compat_terms_explanation_before": "Objecten in deze dataset linken naar gedeelde termen uit het ",
+  "nde_compat_terms_explanation_after": ", waardoor ze eenvoudiger te koppelen zijn aan andere datasets.",
   "network_of_terms": "Termennetwerk",
   "nde_compat_terms_count": [
     {
@@ -368,8 +377,8 @@
       ],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "bevat {display} link naar termen",
-        "countPlural=other": "bevat {display} links naar termen"
+        "countPlural=one": "{display} link naar termen gevonden",
+        "countPlural=other": "{display} links naar termen gevonden"
       }
     }
   ],

--- a/apps/browser/src/app.css
+++ b/apps/browser/src/app.css
@@ -6,6 +6,15 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Animate in-page anchor jumps (e.g. the compatibility section linking down to
+   the Linked Data Summary or Terminology Sources) so the transition is clearer.
+   Gated on prefers-reduced-motion to respect users who opt out of motion. */
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
 @source "../../../node_modules/flowbite-svelte/dist";
 @source "../../../node_modules/flowbite-svelte-icons/dist";
 @source "../../../node_modules/@flowbite-svelte-plugins/chart/dist";

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
   import * as m from '$lib/paraglide/messages';
   import { getLocale } from '$lib/paraglide/runtime';
+  import { Tooltip } from 'flowbite-svelte';
+  import ArrowUpRightFromSquareOutline from 'flowbite-svelte-icons/ArrowUpRightFromSquareOutline.svelte';
   import CheckOutline from 'flowbite-svelte-icons/CheckOutline.svelte';
   import CloseOutline from 'flowbite-svelte-icons/CloseOutline.svelte';
   import ExclamationCircleOutline from 'flowbite-svelte-icons/ExclamationCircleOutline.svelte';
+  import InfoCircleSolid from 'flowbite-svelte-icons/InfoCircleSolid.svelte';
   import {
     compatibilityCriteria,
+    IIIF_URL,
     NDE_VINKJES_URL,
     NETWORK_OF_TERMS_URL,
     type CompatibilityCriterion,
+    type CompatibilityFailureReason,
+    type CompatibilityState,
     type IiifManifests,
     type LinkedData,
     type PersistentUris,
@@ -24,6 +30,7 @@
     terms,
     iiifManifests,
     linkedData,
+    validateHref,
   }: {
     isAnalyzed: boolean;
     registrationStatus: RegistrationFailureReason | null;
@@ -32,6 +39,11 @@
     terms: TermLinks | null;
     iiifManifests: IiifManifests;
     linkedData: LinkedData;
+    // Localized link to this dataset’s validation page, matching the valid/invalid
+    // button in the Registration section. The IIIF criterion links “IIIF” here so
+    // visitors can inspect the manifest validation results. Null when the dataset
+    // has no registered URL to validate.
+    validateHref: string | null;
   } = $props();
 
   const criteria = $derived(
@@ -145,18 +157,100 @@
               ? m.nde_compat_linked_data_explanation_empty()
               : m.nde_compat_linked_data_explanation_none();
         }
-      // A single explanation regardless of state, following the IIIF pattern.
-      // The template renders this with “Network of Terms” as an inline link;
-      // the two halves are joined here as the plain-text fallback.
+      // Met: a positive explanation the template renders with “Network of Terms”
+      // as an inline link (the two halves are joined here as the plain-text
+      // fallback). Failed: a negative explanation, so the red row no longer reads
+      // as if the dataset does link to terms.
       // eslint-disable-next-line no-fallthrough
       case 'terms':
-        return (
-          m.nde_compat_terms_explanation_before() +
-          m.network_of_terms() +
-          m.nde_compat_terms_explanation_after()
-        );
+        return criterion.state === 'met'
+          ? m.nde_compat_terms_explanation_before() +
+              m.network_of_terms() +
+              m.nde_compat_terms_explanation_after()
+          : m.nde_compat_terms_explanation_not_before() +
+              m.network_of_terms() +
+              m.nde_compat_terms_explanation_not_after();
+      // Met: the benefit of providing IIIF, which the template renders with
+      // “IIIF” as an inline link (the halves are joined here as the plain-text
+      // fallback). Failed/unmet: state-specific text, so a row whose media is
+      // unavailable or absent no longer reads as if IIIF works.
       case 'iiif':
-        return m.nde_compat_iiif_explanation();
+        switch (criterion.state) {
+          case 'met':
+            return (
+              m.nde_compat_iiif_explanation_before() +
+              m.iiif() +
+              m.nde_compat_iiif_explanation_after()
+            );
+          case 'failed':
+            return m.nde_compat_iiif_explanation_unavailable();
+          default:
+            return m.nde_compat_iiif_explanation_not_provided();
+        }
+    }
+  }
+
+  // One line in a criterion’s state legend: the status tier (for the indicator’s
+  // shape and colour), the heading that labels that state, and the explanation of
+  // what that state means.
+  type LegendEntry = {
+    state: CompatibilityState;
+    label: string;
+    description: string;
+  };
+
+  // The states to list in a criterion’s tooltip legend. Each line reuses the same
+  // heading() and explanation() strings as the rows (built from a synthetic
+  // criterion), so the legend has no messages of its own to translate and
+  // maintain. Criteria differ in which tiers they can take: registration and
+  // linked data have two distinct red reasons; terms is binary; IIIF has no
+  // warning tier. The neutral “pending” tier (persistent, linked data) is
+  // transient, so it is only listed while the criterion is actually in it; IIIF’s
+  // neutral tier is a real outcome (“no media”) and is always listed.
+  function legendEntries(criterion: CompatibilityCriterion): LegendEntry[] {
+    const entry = (
+      state: CompatibilityState,
+      reason?: CompatibilityFailureReason,
+    ): LegendEntry => {
+      const synthetic: CompatibilityCriterion = {
+        key: criterion.key,
+        state,
+        count: 0,
+        ...(reason ? { reason } : {}),
+      };
+      return {
+        state,
+        label: heading(synthetic),
+        description: explanation(synthetic),
+      };
+    };
+    switch (criterion.key) {
+      case 'registration':
+        return [
+          entry('met'),
+          entry('warning'),
+          entry('failed', 'gone'),
+          entry('failed', 'invalid'),
+        ];
+      case 'persistent':
+        return [
+          entry('met'),
+          entry('warning'),
+          entry('failed'),
+          ...(criterion.state === 'unmet' ? [entry('unmet')] : []),
+        ];
+      case 'linked-data':
+        return [
+          entry('met'),
+          entry('warning'),
+          entry('failed', 'no-linked-data'),
+          entry('failed', 'empty'),
+          ...(criterion.state === 'unmet' ? [entry('unmet')] : []),
+        ];
+      case 'terms':
+        return [entry('met'), entry('failed')];
+      case 'iiif':
+        return [entry('met'), entry('failed'), entry('unmet')];
     }
   }
 
@@ -190,12 +284,33 @@
               display: sampled.toLocaleString(getLocale()),
             });
           }
-          case 'met':
+          case 'met': {
+            // Surface the recognised PID scheme (ARK/Handle) as a bonus, and
+            // name the issuing organisation when known (ARK only). The scheme
+            // enum maps to its proper-name label, identical in both locales.
+            const schemeLabel =
+              persistentUris.scheme === 'ark'
+                ? 'ARK'
+                : persistentUris.scheme === 'handle'
+                  ? 'Handle'
+                  : null;
+            if (schemeLabel && persistentUris.publisher) {
+              return m.nde_compat_persistent_scheme_issued_by({
+                scheme: schemeLabel,
+                publisher: persistentUris.publisher,
+              });
+            }
+            if (schemeLabel) {
+              return m.nde_compat_persistent_uses_scheme({
+                scheme: schemeLabel,
+              });
+            }
             return persistentUris.publisher
               ? m.nde_compat_persistent_issued_by({
                   publisher: persistentUris.publisher,
                 })
               : null;
+          }
           default:
             return null;
         }
@@ -226,16 +341,17 @@
     }
   }
 
-  // In-page anchor to the criterion’s evidence section further down the page, or
-  // null when it has none. Registration points to its Registration section; the
-  // linked-data criterion (when it reports a fact count) to the Linked Data
-  // Summary section; the terms criterion (when met) to the Terminology Sources
-  // section. The template attaches this to the count line when there is one,
-  // otherwise renders a dedicated link.
+  // Link to the criterion’s evidence, or null when it has none. Registration
+  // points to this dataset’s validation page (the same link as the valid/invalid
+  // button in the Registration section); the linked-data criterion (when it
+  // reports a fact count) to the in-page Linked Data Summary section; the terms
+  // criterion (when met) to the in-page Terminology Sources section. The template
+  // attaches this to the count line when there is one, otherwise renders a
+  // dedicated link.
   function sectionAnchor(criterion: CompatibilityCriterion): string | null {
     switch (criterion.key) {
       case 'registration':
-        return '#registration';
+        return validateHref;
       case 'linked-data':
         // Link the fact count down to the Linked Data Summary section; gated to
         // match the count line in detail() so the anchor only appears alongside
@@ -251,6 +367,32 @@
     }
   }
 </script>
+
+<!-- Mini status indicator for the per-criterion state legend, mirroring each
+     row's status box: the shape (tick / exclamation / cross / empty box) carries
+     the meaning alongside the colour, so the legend stays legible for colourblind
+     users and on the dark tooltip background. Decorative — the adjacent text
+     names the state. -->
+{#snippet statusIndicator(state: CompatibilityState)}
+  <span
+    class={`mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border ${
+      state === 'met'
+        ? 'border-green-600 bg-green-600 text-white dark:border-green-500 dark:bg-green-500'
+        : state === 'warning'
+          ? 'border-orange-500 bg-orange-500 text-white dark:border-orange-400 dark:bg-orange-400'
+          : state === 'failed'
+            ? 'border-red-600 bg-red-600 text-white dark:border-red-500 dark:bg-red-500'
+            : 'border-gray-300 bg-white dark:border-gray-400 dark:bg-gray-700'
+    }`}
+    aria-hidden="true"
+  >
+    {#if state === 'met'}<CheckOutline
+        class="h-3 w-3"
+      />{:else if state === 'warning'}<ExclamationCircleOutline
+        class="h-3 w-3"
+      />{:else if state === 'failed'}<CloseOutline class="h-3 w-3" />{/if}
+  </span>
+{/snippet}
 
 <!-- Analysis-dependent criteria are dropped for a dataset that has not been
      analyzed; the section is shown whenever any criterion remains. -->
@@ -270,8 +412,10 @@
         rel="noopener noreferrer"
         class="text-blue-600 hover:underline dark:text-blue-400"
       >
-        {m.nde_compat_learn_more()}
-        <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+        {m.nde_compat_learn_more()}<ArrowUpRightFromSquareOutline
+          class="ms-1 inline-block h-3 w-3 align-[-0.1em]"
+          aria-hidden="true"
+        /><span class="sr-only"> ({m.opens_in_new_tab()})</span>
       </a>
     </p>
     <div
@@ -308,26 +452,72 @@
             </span>
             <div class="min-w-0">
               <h3 class="text-base font-medium text-gray-900 dark:text-white">
-                {heading(criterion)}
+                {heading(criterion)}<span
+                  id={`tooltip-${criterion.key}-states`}
+                  class="ms-1 inline-flex cursor-pointer align-[-0.125em]"
+                  ><InfoCircleSolid
+                    class="h-4 w-4 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+                  /><span class="sr-only"
+                    >{m.nde_compat_state_legend_label()}</span
+                  ></span
+                >
               </h3>
+              <!-- A per-criterion legend of the states this criterion can take, so
+                   visitors can see what each status means here (and what reaching
+                   green requires). Each line reuses the row’s own heading and
+                   explanation for that state (see legendEntries), so there is a
+                   single source of truth. -->
+              <Tooltip
+                triggeredBy={`#tooltip-${criterion.key}-states`}
+                class="max-w-xs text-left"
+              >
+                <ul class="space-y-1.5">
+                  {#each legendEntries(criterion) as item (item.label)}
+                    <li class="flex items-start gap-2">
+                      {@render statusIndicator(item.state)}
+                      <span
+                        ><span class="font-medium">{item.label}</span>: {item.description}</span
+                      >
+                    </li>
+                  {/each}
+                </ul>
+              </Tooltip>
               <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
                 <!-- The terms explanation links “Network of Terms” to the
-                     Termennetwerk browser in the current locale; other criteria
+                     Termennetwerk browser in the current locale — in both the
+                     met and failed states, with state-specific wording around
+                     the link — and the IIIF explanation links “IIIF” to NDE’s
+                     IIIF page. Both are external (new tab + icon). Other criteria
                      render their explanation as plain text. -->
-                {#if criterion.key === 'terms'}{m.nde_compat_terms_explanation_before()}<a
+                {#if criterion.key === 'terms'}{criterion.state === 'met'
+                    ? m.nde_compat_terms_explanation_before()
+                    : m.nde_compat_terms_explanation_not_before()}<a
                     href={`${NETWORK_OF_TERMS_URL}/${getLocale()}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     class="text-blue-600 hover:underline dark:text-blue-400"
-                    >{m.network_of_terms()}<span class="sr-only">
-                      ({m.opens_in_new_tab()})</span
-                    ></a
-                  >{m.nde_compat_terms_explanation_after()}{:else}{explanation(
+                    >{m.network_of_terms()}<ArrowUpRightFromSquareOutline
+                      class="ms-0.5 inline-block h-3 w-3 align-[-0.1em]"
+                      aria-hidden="true"
+                    /><span class="sr-only"> ({m.opens_in_new_tab()})</span></a
+                  >{criterion.state === 'met'
+                    ? m.nde_compat_terms_explanation_after()
+                    : m.nde_compat_terms_explanation_not_after()}{:else if criterion.key === 'iiif' && criterion.state === 'met'}{m.nde_compat_iiif_explanation_before()}<a
+                    href={IIIF_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-blue-600 hover:underline dark:text-blue-400"
+                    >{m.iiif()}<ArrowUpRightFromSquareOutline
+                      class="ms-0.5 inline-block h-3 w-3 align-[-0.1em]"
+                      aria-hidden="true"
+                    /><span class="sr-only"> ({m.opens_in_new_tab()})</span></a
+                  >{m.nde_compat_iiif_explanation_after()}{:else}{explanation(
                     criterion,
                   )}{/if}
-                <!-- A criterion with an evidence section but no count line (e.g.
-                     registration) gets a dedicated in-page link here; one with a
-                     count line carries the link on that line instead. -->
+                <!-- A criterion with an evidence link but no count line (e.g.
+                     registration, linking to the validation page) gets a
+                     dedicated link here; one with a count line carries the link
+                     on that line instead. -->
                 {#if sectionHref && !detailText}
                   <a
                     href={sectionHref}

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -18,6 +18,10 @@ export const NDE_VINKJES_URL =
 export const NETWORK_OF_TERMS_URL =
   'https://termennetwerk.netwerkdigitaalerfgoed.nl';
 
+// NDE’s public page explaining IIIF. The IIIF criterion links the word “IIIF” in
+// its explanation here.
+export const IIIF_URL = 'https://netwerkdigitaalerfgoed.nl/iiif/';
+
 // DQV metric IRIs for the IIIF manifest validation measurements recorded by the
 // Dataset Knowledge Graph.
 export const MANIFESTS_SAMPLED_METRIC =

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -1341,6 +1341,9 @@
     {terms}
     {iiifManifests}
     {linkedData}
+    validateHref={dataset.subjectOf?.$id
+      ? localizeHref(`/validate?url=${encodeUrlParam(dataset.subjectOf.$id)}`)
+      : null}
   />
 
   <!-- VoID Summary Section -->
@@ -1348,7 +1351,7 @@
     <div class="mb-8">
       <h2
         id="linked-data-summary"
-        class="mb-4 flex scroll-mt-4 flex-wrap items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white"
+        class="mb-4 flex scroll-mt-20 flex-wrap items-center gap-2 text-xl font-semibold text-gray-900 lg:scroll-mt-24 dark:text-white"
       >
         {m.detail_linked_data_summary()}
         <span id="tooltip-linked-data-summary" class="cursor-pointer">
@@ -1582,7 +1585,7 @@
 
       <!-- Terminology Sources Section -->
       {#if linksets.length > 0}
-        <div id="terminology-sources" class="mt-6">
+        <div id="terminology-sources" class="mt-6 scroll-mt-20 lg:scroll-mt-24">
           <h3
             class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
           >
@@ -1630,7 +1633,7 @@
   <div class="mb-8">
     <h2
       id="registration"
-      class="mb-4 scroll-mt-4 text-xl font-semibold text-gray-900 dark:text-white"
+      class="mb-4 scroll-mt-20 text-xl font-semibold text-gray-900 lg:scroll-mt-24 dark:text-white"
     >
       {m.detail_registration()}
     </h2>


### PR DESCRIPTION
## What

Adds a per-criterion **state legend** to the NDE compatibility (“vinkjes”) section on the dataset detail page, and tidies up the criteria wording and links along the way.

## Why

The coloured status of each check (🟢/🟠/🔴/⚪) isn’t self-explanatory — orange (“present but not up to standard”) and grey (which means “not yet checked” for some criteria and “not applicable” for others) are easy to misread. Each criterion now has an info tooltip that spells out the states it can take, so a publisher can see what each status means and what reaching green requires.

## Changes

- **State tooltip per criterion.** An info icon next to each heading opens a legend of the states that criterion can take: a status indicator, the heading, and the explanation. Lines are generated from the rows’ own `heading()` and `explanation()` via a synthetic criterion (`legendEntries`), so there are no parallel legend strings to translate — improving a row’s wording updates its tooltip automatically.
- **Colourblind-safe, legible legend.** The legend reuses the rows’ status shapes (tick / exclamation / cross / empty box) rather than coloured dots, so meaning is carried by shape as well as colour and stays readable on the dark tooltip background. The transient “pending” tier is only listed while a criterion is actually in it; registration and linked data list their two distinct red reasons.
- **State-specific IIIF and terms explanations.** Previously the IIIF and terms rows showed the same text in every state; failed/neutral rows now read correctly (e.g. IIIF failed: “the sampled manifests are not valid IIIF manifests”).
- **External links get an icon.** “IIIF” links to NDE’s IIIF page and “Network of Terms” to the Termennetwerk browser, both opening in a new tab with an external-link icon. The registration evidence link points to the dataset’s validation page.
- **Persistent URIs show the PID scheme.** The met row now surfaces the recognised scheme (ARK / Handle) and the issuing organisation when known.
- **Wording and i18n.** Reworded several registration/persistent/terms/IIIF explanations for clarity (plainer than “interoperable”, “sampled” ↔ “steekproef”, etc.) and kept EN and NL in sync.
- **Smooth in-page scrolling.** Anchor jumps (Linked Data Summary, Terminology Sources) now animate, gated on `prefers-reduced-motion`, and scroll margins were corrected so headings clear the fixed header.

Verified the tooltips for all five criteria render correctly in the running app.
