### PR TITLE
fix(deps): declare svelte at the workspace root to prevent lockfile drift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "prettier": "^3.8.3",
         "prettier-plugin-packagejson": "^3.0.2",
         "prettier-plugin-svelte": "^4.1.0",
+        "svelte": "^5.56.2",
         "tslib": "^2.3.0",
         "typescript": "~6.0.3",
         "typescript-eslint": "8.60.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "prettier": "^3.8.3",
     "prettier-plugin-packagejson": "^3.0.2",
     "prettier-plugin-svelte": "^4.1.0",
+    "svelte": "^5.56.2",
     "tslib": "^2.3.0",
     "typescript": "~6.0.3",
     "typescript-eslint": "8.60.1",


### PR DESCRIPTION
## Problem

[PR #2078](https://github.com/netwerk-digitaal-erfgoed/dataset-register/pull/2078) (a Dependabot svelte bump) failed CI in the Docker build with:

```
npm error Invalid: lock file's svelte@5.56.1 does not satisfy svelte@5.56.3
```

`svelte` is a **direct** dependency only in `apps/browser`, but the workspace root needs it too: `nx format:write` (the pre-commit hook) loads `prettier-plugin-svelte` to format `.svelte` files, and that plugin peer-depends on `svelte@^5.0.0`. Because **nothing at the root declared `svelte` directly**, it was only ever pulled in transitively. When Dependabot bumped `apps/browser` to `^5.56.2`, the root copy still satisfied the wide `^5.0.0` peer range, so npm left it on the old version — two versions then coexisted, and `@nx/js:prune-lockfile` produced an inconsistent pruned lockfile that broke `npm ci` in Docker.

This is the documented Nx failure mode for **duplicate transitive dependencies with no top-level anchor** ([nrwl/nx#34322](https://github.com/nrwl/nx/issues/34322)): prune’s re-hoisting logic can’t reliably pick a version when multiple exist and none is reachable from a top-level `package.json`. The upstream fix there is only a crash guard, so the underlying hazard remains on our Nx version (22.7.5).

## Fix

Declare `svelte` directly in the root `package.json` (same range as `apps/browser`). This gives it a top-level anchor, so:

- npm hoists a **single** svelte version (verified: no nested `apps/browser/node_modules/svelte`).
- The Dependabot `svelte` group now bumps **both** manifests in lockstep, so they can’t fall out of sync.

It’s an honest declaration — the root genuinely consumes svelte via `prettier-plugin-svelte` during `nx format:write`.

## Validation

- `npx nx build @dataset-register/browser` – passes
- `npx nx format:check` – clean
- `npx nx run @dataset-register/browser:prune-lockfile` then `npm ci --dry-run` against the pruned output – succeeds with no `does not satisfy` error (the exact step that failed before)
- `npm ls svelte` – single version (`5.56.3`) deduped across the tree
