### PR TITLE
fix(browser): switch Dataset Knowledge Graph to the new QLever endpoint

### DIFF
--- a/apps/browser/.env
+++ b/apps/browser/.env
@@ -1,3 +1,3 @@
 PUBLIC_SPARQL_ENDPOINT=https://datasetregister.netwerkdigitaalerfgoed.nl/sparql
-PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT=https://triplestore.netwerkdigitaalerfgoed.nl/repositories/dataset-knowledge-graph
+PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT=https://sparql.netwerkdigitaalerfgoed.nl/dataset-knowledge-graph
 PUBLIC_API_ENDPOINT=https://datasetregister.netwerkdigitaalerfgoed.nl/api

--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -3,7 +3,10 @@ import { dcterms, foaf, ldkit, xsd } from 'ldkit/namespaces';
 import { createLens, type SchemaInterface } from 'ldkit';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { facetConfigs, type Facets, fetchFacets } from '$lib/services/facets';
-import { PUBLIC_SPARQL_ENDPOINT } from '$env/static/public';
+import {
+  PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT,
+  PUBLIC_SPARQL_ENDPOINT,
+} from '$env/static/public';
 import { schemaNs as schema, voidNs } from '../rdf.js';
 import { getLocale } from '$lib/paraglide/runtime';
 import { normalizeMediaType } from '$lib/utils/sparql';
@@ -355,7 +358,7 @@ export function datasetCardsQuery(
     # via SPARQL Federation. The IIIF subset is itself optional: not every
     # dataset exposes IIIF Presentation manifests.
     OPTIONAL {
-      SERVICE <https://triplestore.netwerkdigitaalerfgoed.nl/repositories/dataset-knowledge-graph> {
+      SERVICE <${PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT}> {
         ?dataset a void:Dataset ;
           void:triples ?size .
         OPTIONAL {
@@ -524,7 +527,7 @@ function filterClauses(searchFilters: SearchRequest, skipDefaults = false) {
     // When filtering by size, require datasets to have size data (not OPTIONAL).
     // This ensures only datasets with known sizes are returned in filtered results.
     filterClausesArray.push(`
-      SERVICE <https://triplestore.netwerkdigitaalerfgoed.nl/repositories/dataset-knowledge-graph> {
+      SERVICE <${PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT}> {
         ?dataset a void:Dataset ;
           void:triples ?datasetSize .
       }


### PR DESCRIPTION
Switches the Dataset Knowledge Graph (DKG) to the new QLever instance.

## Changes

- Point `PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT` at the new QLever endpoint `https://sparql.netwerkdigitaalerfgoed.nl/dataset-knowledge-graph` (was the GraphDB triplestore at `triplestore.netwerkdigitaalerfgoed.nl`).
- Replace the two hard-coded triplestore URLs in the `SERVICE` clauses in `datasets.ts` with the `PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT` env var, so the endpoint is defined in a single place.

## Scope

Endpoint switch only. Whether to lean into QLever-to-QLever federated `SERVICE` queries is deliberately left for a follow-up – we first want to measure whether federation is actually faster before changing query strategy.
