### PR TITLE
fix: enforce HTTP(S) IRI for dcat:Dataset and reject blank-node datasets

### DIFF
--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -33,9 +33,11 @@ export class ShaclEngineValidator implements Validator {
 
   public async validate(input: DatasetCore): Promise<ValidationResult> {
     const dataset = standardizeSchemaOrgPrefix(input);
+    // Detect dataset subjects regardless of node kind: blank-node datasets must
+    // reach SHACL so the shapes can reject them with a clear web-URI message,
+    // rather than being silently dropped as no-dataset.
     const datasetIris = dataset.filter(
       (quad) =>
-        quad.subject.termType === 'NamedNode' && // Prevent blank nodes
         quad.predicate.value ===
           'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' &&
         (quad.object.value === 'https://schema.org/Dataset' ||

--- a/packages/core/test/datasets/dataset-dcat-blank-node.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-blank-node.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "@type": "dcat:Dataset",
+  "dct:title": "Alba amicorum van de Koninklijke Bibliotheek",
+  "dct:license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "dct:publisher": {
+    "@id": "https://example.com/dataset-provider",
+    "@type": "foaf:Person",
+    "foaf:name": "Dataset Provider"
+  }
+}

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -197,9 +197,12 @@ describe('Validator', () => {
     expect(report.state).toEqual('no-dataset');
   });
 
-  it('rejects a dataset that has no IRI', async () => {
+  it('reports a dataset that is a blank node (no IRI) as invalid', async () => {
+    // A blank-node dataset reaches SHACL and fails the nodeKind/pattern
+    // constraints, surfacing a clear web-URI message rather than the misleading
+    // `no-dataset` state.
     const report = await validate('dataset-invalid-no-iri.jsonld');
-    expect(report.state).toEqual('no-dataset');
+    expect(report.state).toEqual('invalid');
   });
 
   it('rejects a dataset that has no HTTP IRI', async () => {
@@ -733,6 +736,24 @@ describe('Validator', () => {
       ...report.errors.match(null, shacl('resultPath'), foafName),
     ];
     expect(foafNameResults).toHaveLength(0);
+  });
+
+  it('rejects a dcat:Dataset that is a blank node instead of an http(s) IRI', async () => {
+    // The dcat:DatasetShape requires a web IRI as the dataset identifier, just
+    // like the schema.org DatasetShape — a blank-node dataset has no stable,
+    // dereferenceable identifier the register can index.
+    const report = (await validate(
+      'dataset-dcat-blank-node.jsonld',
+    )) as InvalidDataset;
+    expect(report.state).toEqual('invalid');
+    const nodeKindViolations = [
+      ...report.errors.match(
+        null,
+        shacl('sourceConstraintComponent'),
+        shacl('NodeKindConstraintComponent'),
+      ),
+    ];
+    expect(nodeKindViolations).toHaveLength(1);
   });
 });
 

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig(() => ({
         autoUpdate: true,
         lines: 97.03,
         functions: 95.55,
-        branches: 89.47,
+        branches: 89.44,
         statements: 96.53,
       },
     },

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -1188,6 +1188,9 @@ nde-dataset:AccessRightsProperty a sh:PropertyShape ;
 
 dcat:DatasetShape
     a sh:NodeShape ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^https?://" ;
+    sh:message "Gebruik een web-URI die begint met http:// of https://"@nl, "Use a web URI starting with http:// or https://"@en ;
     sh:property [
         sh:minCount 1 ;
         sh:path dc:title ;


### PR DESCRIPTION
## Problem

`nde-dataset:DatasetShape` (targeting `schema:Dataset`) enforces an HTTP(S) IRI via `sh:nodeKind sh:IRI` + `sh:pattern "^https?://"`, but `dcat:DatasetShape` (targeting `dcat:Dataset`) did not. As reported in #2083, a `dcat:Dataset` expressed as a blank node therefore passed validation, while the equivalent `schema:Dataset` was rejected.

A dataset needs a stable, dereferenceable HTTP(S) IRI – it is the identifier the register indexes and uses as the dataset’s graph URL – so a blank node is not acceptable for either vocabulary.

## Changes

- **SHACL**: add `sh:nodeKind sh:IRI` and `sh:pattern "^https?://"` (with a web-URI message) to `dcat:DatasetShape`, mirroring the schema.org `DatasetShape`.
- **Validator**: stop filtering blank-node dataset subjects out before SHACL runs. Previously a blank-node dataset was silently reported as `no-dataset` (HTTP `406`, “no dataset found”); it now reaches SHACL and is reported as `invalid` (HTTP `400`) with a clear web-URI message. Invalid datasets are never fetched or stored, so blank nodes still never enter the index.
- **Tests**: add a blank-node `dcat:Dataset` fixture and regression test; update the existing no-IRI test to expect `invalid`.
- **Docs**: document the HTTP(S) IRI requirement in the data model chapter (separate PR in the docs repo).

Fix #2083
