### PR TITLE
feat(browser): fold the catalog browser into the dataset search page as a filter

### DIFF
--- a/apps/browser/src/lib/components/ActiveFilters.svelte
+++ b/apps/browser/src/lib/components/ActiveFilters.svelte
@@ -18,6 +18,7 @@
       format: SelectedFacetValue[];
       class: SelectedFacetValue[];
       terminologySource: SelectedFacetValue[];
+      catalog: SelectedFacetValue[];
       size: {
         min?: number;
         max?: number;
@@ -64,6 +65,10 @@
     })),
     ...selectedValues.terminologySource.map((facet: SelectedFacetValue) => ({
       type: 'terminologySource' as FacetKey,
+      facet,
+    })),
+    ...selectedValues.catalog.map((facet: SelectedFacetValue) => ({
+      type: 'catalog' as FacetKey,
       facet,
     })),
     ...(getSizeDisplay()

--- a/apps/browser/src/lib/services/datasets.ts
+++ b/apps/browser/src/lib/services/datasets.ts
@@ -219,6 +219,7 @@ export interface SearchRequest {
   format: string[];
   class: string[];
   terminologySource: string[];
+  catalog: string[];
   size: {
     min?: number;
     max?: number;
@@ -474,6 +475,7 @@ function filterClauses(searchFilters: SearchRequest, skipDefaults = false) {
     format,
     class: classFilter,
     terminologySource,
+    catalog,
     size,
     status,
   } = searchFilters;
@@ -512,6 +514,10 @@ function filterClauses(searchFilters: SearchRequest, skipDefaults = false) {
     filterClausesArray.push(
       facetConfigs.terminologySource.filterClause(terminologySource),
     );
+  }
+
+  if (catalog.length > 0) {
+    filterClausesArray.push(facetConfigs.catalog.filterClause(catalog));
   }
 
   // Handle status filter with defaultClause support

--- a/apps/browser/src/lib/services/facets.ts
+++ b/apps/browser/src/lib/services/facets.ts
@@ -347,6 +347,26 @@ export const facetConfigs: Record<string, FacetConfig> = {
       }`;
     },
   },
+  // The data catalog a dataset belongs to (dct:isPartOf). This facet is not
+  // shown in the sidebar (catalogs carry no title, so they would read as bare
+  // IRIs) and is excluded from count fetching in fetchFacets(); it exists only
+  // as an active filter, reached from the “Browse catalog” link on the dataset
+  // detail page. Only IRI-valued catalogs are matched — some dct:isPartOf
+  // values are plain literals, which the detail-page link never produces.
+  catalog: {
+    where: `?dataset dct:isPartOf ?value .
+      FILTER(isURI(?value))`,
+    filterClause: (values) => {
+      if (values.length === 0) {
+        return '';
+      }
+
+      const catalogValues = values.map((c) => `<${c}>`).join(', ');
+
+      return `?dataset dct:isPartOf ?catalog .
+        FILTER(?catalog IN (${catalogValues}))`;
+    },
+  },
 };
 
 export type FacetKey = keyof typeof facetConfigs | 'size';
@@ -387,7 +407,11 @@ export const facetQuery = (facet: string, searchFiltersQuery: string) => `
 export async function fetchFacets(
   searchFilters: SearchRequest,
 ): Promise<Facets> {
-  const facetKeys = Object.keys(facetConfigs) as Array<FacetKey>;
+  // Exclude `catalog`: it is a filter-only facet (no sidebar entry), so its
+  // value counts are never displayed and need not be queried.
+  const facetKeys = (Object.keys(facetConfigs) as Array<FacetKey>).filter(
+    (key) => key !== 'catalog',
+  );
 
   // Fetch all facets in parallel and build the result object in one pass
   const [facetEntries, sizeRange, sizeHistogram] = await Promise.all([

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -822,13 +822,12 @@
                     <span class="sr-only"> ({m.opens_in_new_tab()})</span>
                   </a>
                   <a
-                    href={`https://datasetregister.netwerkdigitaalerfgoed.nl/catalog.php?lang=${getLocale()}&uri=${encodeURIComponent(dataset.isPartOf)}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                    href={localizeHref(
+                      `/datasets?catalog=${encodeURIComponent(dataset.isPartOf)}`,
+                    )}
                     class="inline-flex items-center gap-1 rounded-full border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
                   >
                     {m.detail_browse_catalog()}
-                    <span class="sr-only"> ({m.opens_in_new_tab()})</span>
                   </a>
                 {:else}
                   {dataset.isPartOf}

--- a/apps/browser/src/routes/datasets/+page.svelte
+++ b/apps/browser/src/routes/datasets/+page.svelte
@@ -47,6 +47,7 @@
     format: decodeDiscreteParam('format'),
     class: decodeDiscreteParam('class'),
     terminologySource: decodeDiscreteParam('terminologySource'),
+    catalog: decodeDiscreteParam('catalog'),
     size: decodeRangeParam('size'),
     status: decodeDiscreteParam('status'),
   });
@@ -67,6 +68,7 @@
       format: decodeDiscreteParam('format'),
       class: decodeDiscreteParam('class'),
       terminologySource: decodeDiscreteParam('terminologySource'),
+      catalog: decodeDiscreteParam('catalog'),
       size: decodeRangeParam('size'),
       status: decodeDiscreteParam('status'),
     });
@@ -115,6 +117,7 @@
     format: SelectedFacetValue[];
     class: SelectedFacetValue[];
     terminologySource: SelectedFacetValue[];
+    catalog: SelectedFacetValue[];
     size: { min?: number; max?: number };
   } = $derived({
     publisher: searchRequest.publisher.map((value) => {
@@ -158,6 +161,9 @@
         label: facet?.label || { '': value },
       };
     }),
+    // Catalogs have no facet counts (filter-only) and no titles, so the chip
+    // falls back to the shortened catalog IRI.
+    catalog: searchRequest.catalog.map((value) => ({ value })),
     size: {
       min: searchRequest.size.min,
       max: searchRequest.size.max,
@@ -276,6 +282,12 @@
       );
     } else {
       url.searchParams.delete('terminologySource');
+    }
+
+    if (params.catalog && params.catalog.length > 0) {
+      url.searchParams.set('catalog', params.catalog.join(','));
+    } else {
+      url.searchParams.delete('catalog');
     }
 
     if (params.status && params.status.length > 0) {
@@ -458,6 +470,9 @@
             (s) => s !== value,
           );
           updateURL(searchRequest, { terminologySource: newSources });
+        } else if (type === 'catalog') {
+          const newCatalogs = searchRequest.catalog.filter((c) => c !== value);
+          updateURL(searchRequest, { catalog: newCatalogs });
         } else if (type === 'size') {
           updateURL(searchRequest, {
             size: { min: undefined, max: undefined },
@@ -684,6 +699,7 @@
           format: [],
           class: [],
           terminologySource: [],
+          catalog: [],
           size: { min: undefined, max: undefined },
           status: [],
         });

--- a/apps/browser/src/routes/datasets/rss/+server.ts
+++ b/apps/browser/src/routes/datasets/rss/+server.ts
@@ -31,6 +31,7 @@ export async function GET({ url }: RequestEvent) {
       'terminologySource',
       url.searchParams,
     ),
+    catalog: decodeDiscreteParam('catalog', url.searchParams),
     size: decodeRangeParam('size', url.searchParams),
     status: decodeDiscreteParam('status', url.searchParams),
   };


### PR DESCRIPTION
Folds the data-catalog browser into the dataset search page as a filter, replacing the legacy `catalog.php` page.

## Changes

- Add a `catalog` search filter keyed on `dct:isPartOf`, wired through the `catalog` URL param, `SearchRequest`, `filterDatasets`, and the RSS feed endpoint. Only IRI-valued catalogs are matched – some `dct:isPartOf` values are plain literals, which the detail-page link never produces.
- Surface the active catalog as a removable chip in `ActiveFilters`. The catalog is deliberately **not** added to the sidebar facet panel: catalogs carry no `dct:title`, so a list would show bare IRIs. It is excluded from facet count fetching in `fetchFacets` for the same reason.
- Point the “Browse catalog” link on the dataset detail page at the in-app `/datasets?catalog=…` page (locale-aware, same tab) instead of `https://datasetregister.netwerkdigitaalerfgoed.nl/catalog.php`.

## Verification

Built and ran the production server against the live SPARQL endpoint:

- `/en/datasets?catalog=https://www.openarchieven.nl/id/datacatalog` shows the active-filter chip with a remove button and “Found 79 datasets”, matching a direct SPARQL count.
- The “Browse catalog” link on a dataset detail page resolves to `/en/datasets?catalog=…` and navigates in-app.

Fix #2098
