### PR TITLE
fix(probe): preserve dcat:compressFormat so gzipped downloads are not flagged as format mismatches

### DIFF
--- a/packages/core/src/distribution-probe/probe.ts
+++ b/packages/core/src/distribution-probe/probe.ts
@@ -95,7 +95,7 @@ const DEFAULT_FAILURE_STREAK_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_PROBE_CONCURRENCY = 20;
 const DEFAULT_MAX_PROBES = 100;
 
-interface DistributionCandidate {
+export interface DistributionCandidate {
   distributionNode: NamedNode | BlankNode;
   urlNode: NamedNode;
   path: NamedNode;
@@ -389,7 +389,9 @@ function canonicalProbeUrl(accessUrl: URL): URL {
  * and "collects a large catalogue in roughly linear time" fails if `match()` ever loses its
  * index. Do not replace these `match()` calls with manual iteration over `input`.
  */
-function collectDistributions(input: DatasetCore): DistributionCandidate[] {
+export function collectDistributions(
+  input: DatasetCore,
+): DistributionCandidate[] {
   const candidates: DistributionCandidate[] = [];
   for (const profile of ['dcat', 'schema'] as const) {
     const distributionPath =
@@ -417,6 +419,15 @@ function candidatesFor(
     literalValue(input, distributionNode, dcat('mediaType')) ??
     literalValue(input, distributionNode, dct('format')) ??
     literalValue(input, distributionNode, schema('encodingFormat'));
+  // The compression format the register split off the declared media type on
+  // ingest (e.g. `application/n-quads+gzip` becomes media type
+  // `application/n-quads` plus this gzip compress format). The probe needs it so
+  // the content-type check accepts a server that serves the compressed form.
+  const compressFormat = literalValue(
+    input,
+    distributionNode,
+    dcat('compressFormat'),
+  );
   const conformsTo =
     iriValue(input, distributionNode, dct('conformsTo')) ??
     iriValue(input, distributionNode, schema('usageInfo'));
@@ -433,7 +444,12 @@ function candidatesFor(
         distributionNode,
         urlNode: urlTerm,
         path,
-        distribution: toDistribution(urlTerm.value, mediaType, conformsTo),
+        distribution: toDistribution(
+          urlTerm.value,
+          mediaType,
+          conformsTo,
+          compressFormat,
+        ),
       });
     }
   }
@@ -495,6 +511,7 @@ function toDistribution(
   accessUrl: string,
   mediaType: string | undefined,
   conformsTo: URL | undefined,
+  compressFormat: string | undefined,
 ): Distribution | null {
   let url: URL;
   try {
@@ -507,7 +524,11 @@ function toDistribution(
     (mediaType !== undefined && /sparql/i.test(mediaType)
       ? new URL(SPARQL_PROTOCOL_URL)
       : undefined);
-  return new Distribution(url, mediaType, resolvedConformsTo);
+  const distribution = new Distribution(url, mediaType, resolvedConformsTo);
+  if (compressFormat !== undefined) {
+    distribution.compressFormat = compressFormat;
+  }
+  return distribution;
 }
 
 /**

--- a/packages/core/test/distribution-probe.test.ts
+++ b/packages/core/test/distribution-probe.test.ts
@@ -14,6 +14,7 @@ import {
   isDeterministicFailure,
 } from '../src/constants.js';
 import {
+  collectDistributions,
   DistributionProbeStage,
   readProbeSeverities,
 } from '../src/distribution-probe/probe.js';
@@ -1319,5 +1320,70 @@ describe('isDeterministicFailure', () => {
 
   it('is false when there is no outcome', () => {
     expect(isDeterministicFailure(null)).toBe(false);
+  });
+});
+
+describe('collectDistributions', () => {
+  const iana = (type: string) =>
+    `https://www.iana.org/assignments/media-types/${type}`;
+
+  // The register splits a declared `application/n-quads+gzip` into a base
+  // dcat:mediaType plus a dcat:compressFormat on ingest. The probe must carry
+  // that compress format onto the Distribution so the content-type check can
+  // accept a server that serves the compressed form (e.g. `application/n-quads+gzip`).
+  it('carries dcat:compressFormat onto the built Distribution', () => {
+    const dataset = factory.dataset();
+    const datasetNode = factory.namedNode('https://example.org/ds-gzip');
+    const distributionNode = factory.blankNode();
+    const url = factory.namedNode('https://example.org/data.nq.gz');
+    dataset.add(
+      factory.quad(datasetNode, dcat('distribution'), distributionNode),
+    );
+    dataset.add(factory.quad(distributionNode, dcat('downloadURL'), url));
+    dataset.add(
+      factory.quad(
+        distributionNode,
+        dcat('mediaType'),
+        factory.namedNode(iana('application/n-quads')),
+      ),
+    );
+    dataset.add(
+      factory.quad(
+        distributionNode,
+        dcat('compressFormat'),
+        factory.namedNode(iana('application/gzip')),
+      ),
+    );
+
+    const candidates = collectDistributions(dataset);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].distribution?.mimeType).toBe('application/n-quads');
+    expect(candidates[0].distribution?.compressFormat).toBe(
+      iana('application/gzip'),
+    );
+  });
+
+  it('leaves compressFormat unset for an uncompressed distribution', () => {
+    const dataset = factory.dataset();
+    const datasetNode = factory.namedNode('https://example.org/ds-plain');
+    const distributionNode = factory.blankNode();
+    const url = factory.namedNode('https://example.org/data.nq');
+    dataset.add(
+      factory.quad(datasetNode, dcat('distribution'), distributionNode),
+    );
+    dataset.add(factory.quad(distributionNode, dcat('downloadURL'), url));
+    dataset.add(
+      factory.quad(
+        distributionNode,
+        dcat('mediaType'),
+        factory.namedNode(iana('application/n-quads')),
+      ),
+    );
+
+    const candidates = collectDistributions(dataset);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].distribution?.compressFormat).toBeUndefined();
   });
 });

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 97.05,
+        lines: 97.07,
         functions: 95.6,
-        branches: 89.55,
-        statements: 96.56,
+        branches: 89.61,
+        statements: 96.57,
       },
     },
   },


### PR DESCRIPTION
## Problem

A valid gzipped RDF download is flagged by the register's own distribution health check as *“delivers a different format than specified”* (`ContentTypeMismatch`) and marked unavailable, even though the declared and served Content-Type agree.

Example: [DKOR / Collectie Almere](https://datasetregister.netwerkdigitaalerfgoed.nl/dataset?uri=https://n2t.net/ark:/85849/dataset) declares `application/n-quads+gzip` (matching our own SHACL recommendation) and the server serves `application/n-quads+gzip` – yet the probe reports a mismatch.

## Cause

On ingest the register splits the declared media type, storing the base `dcat:mediaType` (`application/n-quads`) plus a separate `dcat:compressFormat` (`application/gzip`). The distribution probe, however, only read `dcat:mediaType` and dropped the compress format when building the `Distribution`. The content-type check then compared the server's full `application/n-quads+gzip` against the bare base `application/n-quads` and always mismatched.

## Change

This is the registry-side half of the fix: `candidatesFor` now reads `dcat:compressFormat` and `toDistribution` sets it on the built `Distribution`, so the declared compression survives onto the probe.

- `collectDistributions` is exported to allow a focused regression test (compress format carried / left unset).

## Note on sequencing

The compression-aware comparison lives in `@lde/distribution-probe` (separate PR in `ldelements/lde`). Until that release is consumed here, this change is a harmless no-op with the current `@lde/distribution-probe@^0.1.8` (the old check ignores `compressFormat`), so it is safe and forward-compatible to merge now.
