### PR TITLE
feat(browser): say whether validation fetched a dataset or a catalog

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -416,6 +416,26 @@
   "validate_url_placeholder": "https://example.org/dataset",
   "validate_url_submit": "Validate URL",
   "validate_url_source_title": "Fetched description",
+  "validate_url_source_title_dataset": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Fetched dataset description",
+        "countPlural=other": "Fetched {count} dataset descriptions"
+      }
+    }
+  ],
+  "validate_url_source_title_catalog": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Fetched data catalog with 1 dataset description",
+        "countPlural=other": "Fetched data catalog with {count} dataset descriptions"
+      }
+    }
+  ],
   "validate_inline_editor_label": "Dataset description",
   "validate_inline_placeholder": "Paste JSON-LD, Turtle, N-Triples…",
   "validate_inline_content_type": "Content type",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -416,6 +416,26 @@
   "validate_url_placeholder": "https://example.org/dataset",
   "validate_url_submit": "URL valideren",
   "validate_url_source_title": "Opgehaalde beschrijving",
+  "validate_url_source_title_dataset": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Opgehaalde datasetbeschrijving",
+        "countPlural=other": "{count} opgehaalde datasetbeschrijvingen"
+      }
+    }
+  ],
+  "validate_url_source_title_catalog": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Opgehaalde datacatalogus met 1 datasetbeschrijving",
+        "countPlural=other": "Opgehaalde datacatalogus met {count} datasetbeschrijvingen"
+      }
+    }
+  ],
   "validate_inline_editor_label": "Datasetbeschrijving",
   "validate_inline_placeholder": "Plak JSON-LD, Turtle, N-Triples…",
   "validate_inline_content_type": "Inhoudstype",

--- a/apps/browser/src/lib/components/validation/UrlValidationForm.svelte
+++ b/apps/browser/src/lib/components/validation/UrlValidationForm.svelte
@@ -18,6 +18,10 @@
     type ContentType,
   } from './detect-content-type.js';
   import { formatRdf } from './format-rdf.js';
+  import {
+    summarizeDescription,
+    type DescriptionSummary,
+  } from './description-summary.js';
 
   interface Props {
     initialUrl?: string;
@@ -78,8 +82,24 @@
   let fetchedText = $state<string | null>(null);
   let fetchedLanguage = $state<'json' | 'xml' | 'turtle' | 'plain'>('plain');
   let fetchedContentType = $state<ContentType | null>(null);
+  let descriptionSummary = $state<DescriptionSummary | null>(null);
   let fetchController: AbortController | null = null;
   let innerGoToLine = $state<((line: number) => void) | undefined>(undefined);
+
+  // Acknowledge what was actually fetched: a single dataset description, several,
+  // or a whole data catalog. Falls back to the generic title when the source
+  // could not be parsed or held no datasets.
+  const sourceTitle = $derived.by(() => {
+    const summary = descriptionSummary;
+    if (!summary) return m.validate_url_source_title();
+    if (summary.isCatalog) {
+      return m.validate_url_source_title_catalog({
+        count: summary.datasetCount,
+      });
+    }
+    if (summary.datasetCount === 0) return m.validate_url_source_title();
+    return m.validate_url_source_title_dataset({ count: summary.datasetCount });
+  });
 
   // Expose a wrapped goToLine: auto-open the accordion and wait for the
   // grid-template-rows transition (~200ms) so CodeMirror has measurable
@@ -167,6 +187,7 @@
     fetchController = controller;
     fetchedText = null;
     fetchedContentType = null;
+    descriptionSummary = null;
     try {
       const response = await fetch(
         `/proxy/dereference?url=${encodeURIComponent(targetUrl)}`,
@@ -184,6 +205,8 @@
       if (guessed) {
         const formatted = await formatRdf(body, guessed);
         fetchedText = formatted.kind === 'ok' ? formatted.text : body;
+        const summary = await summarizeDescription(body, guessed);
+        if (!controller.signal.aborted) descriptionSummary = summary;
       } else {
         fetchedText = body;
       }
@@ -289,7 +312,7 @@
         aria-expanded={sourceOpen}
         class="sticky top-0 z-10 flex w-full cursor-pointer items-center justify-between gap-2 rounded-t-lg bg-gray-50 px-4 py-3 text-left text-sm font-medium text-gray-900 shadow-sm hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
       >
-        <span>{m.validate_url_source_title()}</span>
+        <span>{sourceTitle}</span>
         <ChevronDownOutline
           class="h-4 w-4 shrink-0 transition-transform duration-200 {sourceOpen
             ? 'rotate-180'

--- a/apps/browser/src/lib/components/validation/description-summary.test.ts
+++ b/apps/browser/src/lib/components/validation/description-summary.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeDescription } from './description-summary.js';
+
+describe('summarizeDescription', () => {
+  it('returns no datasets for empty input', async () => {
+    expect(await summarizeDescription('', 'application/ld+json')).toEqual({
+      datasetCount: 0,
+      isCatalog: false,
+    });
+  });
+
+  it('counts a single JSON-LD dataset description', async () => {
+    const source = JSON.stringify({
+      '@context': 'https://schema.org/',
+      '@type': 'Dataset',
+      '@id': 'https://example.org/dataset',
+    });
+    expect(await summarizeDescription(source, 'application/ld+json')).toEqual({
+      datasetCount: 1,
+      isCatalog: false,
+    });
+  });
+
+  it('detects a data catalog and counts its datasets (JSON-LD)', async () => {
+    const source = JSON.stringify({
+      '@context': { dcat: 'http://www.w3.org/ns/dcat#' },
+      '@type': 'dcat:Catalog',
+      '@id': 'https://example.org/catalog',
+      'dcat:dataset': [
+        { '@type': 'dcat:Dataset', '@id': 'https://example.org/a' },
+        { '@type': 'dcat:Dataset', '@id': 'https://example.org/b' },
+      ],
+    });
+    expect(await summarizeDescription(source, 'application/ld+json')).toEqual({
+      datasetCount: 2,
+      isCatalog: true,
+    });
+  });
+
+  it('counts distinct datasets and detects a catalog (Turtle)', async () => {
+    const source = `
+      @prefix dcat: <http://www.w3.org/ns/dcat#> .
+      <https://example.org/catalog> a dcat:Catalog ;
+        dcat:dataset <https://example.org/a>, <https://example.org/b> .
+      <https://example.org/a> a dcat:Dataset .
+      <https://example.org/b> a dcat:Dataset .
+    `;
+    expect(await summarizeDescription(source, 'text/turtle')).toEqual({
+      datasetCount: 2,
+      isCatalog: true,
+    });
+  });
+
+  it('reports several dataset descriptions without a catalog node', async () => {
+    const source = `
+      @prefix schema: <https://schema.org/> .
+      <https://example.org/a> a schema:Dataset .
+      <https://example.org/b> a schema:Dataset .
+    `;
+    expect(await summarizeDescription(source, 'text/turtle')).toEqual({
+      datasetCount: 2,
+      isCatalog: false,
+    });
+  });
+});

--- a/apps/browser/src/lib/components/validation/description-summary.ts
+++ b/apps/browser/src/lib/components/validation/description-summary.ts
@@ -1,0 +1,70 @@
+import type { ContentType } from './detect-content-type.js';
+import {
+  expandTerm,
+  parseN3Quads,
+  safeParseJson,
+  walkJsonLd,
+} from './rdf-helpers.js';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+const DATASET_TYPES = new Set([
+  'http://www.w3.org/ns/dcat#Dataset',
+  'https://schema.org/Dataset',
+  'http://schema.org/Dataset',
+]);
+
+const CATALOG_TYPES = new Set([
+  'http://www.w3.org/ns/dcat#Catalog',
+  'https://schema.org/DataCatalog',
+  'http://schema.org/DataCatalog',
+]);
+
+export interface DescriptionSummary {
+  /** Number of distinct schema:Dataset / dcat:Dataset resources found. */
+  datasetCount: number;
+  /** Whether a dcat:Catalog / schema:DataCatalog resource is present. */
+  isCatalog: boolean;
+}
+
+/**
+ * Inspect the fetched source so the UI can say whether it retrieved a single
+ * dataset description, several, or a whole data catalog. Best effort — unknown
+ * formats or parse errors return zero datasets and no catalog.
+ */
+export async function summarizeDescription(
+  sourceText: string,
+  contentType: ContentType,
+): Promise<DescriptionSummary> {
+  if (!sourceText.trim()) return { datasetCount: 0, isCatalog: false };
+
+  if (contentType === 'application/ld+json') {
+    const datasets = new Set<string>();
+    let anonymousDatasets = 0;
+    let isCatalog = false;
+    walkJsonLd(safeParseJson(sourceText), (node, context) => {
+      const type = node['@type'];
+      const types = Array.isArray(type) ? type : type ? [type] : [];
+      for (const rawType of types) {
+        if (typeof rawType !== 'string') continue;
+        const iri = expandTerm(rawType, context) ?? rawType;
+        if (CATALOG_TYPES.has(iri)) isCatalog = true;
+        if (DATASET_TYPES.has(iri)) {
+          const id = node['@id'];
+          if (typeof id === 'string') datasets.add(id);
+          else anonymousDatasets += 1;
+        }
+      }
+    });
+    return { datasetCount: datasets.size + anonymousDatasets, isCatalog };
+  }
+
+  const datasets = new Set<string>();
+  let isCatalog = false;
+  for (const quad of await parseN3Quads(sourceText, contentType)) {
+    if (quad.predicate.value !== RDF_TYPE) continue;
+    if (CATALOG_TYPES.has(quad.object.value)) isCatalog = true;
+    if (DATASET_TYPES.has(quad.object.value)) datasets.add(quad.subject.value);
+  }
+  return { datasetCount: datasets.size, isCatalog };
+}


### PR DESCRIPTION
## What

When you validate a URL, the fetched-source panel always said “Fetched description”, even when the URL resolved to a whole data catalog containing many dataset descriptions. This made it unclear whether the validator looked at a single dataset or the entire catalog.

The title is now count-aware:

- a single dataset description → “Fetched dataset description”
- several datasets → “Fetched N dataset descriptions”
- a data catalog → “Fetched data catalog with N dataset descriptions”

## How

- Add a small `summarizeDescription` helper that parses the fetched source (JSON-LD or any N3 format) and reports the number of `schema:Dataset` / `dcat:Dataset` resources and whether a `dcat:Catalog` / `schema:DataCatalog` is present.
- Compute the title in `UrlValidationForm` from that summary, falling back to the generic label when the source cannot be parsed.
- Add English and Dutch plural message variants.
- Unit-test the helper for JSON-LD and Turtle sources.

## Scope

This is the wording part of the issue only. The “Valid” badge clarification on the dataset page and the question of per-dataset validation (`?uri=`) are intentionally left out – see the discussion on the issue.

Refs #2096
