### PR TITLE
feat(browser): clarify that the registration status covers the whole catalog

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -207,6 +207,7 @@
   "detail_valid": "Valid",
   "detail_invalid": "Invalid",
   "detail_gone": "Gone",
+  "detail_registration_status_description": "This status applies to the validation of the registered URL as a whole. When the registration is a data catalog, it covers all its dataset descriptions, not just this one.",
   "detail_distributions_tooltip": "Distributions provide access to the data.",
   "detail_distributions_showing": "Showing {shown} of {total} distributions.",
   "lang_badge_also_in": "Also in {lang}:",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -207,6 +207,7 @@
   "detail_valid": "Geldig",
   "detail_invalid": "Ongeldig",
   "detail_gone": "Verdwenen",
+  "detail_registration_status_description": "Deze status geldt voor de validatie van de geregistreerde URL als geheel. Als de registratie een datacatalogus is, geldt deze voor alle datasetbeschrijvingen, niet alleen voor deze.",
   "detail_distributions_tooltip": "Distributies geven toegang tot de data.",
   "detail_distributions_showing": "{shown} van {total} distributies getoond.",
   "lang_badge_also_in": "Ook in het {lang}:",

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -1736,6 +1736,7 @@
                   <span class="sr-only"> ({m.opens_in_new_tab()})</span>
                 </a>
                 <a
+                  id="tooltip-registration-status"
                   href={localizeHref(
                     `/validate?url=${encodeUrlParam(dataset.subjectOf.$id)}`,
                   )}
@@ -1765,6 +1766,9 @@
                   {/if}
                   <span class="sr-only"> ({m.opens_in_new_tab()})</span>
                 </a>
+                <Tooltip triggeredBy="#tooltip-registration-status"
+                  >{m.detail_registration_status_description()}</Tooltip
+                >
               </div>
             </dd>
           </div>


### PR DESCRIPTION
## What

The valid/invalid/gone badge in a dataset’s Registration section reflects the validation of the *registered URL as a whole*, not of that individual dataset. When the registration is a data catalog, the badge therefore describes every dataset description it contains – which is confusing on a single dataset’s page.

This adds a tooltip on the badge making that explicit. No behavioural change.

## How

- Give the badge an id and attach a `Tooltip` to it.
- Add English and Dutch messages explaining the status applies to the whole registered URL and, for catalogs, to all dataset descriptions.

## Scope

Minimal, tooltip-only clarification – part of #2096. The fetched-source wording fix is in #2105; per-dataset validation (`?uri=`) is intentionally not pursued, see the discussion on the issue.

Refs #2096
