### PR TITLE
fix(browser): disable autocorrect on the dataset search input

### DIFF
--- a/apps/browser/src/routes/datasets/+page.svelte
+++ b/apps/browser/src/routes/datasets/+page.svelte
@@ -445,6 +445,9 @@
     class="w-full px-6 py-4 text-lg border-2 border-gray-300 dark:border-gray-600 rounded-lg mb-8 transition-colors focus:outline-none focus:border-blue-500 dark:focus:border-blue-400 placeholder:text-gray-400 dark:placeholder:text-gray-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
     placeholder={m.search_placeholder()}
     type="search"
+    autocorrect="off"
+    autocapitalize="off"
+    spellcheck="false"
   />
 
   {#if searchResults}


### PR DESCRIPTION
Disables browser autocorrect on the dataset search input.

On macOS/Safari, the search field would rewrite typed terms, capitalize the first letter and flag words with the spell-checker, which interferes with searching for exact terms, identifiers and non-dictionary words.

## Change

Add three attributes to the `<input type="search">` on the datasets page:

- `autocorrect="off"` – stop Safari/macOS from rewriting typed terms
- `autocapitalize="off"` – stop auto-capitalizing the first letter
- `spellcheck="false"` – remove the red squiggle underlines
