### PR TITLE
fix(browser): grey out Query action when every SPARQL endpoint is unavailable

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -170,6 +170,8 @@
   "detail_archived_warning": "This dataset has been archived",
   "detail_archived_message": "This dataset is no longer actively maintained and may be out of date.",
   "detail_query_dataset": "Query this dataset",
+  "detail_query_none_available": "No working endpoint available",
+  "detail_query_none_available_tooltip": "None of this dataset’s SPARQL endpoints currently return data, according to the register’s latest check.",
   "detail_uri": "URI",
   "detail_uri_description": "The unique identifier (URI) for this dataset.",
   "detail_publisher": "Publisher",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -170,6 +170,8 @@
   "detail_archived_warning": "Deze dataset is gearchiveerd",
   "detail_archived_message": "Deze dataset wordt niet langer actief onderhouden en kan verouderd zijn.",
   "detail_query_dataset": "Bevraag deze dataset",
+  "detail_query_none_available": "Geen werkend endpoint beschikbaar",
+  "detail_query_none_available_tooltip": "Geen van de SPARQL-endpoints van deze dataset geeft op dit moment gegevens terug, volgens de meest recente controle van het register.",
   "detail_uri": "URI",
   "detail_uri_description": "De unieke identificatie (URI) van deze dataset.",
   "detail_publisher": "Uitgever",

--- a/apps/browser/src/lib/utils/distribution-ranking.test.ts
+++ b/apps/browser/src/lib/utils/distribution-ranking.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
-  selectPreferredDownload,
+  selectPreferredDistribution,
   sortDistributionsByAvailability,
 } from './distribution-ranking';
 import type { DistributionHealth } from '$lib/services/distribution-health';
@@ -27,7 +27,7 @@ const healthy: DistributionHealth = {
   sourceFingerprint: null,
 };
 
-describe('selectPreferredDownload', () => {
+describe('selectPreferredDistribution', () => {
   it('prefers a reachable distribution over an unavailable one of the same type', () => {
     const unavailable = {
       accessURL: 'https://example.org/empty.ttl',
@@ -41,9 +41,9 @@ describe('selectPreferredDownload', () => {
       [unavailable.accessURL, staleFailure],
       [reachable.accessURL, healthy],
     ]);
-    expect(selectPreferredDownload([unavailable, reachable], health, now)).toBe(
-      reachable,
-    );
+    expect(
+      selectPreferredDistribution([unavailable, reachable], health, now),
+    ).toBe(reachable);
   });
 
   it('prefers a valid distribution over a reachable-but-invalid one, but still offers the invalid bytes as a last resort', () => {
@@ -63,13 +63,13 @@ describe('selectPreferredDownload', () => {
 
     // A valid distribution wins even though both are reachable.
     expect(
-      selectPreferredDownload([invalid, valid], health, now, invalidUrls),
+      selectPreferredDistribution([invalid, valid], health, now, invalidUrls),
     ).toBe(valid);
     // When the invalid one is the only reachable option, its bytes are still
     // offered rather than disabling the download.
-    expect(selectPreferredDownload([invalid], health, now, invalidUrls)).toBe(
-      invalid,
-    );
+    expect(
+      selectPreferredDistribution([invalid], health, now, invalidUrls),
+    ).toBe(invalid);
   });
 
   it('applies type priority among reachable distributions (gzipped N-Triples wins over Turtle, Turtle over JSON-LD)', () => {
@@ -87,10 +87,12 @@ describe('selectPreferredDownload', () => {
     };
     // No health records: all unknown, hence all selectable.
     const health = new Map<string, DistributionHealth>();
-    expect(selectPreferredDownload([jsonLd, turtle], health, now)).toBe(turtle);
-    expect(selectPreferredDownload([jsonLd, turtle, ntGzip], health, now)).toBe(
-      ntGzip,
+    expect(selectPreferredDistribution([jsonLd, turtle], health, now)).toBe(
+      turtle,
     );
+    expect(
+      selectPreferredDistribution([jsonLd, turtle, ntGzip], health, now),
+    ).toBe(ntGzip);
   });
 
   it('returns undefined when every distribution is unavailable', () => {
@@ -106,7 +108,7 @@ describe('selectPreferredDownload', () => {
       [a.accessURL, staleFailure],
       [b.accessURL, staleFailure],
     ]);
-    expect(selectPreferredDownload([a, b], health, now)).toBeUndefined();
+    expect(selectPreferredDistribution([a, b], health, now)).toBeUndefined();
   });
 });
 
@@ -194,7 +196,7 @@ describe('sortDistributionsByAvailability', () => {
   });
 });
 
-describe('selectPreferredDownload matches the topmost dropdown entry', () => {
+describe('selectPreferredDistribution matches the topmost dropdown entry', () => {
   it('points at the compressed N-Triples that also sorts to the top', () => {
     const jsonLd = {
       accessURL: 'https://example.org/data.jsonld',
@@ -211,8 +213,8 @@ describe('selectPreferredDownload matches the topmost dropdown entry', () => {
     const health = new Map<string, DistributionHealth>();
     const candidates = [jsonLd, turtle, ntGzip];
     const top = sortDistributionsByAvailability(candidates, health, now)[0];
-    expect(selectPreferredDownload(candidates, health, now)).toBe(top);
-    expect(selectPreferredDownload(candidates, health, now)).toBe(ntGzip);
+    expect(selectPreferredDistribution(candidates, health, now)).toBe(top);
+    expect(selectPreferredDistribution(candidates, health, now)).toBe(ntGzip);
   });
 
   it('skips an unavailable topmost entry and points at the next working one', () => {
@@ -227,6 +229,8 @@ describe('selectPreferredDownload matches the topmost dropdown entry', () => {
     // The otherwise-preferred compressed download is unavailable, so the button
     // falls through to the first reachable entry rather than a broken link.
     const health = new Map([[ntGzip.accessURL, staleFailure]]);
-    expect(selectPreferredDownload([ntGzip, turtle], health, now)).toBe(turtle);
+    expect(selectPreferredDistribution([ntGzip, turtle], health, now)).toBe(
+      turtle,
+    );
   });
 });

--- a/apps/browser/src/lib/utils/distribution-ranking.ts
+++ b/apps/browser/src/lib/utils/distribution-ranking.ts
@@ -76,15 +76,16 @@ function availabilityOf(
   );
 }
 
-// Select the distribution the default Download action should point at: the first
-// reachable (or not-yet-probed) entry in the same order the dropdown renders, so
-// the primary button always matches the topmost working option and the visitor
-// never has to open the dropdown to find it. A distribution that is reachable but
-// serves invalid RDF (in `invalidUrls`) is only offered as a last resort — a
-// valid one is always preferred — but its bytes are still downloadable when it is
-// the sole option. Returns undefined when every distribution is unavailable,
-// which drives the disabled download state.
-export function selectPreferredDownload<T extends RankableDistribution>(
+// Select the distribution a default split-button action (Download or Query)
+// should point at: the first reachable (or not-yet-probed) entry in the same
+// order the dropdown renders, so the primary button always matches the topmost
+// working option and the visitor never has to open the dropdown to find it. A
+// distribution that is reachable but serves invalid RDF (in `invalidUrls`) is
+// only offered as a last resort — a valid one is always preferred — but its
+// bytes are still downloadable when it is the sole option. Returns undefined
+// when every distribution is unavailable, which drives the disabled state of
+// that action.
+export function selectPreferredDistribution<T extends RankableDistribution>(
   distributions: readonly T[],
   healthByUrl: ReadonlyMap<string, DistributionHealth>,
   now: Date,

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -21,7 +21,7 @@
   } from '$lib/services/distribution-health';
   import {
     compressionSuffix,
-    selectPreferredDownload,
+    selectPreferredDistribution,
     sortDistributionsByAvailability,
   } from '$lib/utils/distribution-ranking';
   import {
@@ -202,8 +202,21 @@
   // so it always works; undefined when every download is unavailable, which
   // disables the primary action.
   const preferredDownload = $derived(
-    selectPreferredDownload(
+    selectPreferredDistribution(
       downloadDistributions,
+      healthByUrl,
+      now,
+      invalidUrls,
+    ),
+  );
+
+  // Likewise for the Query action: point it at the first reachable SPARQL
+  // endpoint; undefined when every endpoint is unavailable, which greys out the
+  // primary action. The dropdown still lists each endpoint URL so an unavailable
+  // endpoint can be inspected or copied.
+  const preferredEndpoint = $derived(
+    selectPreferredDistribution(
+      sparqlDistributions,
       healthByUrl,
       now,
       invalidUrls,
@@ -1364,16 +1377,30 @@
         <!-- Query dataset split button -->
         {#if sparqlDistributions.length > 0}
           <div class="inline-flex rounded-lg shadow-sm" role="group">
-            <a
-              href={yasguiUrl(sparqlDistributions[0].accessURL)}
-              target="_blank"
-              rel="noopener noreferrer"
-              class={splitBtnMainClass}
-            >
-              <SearchOutline class="me-2 h-4 w-4" />
-              {m.detail_query_dataset()}
-              <span class="sr-only"> ({m.opens_in_new_tab()})</span>
-            </a>
+            {#if preferredEndpoint}
+              <a
+                href={yasguiUrl(preferredEndpoint.accessURL)}
+                target="_blank"
+                rel="noopener noreferrer"
+                class={splitBtnMainClass}
+              >
+                <SearchOutline class="me-2 h-4 w-4" />
+                {m.detail_query_dataset()}
+                <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+              </a>
+            {:else}
+              <span
+                id="query-none-available"
+                class={splitBtnMainDisabledClass}
+                aria-disabled="true"
+              >
+                <SearchOutline class="me-2 h-4 w-4" />
+                {m.detail_query_none_available()}
+              </span>
+              <Tooltip triggeredBy="#query-none-available"
+                >{m.detail_query_none_available_tooltip()}</Tooltip
+              >
+            {/if}
             <button
               type="button"
               id="btn-query-dropdown"


### PR DESCRIPTION
## Problem

On the dataset detail page, the **Query this dataset** primary button always linked to the first SPARQL endpoint, even when the register’s probe had marked every endpoint unavailable (e.g. the Kadaster WBK dataset, whose endpoint is currently broken). Visitors clicked through to a dead endpoint, while the **Download** button already greyed out correctly in the same situation.

## Change

- **Grey out the Query action** when no SPARQL endpoint is reachable, mirroring the Download split button: the primary button becomes a disabled, `aria-disabled` element with an explanatory tooltip instead of a link to a broken endpoint.
- **Keep the endpoint visible.** The dropdown still lists every SPARQL endpoint URL — with its status badge, failure reason, and copy button — so an unavailable endpoint can still be inspected or copied.
- **Generalize the ranking helper.** `selectPreferredDownload` → `selectPreferredDistribution`, now used for both the Download and Query actions (it was already generic). The `invalidUrls` last-resort logic is preserved and applied to endpoint selection too, so a reachable-but-invalid endpoint is deprioritized consistently with the dropdown order.
- **i18n.** New `detail_query_none_available` label and `detail_query_none_available_tooltip` in `en` and `nl`.

## Notes

A distribution only classifies as unavailable once the register’s probe has recorded a sustained failure; until then it stays “unknown” and the button remains enabled. That is the probe/health side, unchanged here.
