### PR TITLE
feat: distinguish an errored persistent-URI sampling from never-checked

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -283,11 +283,13 @@
   "nde_compat_persistent_heading_resolves": "Uses a non-persistent domain name",
   "nde_compat_persistent_heading_unresolved": "Some URIs are not reachable",
   "nde_compat_persistent_heading_pending": "Persistent URIs not yet checked",
+  "nde_compat_persistent_heading_sampling_failed": "Persistent URIs could not be checked",
   "nde_compat_state_legend_label": "What the colours mean",
   "nde_compat_persistent_explanation_persistent": "This dataset’s URIs resolve to a landing page.",
   "nde_compat_persistent_explanation_resolves": "The URIs resolve, but on a domain that may change, such as a software vendor’s.",
   "nde_compat_persistent_explanation_unresolved": "Some of this dataset’s sampled URIs do not resolve to a landing page.",
   "nde_compat_persistent_explanation_pending": "This dataset’s URIs have not been checked for persistence yet.",
+  "nde_compat_persistent_explanation_sampling_failed": "We tried to sample this dataset’s URIs, but its source could not be queried this time, so persistence could not be assessed. The check runs again automatically on the next analysis.",
   "nde_compat_persistent_count_unresolved": [
     {
       "declarations": [

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -283,11 +283,13 @@
   "nde_compat_persistent_heading_resolves": "Gebruikt een niet-persistente domeinnaam",
   "nde_compat_persistent_heading_unresolved": "Sommige URI’s zijn niet bereikbaar",
   "nde_compat_persistent_heading_pending": "Persistente URI’s nog niet gecontroleerd",
+  "nde_compat_persistent_heading_sampling_failed": "Persistente URI’s konden niet worden gecontroleerd",
   "nde_compat_state_legend_label": "Wat de kleuren betekenen",
   "nde_compat_persistent_explanation_persistent": "De persistente URI’s van deze dataset leiden naar een landingspagina.",
   "nde_compat_persistent_explanation_resolves": "De URI’s werken nu, maar gebruiken een domein dat kan veranderen, bijvoorbeeld dat van een software-leverancier.",
   "nde_compat_persistent_explanation_unresolved": "Sommige URI’s uit de steekproef leiden niet naar een landingspagina.",
   "nde_compat_persistent_explanation_pending": "De URI’s van deze dataset zijn nog niet op persistentie gecontroleerd.",
+  "nde_compat_persistent_explanation_sampling_failed": "We hebben geprobeerd de URI’s van deze dataset te bemonsteren, maar de bron kon deze keer niet worden bevraagd, waardoor de persistentie niet kon worden beoordeeld. De controle wordt automatisch opnieuw uitgevoerd bij de volgende analyse.",
   "nde_compat_persistent_count_unresolved": [
     {
       "declarations": [

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -82,11 +82,17 @@
           case 'met':
             return m.nde_compat_persistent_heading_persistent();
           case 'warning':
-            // Two orange reasons: pages that resolve but do not reference their
-            // PID, versus a namespace that resolves but is non-durable.
-            return criterion.reason === 'no-self-reference'
-              ? m.nde_compat_persistent_heading_no_self_reference()
-              : m.nde_compat_persistent_heading_resolves();
+            // Three orange reasons: pages that resolve but do not reference their
+            // PID, a sample that errored, versus a namespace that resolves but is
+            // non-durable.
+            switch (criterion.reason) {
+              case 'no-self-reference':
+                return m.nde_compat_persistent_heading_no_self_reference();
+              case 'sampling-failed':
+                return m.nde_compat_persistent_heading_sampling_failed();
+              default:
+                return m.nde_compat_persistent_heading_resolves();
+            }
           case 'failed':
             return m.nde_compat_persistent_heading_unresolved();
           // Neutral: analyzed, but resolution has not been measured yet.
@@ -144,9 +150,14 @@
           case 'met':
             return m.nde_compat_persistent_explanation_persistent();
           case 'warning':
-            return criterion.reason === 'no-self-reference'
-              ? m.nde_compat_persistent_explanation_no_self_reference()
-              : m.nde_compat_persistent_explanation_resolves();
+            switch (criterion.reason) {
+              case 'no-self-reference':
+                return m.nde_compat_persistent_explanation_no_self_reference();
+              case 'sampling-failed':
+                return m.nde_compat_persistent_explanation_sampling_failed();
+              default:
+                return m.nde_compat_persistent_explanation_resolves();
+            }
           case 'failed':
             return m.nde_compat_persistent_explanation_unresolved();
           default:
@@ -245,6 +256,11 @@
           entry('met'),
           entry('warning', 'non-durable'),
           entry('warning', 'no-self-reference'),
+          // Errored sampling is a transient condition, so list it only while the
+          // criterion is actually in it, like the neutral pending tier below.
+          ...(criterion.reason === 'sampling-failed'
+            ? [entry('warning', 'sampling-failed')]
+            : []),
           entry('failed', 'unresolved'),
           ...(criterion.state === 'unmet' ? [entry('unmet')] : []),
         ];

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -502,9 +502,11 @@ async function fetchIiifManifests(datasetUri: string): Promise<IiifManifests> {
 // scoped to that namespace, plus a recognised PID scheme (`dcterms:conformsTo`)
 // and its issuing `dcterms:publisher` (ARK) as positive embellishments, and a
 // `subject-namespace-durable` boolean flag (`false`) when the namespace is on the
-// disallow list. The sampled measurement keys the join, so the right subset is
-// selected even when the dataset has other subsets (e.g. IIIF). Every field is
-// null/false when no such subset has been recorded yet.
+// disallow list, and a `subject-uris-sampling-failed` boolean (`true`) when the
+// sample query failed every attempt. A resolution outcome — the sampled ratio or
+// the sampling-failed marker — keys the join, so the right subset is selected
+// even when the dataset has other subsets (e.g. IIIF) and even when sampling
+// produced no ratio. Every field is null/false when no such subset exists yet.
 async function fetchPersistentUris(
   datasetUri: string,
 ): Promise<PersistentUris> {
@@ -518,23 +520,32 @@ async function fetchPersistentUris(
     // The per-URI failures are fetched separately (fetchPersistentUriFailures)
     // and merged in by fetchDatasetDetail; this query does not read them.
     failures: [],
+    samplingFailed: false,
   };
   const query = `
     PREFIX void: <http://rdfs.org/ns/void#>
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX dqv: <http://www.w3.org/ns/dqv#>
     PREFIX nde: <https://def.nde.nl/metric#>
-    SELECT ?uriSpace ?scheme ?publisher ?sampled ?resolved ?durable WHERE {
+    SELECT ?uriSpace ?scheme ?publisher ?sampled ?resolved ?durable ?samplingFailed WHERE {
       <${datasetUri}> void:subset ?ns .
-      ?ns void:uriSpace ?uriSpace ;
-        dqv:hasQualityMeasurement [
+      ?ns void:uriSpace ?uriSpace .
+      OPTIONAL {
+        ?ns dqv:hasQualityMeasurement [
           dqv:isMeasurementOf nde:subject-uris-sampled ;
           dqv:value ?sampled
-        ] .
+        ]
+      }
       OPTIONAL {
         ?ns dqv:hasQualityMeasurement [
           dqv:isMeasurementOf nde:subject-uris-resolved ;
           dqv:value ?resolved
+        ]
+      }
+      OPTIONAL {
+        ?ns dqv:hasQualityMeasurement [
+          dqv:isMeasurementOf nde:subject-uris-sampling-failed ;
+          dqv:value ?samplingFailed
         ]
       }
       OPTIONAL {
@@ -548,6 +559,9 @@ async function fetchPersistentUris(
         FILTER(STRSTARTS(STR(?scheme), "${PID_SCHEME_BASE_URI}"))
       }
       OPTIONAL { ?ns dct:publisher ?publisher }
+      # The winner subset is the one carrying a resolution outcome — a sampled
+      # ratio or the sampling-failed marker — not just any uriSpace subset.
+      FILTER(BOUND(?sampled) || BOUND(?samplingFailed))
     }
     LIMIT 1
   `;
@@ -564,6 +578,7 @@ async function fetchPersistentUris(
         sampled?: { value: string };
         resolved?: { value: string };
         durable?: { value: string };
+        samplingFailed?: { value: string };
       };
       return {
         uriSpace: binding.uriSpace?.value ?? null,
@@ -581,6 +596,9 @@ async function fetchPersistentUris(
         onDisallowList: binding.durable?.value === 'false',
         // Merged in by fetchDatasetDetail from fetchPersistentUriFailures.
         failures: [],
+        // The DKG emits this `true` only when the sample query failed every
+        // attempt; absence (or a never-sampled namespace) leaves it false.
+        samplingFailed: binding.samplingFailed?.value === 'true',
       };
     }
   } catch (e: unknown) {

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -210,6 +210,32 @@ describe('persistentUrisState', () => {
     ).toEqual({ state: 'unmet' });
   });
 
+  it('is a warning (sampling-failed) when sampling was attempted but failed, with no ratio', () => {
+    // The DKG recorded a subject-uris-sampling-failed marker: the namespace was
+    // selected and sampled, but the endpoint could not be queried. An error to
+    // surface (🟠), not the neutral pending (⚪) of a never-sampled namespace.
+    expect(
+      persistentUrisState({ ...pendingPersistent, samplingFailed: true }),
+    ).toEqual({ state: 'warning', reason: 'sampling-failed' });
+  });
+
+  it('prefers a real resolution ratio over the sampling-failed marker', () => {
+    // The two are mutually exclusive in DKG output, but the ratio must win
+    // defensively: a measured sample is conclusive, the marker is not.
+    expect(
+      persistentUrisState({
+        uriSpace: 'https://n2t.net/ark:/22921/',
+        scheme: 'ark',
+        publisher: null,
+        sampled: 10,
+        resolved: 10,
+        onDisallowList: false,
+        failures: [],
+        samplingFailed: true,
+      }),
+    ).toEqual({ state: 'met' });
+  });
+
   it('treats a missing resolved measurement as zero resolved (failed/unresolved)', () => {
     expect(
       persistentUrisState({

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -49,6 +49,15 @@ export const SUBJECT_URIS_SAMPLED_METRIC =
 export const SUBJECT_URIS_RESOLVED_METRIC =
   'https://def.nde.nl/metric#subject-uris-resolved';
 
+// Boolean DQV metric the Dataset Knowledge Graph records (`true`) when the
+// subject-URI sample query failed on every attempt — the namespace was selected
+// and sampling was attempted, but the endpoint could not serve the sample this
+// run. It lets the register tell an errored sample (🟠) apart from a namespace
+// that was never sampled (⚪): both otherwise lack a `subject-uris-sampled`
+// ratio. Absent when sampling succeeded or was never attempted.
+export const SUBJECT_URIS_SAMPLING_FAILED_METRIC =
+  'https://def.nde.nl/metric#subject-uris-sampling-failed';
+
 // Boolean DQV metric flagging the subject namespace as non-durable: emitted with
 // value `false` when the namespace is on the Dataset Knowledge Graph’s disallow
 // list of known non-durable vendor namespaces. Absent for an unflagged
@@ -131,10 +140,16 @@ export type SchemaApNdeFailureReason = 'violations' | 'declared-but-empty';
 //                       reference their PID.
 // 'non-durable'       — 🟠 the URIs resolve, but on a namespace the DKG flags as
 //                       a non-durable home (its disallow list).
+// 'sampling-failed'   — 🟠 the namespace was selected and sampling was attempted,
+//                       but the sample query failed every attempt this run (the
+//                       DKG recorded a `subject-uris-sampling-failed` marker), so
+//                       the criterion could not be assessed — an error to fix,
+//                       not the neutral “not yet checked” of a never-sampled one.
 export type PersistentFailureReason =
   | 'unresolved'
   | 'no-self-reference'
-  | 'non-durable';
+  | 'non-durable'
+  | 'sampling-failed';
 
 // Why a criterion is in a non-green state. The registration reasons ('gone',
 // 'invalid') carry the dataset’s status; the linked-data reasons say why no
@@ -213,6 +228,13 @@ export interface PersistentUriFailure {
 //                   its PID (🟠), otherwise at least one page did not resolve
 //                   (🔴). Empty until the DKG ships the per-URI data, so the
 //                   split falls back to the hard red state — matching today.
+// 'samplingFailed' — whether the DKG recorded a `subject-uris-sampling-failed`
+//                   marker: the namespace was selected and sampling was attempted
+//                   but failed every attempt this run. Distinguishes an errored
+//                   sample (🟠) from a namespace that was never sampled (⚪, where
+//                   `sampled` is also null). Optional: absent (the common case,
+//                   and all data before the DKG shipped the marker) reads as not
+//                   failed.
 export interface PersistentUris {
   uriSpace: string | null;
   scheme: PidScheme | null;
@@ -221,6 +243,7 @@ export interface PersistentUris {
   resolved: number | null;
   onDisallowList: boolean;
   failures: PersistentUriFailure[];
+  samplingFailed?: boolean;
 }
 
 // SCHEMA-AP-NDE sample-conformance figures from the Knowledge Graph plus whether
@@ -412,17 +435,21 @@ export function iiifState(manifests: IiifManifests): CompatibilityState {
 //
 // A namespace that fully resolves but is on the DKG’s disallow list of known
 // non-durable vendor namespaces is a `warning` (🟠, 'non-durable'): it works
-// today but is not a durable home for the identifiers. With no measurement yet —
-// the resolution step has not run, or the DKG found no self-minted namespace to
-// sample — the criterion is neutral pending (⚪): a grey row signalling “this
-// will still be checked”, unlike terms it keeps its place rather than being
-// omitted.
+// today but is not a durable home for the identifiers. With no ratio, the
+// sampling-failed marker splits the two no-measurement cases: a sample that was
+// attempted and failed this run is a `warning` (🟠, 'sampling-failed') — an error
+// to surface — whereas no marker means the resolution step has not run, or the
+// DKG found no self-minted namespace to sample, so the criterion is neutral
+// pending (⚪): a grey row signalling “this will still be checked”, unlike terms
+// it keeps its place rather than being omitted.
 export function persistentUrisState(persistent: PersistentUris): {
   state: CompatibilityState;
   reason?: PersistentFailureReason;
 } {
   if (persistent.sampled === null || persistent.sampled <= 0) {
-    return { state: 'unmet' };
+    return persistent.samplingFailed
+      ? { state: 'warning', reason: 'sampling-failed' }
+      : { state: 'unmet' };
   }
   const resolved = persistent.resolved ?? 0;
   if (resolved < persistent.sampled) {


### PR DESCRIPTION
Surfaces the consumer side of the Knowledge Graph’s new `subject-uris-sampling-failed` marker (produced by netwerk-digitaal-erfgoed/dataset-knowledge-graph#371, for dataset-knowledge-graph#370).

Until now, every way the persistent-URI check could fail to record a ratio collapsed to the same grey “Persistent URIs not yet checked” row — whether the namespace was never sampled or sampling was attempted and the endpoint could not be queried. The DKG now records a marker for the latter; this reads it and shows it distinctly.

## Changes

- **`fetchPersistentUris`** reads the `subject-uris-sampling-failed` boolean and keys the subset join on *either* a sampled ratio *or* the marker (`FILTER(BOUND(?sampled) || BOUND(?samplingFailed))`), so the winner subset is still selected when sampling produced no ratio. Verified against live DKG data that the success case still resolves the right subset and ratio.
- **`persistentUrisState`** maps the new `samplingFailed` signal to a `warning` / `sampling-failed` state: an errored sample now shows an amber “could not be checked” row instead of the grey “not yet checked” of a namespace that was never sampled. A real ratio still wins defensively when both are somehow present.
- **UI**: new heading + explanation (en + nl) and a tooltip legend entry shown only while the criterion is in that state.

## Notes

- The new `PersistentUris.samplingFailed` field is optional — absent reads as not-failed, covering all data from before the DKG shipped the marker.
- The marker is dormant in production until dataset-knowledge-graph#371 deploys, so this is a no-op for existing data until then.
