### PR TITLE
fix(api,crawler): declare search-indexer's externalized runtime deps

### DIFF
--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -12,7 +12,16 @@ export default [
             '{projectRoot}/eslint.config.{js,cjs,mjs}',
             '{projectRoot}/vite.config.{js,ts,mjs,mts}',
           ],
-          ignoredDependencies: ['@dataset-register/core'],
+          // Workspace libs and the npm deps esbuild externalizes out of the
+          // bundled @dataset-register/search-indexer: required at runtime but not
+          // imported by this app's own source, so the check must not strip them.
+          ignoredDependencies: [
+            '@dataset-register/core',
+            '@lde/search',
+            '@lde/search-typesense',
+            '@lde/text-normalization',
+            'typesense',
+          ],
         },
       ],
     },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,11 +10,15 @@
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",
     "@lde/fastify-rdf": "^0.4.5",
+    "@lde/search": "^0.1.1",
+    "@lde/search-typesense": "^0.1.0",
+    "@lde/text-normalization": "^0.1.0",
     "@rdfjs/types": "2.0.1",
     "env-schema": "^7.0.0",
     "fastify": "^5.8.5",
     "psl": "1.15.0",
-    "rdf-ext": "2.6.0"
+    "rdf-ext": "2.6.0",
+    "typesense": "^3.0.6"
   },
   "nx": {
     "projectType": "application",

--- a/apps/crawler/eslint.config.mjs
+++ b/apps/crawler/eslint.config.mjs
@@ -12,7 +12,16 @@ export default [
             '{projectRoot}/eslint.config.{js,cjs,mjs}',
             '{projectRoot}/vite.config.{js,ts,mjs,mts}',
           ],
-          ignoredDependencies: ['@dataset-register/core'],
+          // Workspace libs and the npm deps esbuild externalizes out of the
+          // bundled @dataset-register/search-indexer: required at runtime but not
+          // imported by this app's own source, so the check must not strip them.
+          ignoredDependencies: [
+            '@dataset-register/core',
+            '@lde/search',
+            '@lde/search-typesense',
+            '@lde/text-normalization',
+            'typesense',
+          ],
         },
       ],
     },

--- a/apps/crawler/package.json
+++ b/apps/crawler/package.json
@@ -5,9 +5,13 @@
   "type": "module",
   "dependencies": {
     "@dataset-register/core": "*",
+    "@lde/search": "^0.1.1",
+    "@lde/search-typesense": "^0.1.0",
+    "@lde/text-normalization": "^0.1.0",
     "env-schema": "^7.0.0",
     "node-schedule": "^2.1.1",
-    "pino": "^10.2.0"
+    "pino": "^10.2.0",
+    "typesense": "^3.0.6"
   },
   "devDependencies": {
     "@types/node-schedule": "^2.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,11 +57,15 @@
         "@fastify/swagger": "^9.7.0",
         "@fastify/swagger-ui": "^6.0.0",
         "@lde/fastify-rdf": "^0.4.5",
+        "@lde/search": "^0.1.1",
+        "@lde/search-typesense": "^0.1.0",
+        "@lde/text-normalization": "^0.1.0",
         "@rdfjs/types": "2.0.1",
         "env-schema": "^7.0.0",
         "fastify": "^5.8.5",
         "psl": "1.15.0",
-        "rdf-ext": "2.6.0"
+        "rdf-ext": "2.6.0",
+        "typesense": "^3.0.6"
       }
     },
     "apps/browser": {
@@ -121,9 +125,13 @@
       "version": "0.0.1",
       "dependencies": {
         "@dataset-register/core": "*",
+        "@lde/search": "^0.1.1",
+        "@lde/search-typesense": "^0.1.0",
+        "@lde/text-normalization": "^0.1.0",
         "env-schema": "^7.0.0",
         "node-schedule": "^2.1.1",
-        "pino": "^10.2.0"
+        "pino": "^10.2.0",
+        "typesense": "^3.0.6"
       },
       "devDependencies": {
         "@types/node-schedule": "^2.1.8",


### PR DESCRIPTION
The #2119 api/crawler images crash-looped on deploy:
`Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@lde/search-typesense'`.

**Root cause:** the apps esbuild-bundle `@dataset-register/search-indexer` but externalize its npm deps. When the lib is inlined, its package boundary disappears from the dependency graph, so `prune-lockfile` (which builds the Docker image's `node_modules` from the app's `package.json`) drops `@lde/search`, `@lde/search-typesense`, `@lde/text-normalization` and `typesense`. They live in the monorepo root `node_modules` — so local dev, `nx build` and tests all pass — but not in the pruned production image, so it only fails at container startup.

**Fix:** declare those four as direct deps of api + crawler (as the api already does for core's externalized `rdf-ext`/`psl`), and add them to each app's `@nx/dependency-checks` `ignoredDependencies` so the lint autofix stops stripping them back out (which is how they went missing in the first place).

**No user impact meanwhile:** the new pods failed readiness, so the old api/crawler/browser kept serving (registration API stayed up). The browser is still pinned via infra #247, so the cutover is unaffected — this just lets the indexer-capable images deploy.
