### PR TITLE
fix(browser): keep facet checkboxes square, not circular

### DIFF
--- a/apps/browser/src/lib/components/FacetItem.svelte
+++ b/apps/browser/src/lib/components/FacetItem.svelte
@@ -40,7 +40,7 @@
 >
   <input
     checked={isChecked}
-    class="w-4 h-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-600 cursor-pointer"
+    class="w-4 h-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded-xs focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-600 cursor-pointer"
     onchange={handleChange}
     type="checkbox"
     value={value.value}


### PR DESCRIPTION
## Problem

On the dataset listing page, the facet checkboxes render as perfect circles, so they look like radio buttons.

## Cause

flowbite-svelte v2’s `default` theme (imported in `app.css`) sets a global `--radius: 8px`. `FacetItem.svelte` hand-rolls a raw `<input type="checkbox">` with the bare `rounded` utility, which resolves to `var(--radius)`. On the 16px (`w-4 h-4`) checkbox an 8px radius is exactly half the side length, producing a full circle.

This started after the flowbite-svelte v2 upgrade raised `--radius` from the previous ~4px default to 8px. It is not a library bug: flowbite-svelte’s own `Checkbox` component caps the input radius (`rounded-xs`) rather than inheriting the global token, precisely to avoid this.

## Fix

Use `rounded-xs` on the checkbox input, matching what the library’s own component does. The checkbox now renders as a rounded square (4px radius), clearly distinct from a radio button.

Verified with Playwright on `/datasets`: computed `border-radius` goes from `8px` (circle) to `4px` (rounded square).
