### PR TITLE
build: stop bundling the api and crawler node apps

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -36,7 +36,11 @@ jobs:
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: npx nx-cloud record -- echo Hello World
-      - run: npx nx affected -t lint test typecheck check build docker:build
+      # docker:smoke runs each freshly built image and asserts it reaches startup,
+      # so a runtime-only failure (e.g. a runtime dep missing from the pruned image,
+      # surfacing as ERR_MODULE_NOT_FOUND at boot) is caught here rather than in
+      # production — docker:build alone only builds, it never runs the image (#2128).
+      - run: npx nx affected -t lint test typecheck check build docker:build docker:smoke
 
       # Only set up Playwright when a project that owns an e2e target is actually
       # affected, so config-only PRs do not pay for (or flake on) a browser download

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -39,7 +39,7 @@ jobs:
       # docker:smoke runs each freshly built image and asserts it reaches startup,
       # so a runtime-only failure (e.g. a runtime dep missing from the pruned image,
       # surfacing as ERR_MODULE_NOT_FOUND at boot) is caught here rather than in
-      # production — docker:build alone only builds, it never runs the image (#2128).
+      # production – docker:build alone only builds, it never runs the image (#2128).
       - run: npx nx affected -t lint test typecheck check build docker:build docker:smoke
 
       # Only set up Playwright when a project that owns an e2e target is actually

--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -12,15 +12,15 @@ export default [
             '{projectRoot}/eslint.config.{js,cjs,mjs}',
             '{projectRoot}/vite.config.{js,ts,mjs,mts}',
           ],
-          // Workspace libs and the npm deps esbuild externalizes out of the
-          // bundled @dataset-register/search-indexer: required at runtime but not
-          // imported by this app's own source, so the check must not strip them.
+          // The workspace libs are declared with a floating `*` version that the
+          // dependency-checks rule cannot verify, so they are ignored here. Their
+          // own npm deps (typesense, @lde/search*, etc.) no longer need declaring
+          // on the app: with `bundle: false` the libs are copied (not inlined), so
+          // prune-lockfile reads each copied lib's package.json and pulls the
+          // transitives into the image automatically.
           ignoredDependencies: [
             '@dataset-register/core',
-            '@lde/search',
-            '@lde/search-typesense',
-            '@lde/text-normalization',
-            'typesense',
+            '@dataset-register/search-indexer',
           ],
         },
       ],

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,20 +5,17 @@
   "type": "module",
   "dependencies": {
     "@dataset-register/core": "*",
+    "@dataset-register/search-indexer": "*",
     "@fastify/bearer-auth": "^10.1.2",
     "@fastify/cors": "^11.0.0",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",
     "@lde/fastify-rdf": "^0.4.5",
-    "@lde/search": "^0.1.1",
-    "@lde/search-typesense": "^0.1.0",
-    "@lde/text-normalization": "^0.1.0",
     "@rdfjs/types": "2.0.1",
     "env-schema": "^7.0.0",
     "fastify": "^5.8.5",
     "psl": "1.15.0",
-    "rdf-ext": "2.6.0",
-    "typesense": "^3.0.6"
+    "rdf-ext": "2.6.0"
   },
   "nx": {
     "projectType": "application",
@@ -32,7 +29,7 @@
         "options": {
           "platform": "node",
           "outputPath": "apps/api/dist",
-          "bundle": true,
+          "bundle": false,
           "main": "apps/api/src/main.ts",
           "declarationRootDir": "apps/api/src",
           "tsConfig": "apps/api/tsconfig.app.json",
@@ -90,7 +87,17 @@
         }
       },
       "copy-workspace-modules": {},
-      "prune-lockfile": {}
+      "prune-lockfile": {},
+      "docker:smoke": {
+        "executor": "nx:run-commands",
+        "dependsOn": [
+          "docker:build"
+        ],
+        "cache": false,
+        "options": {
+          "command": "./apps/docker-smoke.sh apps-api 'Server listening'"
+        }
+      }
     }
   }
 }

--- a/apps/crawler/eslint.config.mjs
+++ b/apps/crawler/eslint.config.mjs
@@ -12,15 +12,15 @@ export default [
             '{projectRoot}/eslint.config.{js,cjs,mjs}',
             '{projectRoot}/vite.config.{js,ts,mjs,mts}',
           ],
-          // Workspace libs and the npm deps esbuild externalizes out of the
-          // bundled @dataset-register/search-indexer: required at runtime but not
-          // imported by this app's own source, so the check must not strip them.
+          // The workspace libs are declared with a floating `*` version that the
+          // dependency-checks rule cannot verify, so they are ignored here. Their
+          // own npm deps (typesense, @lde/search*, etc.) no longer need declaring
+          // on the app: with `bundle: false` the libs are copied (not inlined), so
+          // prune-lockfile reads each copied lib's package.json and pulls the
+          // transitives into the image automatically.
           ignoredDependencies: [
             '@dataset-register/core',
-            '@lde/search',
-            '@lde/search-typesense',
-            '@lde/text-normalization',
-            'typesense',
+            '@dataset-register/search-indexer',
           ],
         },
       ],

--- a/apps/crawler/package.json
+++ b/apps/crawler/package.json
@@ -5,13 +5,10 @@
   "type": "module",
   "dependencies": {
     "@dataset-register/core": "*",
-    "@lde/search": "^0.1.1",
-    "@lde/search-typesense": "^0.1.0",
-    "@lde/text-normalization": "^0.1.0",
+    "@dataset-register/search-indexer": "*",
     "env-schema": "^7.0.0",
     "node-schedule": "^2.1.1",
-    "pino": "^10.2.0",
-    "typesense": "^3.0.6"
+    "pino": "^10.2.0"
   },
   "devDependencies": {
     "@types/node-schedule": "^2.1.8",
@@ -29,7 +26,7 @@
         "options": {
           "platform": "node",
           "outputPath": "apps/crawler/dist",
-          "bundle": true,
+          "bundle": false,
           "format": [
             "esm"
           ],
@@ -79,7 +76,17 @@
         }
       },
       "copy-workspace-modules": {},
-      "prune-lockfile": {}
+      "prune-lockfile": {},
+      "docker:smoke": {
+        "executor": "nx:run-commands",
+        "dependsOn": [
+          "docker:build"
+        ],
+        "cache": false,
+        "options": {
+          "command": "./apps/docker-smoke.sh apps-crawler 'Crawler scheduled'"
+        }
+      }
     }
   }
 }

--- a/apps/docker-smoke.sh
+++ b/apps/docker-smoke.sh
@@ -2,8 +2,8 @@
 #
 # Smoke-test a built application image by actually running it and asserting it
 # reaches startup. `nx … docker:build` only *builds* the image, so a runtime-only
-# failure — e.g. a runtime dependency missing from the pruned image, surfacing as
-# `ERR_MODULE_NOT_FOUND` at boot — passes the build yet crashes in production (the
+# failure – e.g. a runtime dependency missing from the pruned image, surfacing as
+# `ERR_MODULE_NOT_FOUND` at boot – passes the build yet crashes in production (the
 # #2128 incident). This is the gate that catches that class before it ships.
 #
 # Usage: docker-smoke.sh <image-tag> <startup-log-regex>
@@ -31,10 +31,9 @@ docker run -d --name "$container" \
 
 for _ in $(seq 1 30); do
   logs="$(docker logs "$container" 2>&1)"
-  if echo "$logs" | grep -qE "$startup_pattern"; then
-    echo "PASS: $image reached startup (matched /$startup_pattern/)"
-    exit 0
-  fi
+  # Check failure conditions before success: a container that logged the startup
+  # line and then crashed must be reported FAIL, not PASS, so liveness is gated
+  # ahead of the startup match.
   if echo "$logs" | grep -qiE "ERR_MODULE_NOT_FOUND|Cannot find (package|module)"; then
     echo "FAIL: $image hit a module-resolution error at startup:"
     echo "$logs"
@@ -44,6 +43,10 @@ for _ in $(seq 1 30); do
     echo "FAIL: $image exited before reaching startup:"
     echo "$logs"
     exit 1
+  fi
+  if echo "$logs" | grep -qE "$startup_pattern"; then
+    echo "PASS: $image reached startup (matched /$startup_pattern/)"
+    exit 0
   fi
   sleep 1
 done

--- a/apps/docker-smoke.sh
+++ b/apps/docker-smoke.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Smoke-test a built application image by actually running it and asserting it
+# reaches startup. `nx … docker:build` only *builds* the image, so a runtime-only
+# failure — e.g. a runtime dependency missing from the pruned image, surfacing as
+# `ERR_MODULE_NOT_FOUND` at boot — passes the build yet crashes in production (the
+# #2128 incident). This is the gate that catches that class before it ships.
+#
+# Usage: docker-smoke.sh <image-tag> <startup-log-regex>
+set -euo pipefail
+
+image="$1"
+startup_pattern="$2"
+container="smoke-${image}-$$"
+
+cleanup() { docker rm -f "$container" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# A superset of both apps' required env. Values are dummy: we test module
+# resolution and startup, not behaviour. SPARQL stores connect lazily, so an
+# unreachable URL does not block boot. CRAWLER_SCHEDULE keeps the crawler
+# scheduling (idle) instead of crawling the dummy endpoint on startup. Setting
+# TYPESENSE_* exercises the search-indexer import chain that #2128 broke.
+docker run -d --name "$container" \
+  -e SPARQL_URL=http://example.invalid/sparql \
+  -e SPARQL_ACCESS_TOKEN=dummy \
+  -e CRAWLER_SCHEDULE="0 0 * * *" \
+  -e TYPESENSE_HOST=localhost \
+  -e TYPESENSE_API_KEY=dummy \
+  "$image" >/dev/null
+
+for _ in $(seq 1 30); do
+  logs="$(docker logs "$container" 2>&1)"
+  if echo "$logs" | grep -qE "$startup_pattern"; then
+    echo "PASS: $image reached startup (matched /$startup_pattern/)"
+    exit 0
+  fi
+  if echo "$logs" | grep -qiE "ERR_MODULE_NOT_FOUND|Cannot find (package|module)"; then
+    echo "FAIL: $image hit a module-resolution error at startup:"
+    echo "$logs"
+    exit 1
+  fi
+  if [ "$(docker inspect -f '{{.State.Status}}' "$container")" = "exited" ]; then
+    echo "FAIL: $image exited before reaching startup:"
+    echo "$logs"
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "FAIL: $image did not reach startup within 30s:"
+docker logs "$container" 2>&1
+exit 1

--- a/nx.json
+++ b/nx.json
@@ -69,6 +69,11 @@
     }
   },
   "targetDefaults": {
+    "build": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
+    },
     "@nx/esbuild:esbuild": {
       "cache": true,
       "dependsOn": ["^build"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,20 +52,17 @@
       "version": "0.0.1",
       "dependencies": {
         "@dataset-register/core": "*",
+        "@dataset-register/search-indexer": "*",
         "@fastify/bearer-auth": "^10.1.2",
         "@fastify/cors": "^11.0.0",
         "@fastify/swagger": "^9.7.0",
         "@fastify/swagger-ui": "^6.0.0",
         "@lde/fastify-rdf": "^0.4.5",
-        "@lde/search": "^0.1.1",
-        "@lde/search-typesense": "^0.1.0",
-        "@lde/text-normalization": "^0.1.0",
         "@rdfjs/types": "2.0.1",
         "env-schema": "^7.0.0",
         "fastify": "^5.8.5",
         "psl": "1.15.0",
-        "rdf-ext": "2.6.0",
-        "typesense": "^3.0.6"
+        "rdf-ext": "2.6.0"
       }
     },
     "apps/browser": {
@@ -125,13 +122,10 @@
       "version": "0.0.1",
       "dependencies": {
         "@dataset-register/core": "*",
-        "@lde/search": "^0.1.1",
-        "@lde/search-typesense": "^0.1.0",
-        "@lde/text-normalization": "^0.1.0",
+        "@dataset-register/search-indexer": "*",
         "env-schema": "^7.0.0",
         "node-schedule": "^2.1.1",
-        "pino": "^10.2.0",
-        "typesense": "^3.0.6"
+        "pino": "^10.2.0"
       },
       "devDependencies": {
         "@types/node-schedule": "^2.1.8",
@@ -32532,7 +32526,6 @@
         "@rdfjs/types": "2.0.1",
         "jsonld-streaming-parser": "^5.0.1",
         "n3": "^2.0.3",
-        "node-fetch": "^3.3.1",
         "rdf-dereference": "^5.0.0",
         "rdf-ext": "^2.6.0",
         "shacl-engine": "^1.0.2",
@@ -32543,6 +32536,7 @@
         "@types/rdf-ext": "^2.0.1",
         "microdata-rdf-streaming-parser": "^3.0.0",
         "nock": "^14.0.15",
+        "node-fetch": "^3.3.1",
         "rdfa-streaming-parser": "^3.0.1",
         "testcontainers": "^12.0.1"
       }
@@ -32551,18 +32545,16 @@
       "name": "@dataset-register/search-indexer",
       "version": "0.0.1",
       "dependencies": {
-        "@comunica/types": "^5.2.3",
         "@dataset-register/core": "*",
         "@lde/search": "^0.1.1",
         "@lde/search-typesense": "^0.1.0",
-        "@lde/text-normalization": "^0.1.0",
+        "@rdfjs/types": "2.0.1",
         "env-schema": "^7.0.0",
         "pino": "^10.2.0",
         "tslib": "^2.3.0",
         "typesense": "^3.0.6"
       },
       "devDependencies": {
-        "@rdfjs/types": "^2.0.1",
         "@types/jsonld": "^1.5.15",
         "jsonld": "^9.0.0",
         "n3": "^2.0.3",

--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -11,6 +11,9 @@ export default [
           ignoredFiles: [
             '{projectRoot}/eslint.config.{js,cjs,mjs}',
             '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+            // Test-only helpers (e.g. testcontainers) live here and are not part
+            // of the built library, so they must not require runtime dependencies.
+            '{projectRoot}/test/**',
           ],
         },
       ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,16 +63,8 @@
     "targets": {
       "build": {
         "executor": "nx:run-commands",
-        "cache": true,
-        "inputs": [
-          "production",
-          "^production"
-        ],
         "outputs": [
           "{projectRoot}/dist"
-        ],
-        "dependsOn": [
-          "^build"
         ],
         "options": {
           "command": "tsc -b packages/core/tsconfig.lib.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,29 +5,29 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./constants": {
-      "types": "./src/constants.ts",
-      "import": "./src/constants.ts",
-      "default": "./src/constants.ts"
+      "development": "./src/constants.ts",
+      "types": "./dist/constants.d.ts",
+      "default": "./dist/constants.js"
     },
     "./search": {
-      "types": "./src/search/index.ts",
-      "import": "./src/search/index.ts",
-      "default": "./src/search/index.ts"
+      "development": "./src/search/index.ts",
+      "types": "./dist/search/index.d.ts",
+      "default": "./dist/search/index.js"
     },
     "./test-utils": {
-      "types": "./src/test-utils.ts",
-      "import": "./src/test-utils.ts",
-      "default": "./src/test-utils.ts"
+      "development": "./src/test-utils.ts",
+      "types": "./dist/test-utils.d.ts",
+      "default": "./dist/test-utils.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "dependencies": {
     "@comunica/query-sparql": "^5.2.3",
     "@comunica/types": "^5.2.3",
@@ -44,7 +44,6 @@
     "@rdfjs/types": "2.0.1",
     "jsonld-streaming-parser": "^5.0.1",
     "n3": "^2.0.3",
-    "node-fetch": "^3.3.1",
     "rdf-dereference": "^5.0.0",
     "rdf-ext": "^2.6.0",
     "shacl-engine": "^1.0.2",
@@ -55,10 +54,30 @@
     "@types/rdf-ext": "^2.0.1",
     "microdata-rdf-streaming-parser": "^3.0.0",
     "nock": "^14.0.15",
+    "node-fetch": "^3.3.1",
     "rdfa-streaming-parser": "^3.0.1",
     "testcontainers": "^12.0.1"
   },
   "nx": {
-    "projectType": "library"
+    "projectType": "library",
+    "targets": {
+      "build": {
+        "executor": "nx:run-commands",
+        "cache": true,
+        "inputs": [
+          "production",
+          "^production"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
+        "dependsOn": [
+          "^build"
+        ],
+        "options": {
+          "command": "tsc -b packages/core/tsconfig.lib.json"
+        }
+      }
+    }
   }
 }

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -5,6 +5,7 @@
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": false,
+    "rewriteRelativeImportExtensions": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]
   },

--- a/packages/search-indexer/eslint.config.mjs
+++ b/packages/search-indexer/eslint.config.mjs
@@ -11,6 +11,9 @@ export default [
           ignoredFiles: [
             '{projectRoot}/eslint.config.{js,cjs,mjs}',
             '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+            // Test-only helpers (e.g. testcontainers) live here and are not part
+            // of the built library, so they must not require runtime dependencies.
+            '{projectRoot}/test/**',
           ],
         },
       ],

--- a/packages/search-indexer/package.json
+++ b/packages/search-indexer/package.json
@@ -5,27 +5,25 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
+      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "./src/index.ts",
-  "types": "./src/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "dependencies": {
-    "@comunica/types": "^5.2.3",
     "@dataset-register/core": "*",
     "@lde/search": "^0.1.1",
     "@lde/search-typesense": "^0.1.0",
-    "@lde/text-normalization": "^0.1.0",
+    "@rdfjs/types": "2.0.1",
     "env-schema": "^7.0.0",
     "pino": "^10.2.0",
     "tslib": "^2.3.0",
     "typesense": "^3.0.6"
   },
   "devDependencies": {
-    "@rdfjs/types": "^2.0.1",
     "@types/jsonld": "^1.5.15",
     "jsonld": "^9.0.0",
     "n3": "^2.0.3",
@@ -33,6 +31,25 @@
     "testcontainers": "^12.0.1"
   },
   "nx": {
-    "projectType": "library"
+    "projectType": "library",
+    "targets": {
+      "build": {
+        "executor": "nx:run-commands",
+        "cache": true,
+        "inputs": [
+          "production",
+          "^production"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
+        "dependsOn": [
+          "^build"
+        ],
+        "options": {
+          "command": "tsc -b packages/search-indexer/tsconfig.lib.json"
+        }
+      }
+    }
   }
 }

--- a/packages/search-indexer/package.json
+++ b/packages/search-indexer/package.json
@@ -35,16 +35,8 @@
     "targets": {
       "build": {
         "executor": "nx:run-commands",
-        "cache": true,
-        "inputs": [
-          "production",
-          "^production"
-        ],
         "outputs": [
           "{projectRoot}/dist"
-        ],
-        "dependsOn": [
-          "^build"
         ],
         "options": {
           "command": "tsc -b packages/search-indexer/tsconfig.lib.json"

--- a/packages/search-indexer/tsconfig.lib.json
+++ b/packages/search-indexer/tsconfig.lib.json
@@ -5,6 +5,7 @@
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": false,
+    "rewriteRelativeImportExtensions": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]
   },


### PR DESCRIPTION
## Why

The `api` and `crawler` node apps build with esbuild `bundle: true`. For a node target that **inlines** the workspace libs (`@dataset-register/core`, `@dataset-register/search-indexer`) but **externalizes** their npm deps. Because the inlined lib’s package boundary disappears, `@nx/js:prune-lockfile` never sees those externalized transitives, the Docker `npm ci` omits them, and the container crashes at startup with `ERR_MODULE_NOT_FOUND` (the earlier `@lde/search-typesense` incident).

The previous fix re-declared the missing transitives (`@lde/search`, `@lde/search-typesense`, `@lde/text-normalization`, `typesense`) on each app and ignored them in `@nx/dependency-checks`. That works but is fragile: every future workspace-lib dependency change needs the same manual re-declaration or it crashes in prod again.

## What

Switch the node apps off bundling and let Nx’s standard node-deploy mechanism do the work:

- **`bundle: false`** on the `api` and `crawler` esbuild targets. The workspace libs are now **copied** (not inlined), so `prune-lockfile` reads each copied lib’s `package.json` and pulls its runtime transitives into the image automatically. The four hand-declared deps and their `dependency-checks` ignores are gone; each app now declares `@dataset-register/search-indexer` (which it imports directly).
- **Make `@dataset-register/core` and `@dataset-register/search-indexer` buildable.** They were source-only (their `exports` pointed at `.ts`), which only works while a bundler transpiles them inline. They now have a `tsc` build target (`rewriteRelativeImportExtensions` handles the mixed `.ts`/`.js` import style) and **dual export conditions**: `development` resolves to `src` for dev/test (via the existing `customConditions: ["development"]`), `default` resolves to the built `dist` for Node. Node never passes the `development` condition, so production loads the compiled JS.
- **Add a `build` target default** (`dependsOn: ["^build"]`, cache, production inputs) in `nx.json`. With the libs now resolving their `default` export to `dist`, every consumer must build them first. The `api`/`crawler` esbuild builds already got `^build` from the executor default, but the browser build (a Vite `nx:run-script` target, excluded from the Nx Vite plugin) had none – without this it would fail with `ERR_MODULE_NOT_FOUND` for `core/dist` whenever core was not already built (e.g. a future browser-only PR on a fresh runner). This is the canonical Nx default.
- **Correct latent lib manifests** surfaced now that `dependency-checks` runs on the buildable libs: move test-only `node-fetch` and production-type `@rdfjs/types` to their correct sections, drop genuinely unused `@comunica/types` and `@lde/text-normalization` from `search-indexer`, and exclude `test/` helpers from the check.
- **Add a `docker:smoke` target** that runs each freshly built image and asserts it reaches startup, wired into CI after `docker:build`. `docker:build` only *builds* the image; it never *runs* it, which is exactly how the runtime-only `ERR_MODULE_NOT_FOUND` reached prod. The script checks for a module-resolution error or an exited container before accepting the startup line, so a crashed image can’t false-pass.

## Validation

Built and ran the production Docker images for both apps locally, before and after the change:

- The pruned `apps/*/dist/package.json` + `package-lock.json` carry `@lde/search`, `@lde/search-typesense`, `@lde/text-normalization` and `typesense` transitively (via the copied libs), with none hand-declared on the apps.
- Both images start cleanly with no module-resolution errors – `api` reaches “Server listening”, `crawler` reaches “Crawler scheduled” – including with `TYPESENSE_*` set, which exercises the `search-indexer` import chain that previously broke.
- `nx build browser` succeeds in isolation with the lib `dist` wiped (it now builds core first), confirming the `^build` wiring.
- `lint`, `typecheck`, `build` and the full `test` suites pass for all affected projects; the new `docker:smoke` target passes for both apps.

## Notes

- The libs are private workspace packages, so the `exports`/`main` changes are internal only – no public API change.
- Dev (`nx dev`) now also runs `bundle: false`; it loads the libs’ built `dist` (rebuilt via `^build`) rather than inlined source. Tests and typecheck still resolve to `src` through the `development` condition.
