### PR TITLE
fix(browser): remove scroll animation when opening a dataset

### DIFF
--- a/apps/browser/src/app.css
+++ b/apps/browser/src/app.css
@@ -6,14 +6,13 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* Animate in-page anchor jumps (e.g. the compatibility section linking down to
-   the Linked Data Summary or Terminology Sources) so the transition is clearer.
-   Gated on prefers-reduced-motion to respect users who opt out of motion. */
-@media (prefers-reduced-motion: no-preference) {
-  html {
-    scroll-behavior: smooth;
-  }
-}
+/* Note: `scroll-behavior: smooth` is deliberately NOT set on `html`. A global
+   smooth scroll also animates the scroll-to-top that SvelteKit performs on every
+   navigation (and the scroll-position restore on back navigation), which reads
+   as a jarring scroll animation when opening a dataset. In-page anchor jumps
+   that want smoothing request `behavior: 'smooth'` per call instead (gated on
+   prefers-reduced-motion), e.g. the compatibility section links in
+   NdeCompatibility.svelte. */
 
 @source "../../../node_modules/flowbite-svelte/dist";
 @source "../../../node_modules/flowbite-svelte-icons/dist";

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -23,6 +23,8 @@
     type RegistrationFailureReason,
     type TermLinks,
   } from '$lib/services/nde-compatibility';
+  import { replaceState } from '$app/navigation';
+  import { page } from '$app/state';
 
   let {
     isAnalyzed,
@@ -423,6 +425,34 @@
         return null;
     }
   }
+
+  // Smoothly scroll in-page anchor links (the `#…` evidence links above) to
+  // their target section. Smoothing is applied per click here rather than via a
+  // global `html { scroll-behavior: smooth }`, which would also animate the
+  // scroll-to-top on every navigation. Honours prefers-reduced-motion. Real
+  // (non-anchor) hrefs, e.g. the registration link to the validation page, fall
+  // through to default navigation.
+  function scrollToSection(event: MouseEvent, href: string | null) {
+    if (!href?.startsWith('#')) {
+      return;
+    }
+    const target = document.querySelector(href);
+    if (!target) {
+      return;
+    }
+    event.preventDefault();
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+    target.scrollIntoView({
+      behavior: prefersReducedMotion ? 'auto' : 'smooth',
+      block: 'start',
+    });
+    // Reflect the section in the URL (so it stays copy-pasteable) without a
+    // router navigation. Use SvelteKit’s replaceState, not history.replaceState,
+    // which conflicts with the router.
+    replaceState(href, page.state);
+  }
 </script>
 
 <!-- Mini status indicator for the per-criterion state legend, mirroring each
@@ -578,6 +608,7 @@
                 {#if sectionHref && !detailText}
                   <a
                     href={sectionHref}
+                    onclick={(event) => scrollToSection(event, sectionHref)}
                     class="text-blue-600 hover:underline dark:text-blue-400"
                   >
                     {m.nde_compat_registration_view_details()}
@@ -641,6 +672,7 @@
                     {#if sectionHref}
                       <a
                         href={sectionHref}
+                        onclick={(event) => scrollToSection(event, sectionHref)}
                         class="text-blue-600 hover:underline dark:text-blue-400"
                       >
                         {detailText}


### PR DESCRIPTION
## Problem

Opening a dataset from the listing page played a visible scroll animation: the page smoothly scrolled to the top before (or as) the detail page appeared, which felt janky.

## Cause

`app.css` set `html { scroll-behavior: smooth }` globally. That smoothing applies to every programmatic scroll, including the scroll-to-top SvelteKit performs on each navigation — and the scroll-position restore on back navigation. The rule was only ever intended to smooth the two in-page anchor jumps in the compatibility section.

## Fix

- Remove the global `html { scroll-behavior: smooth }`. Navigation scroll-to-top is now instant, and the existing back-navigation scroll-position restore lands instantly instead of animating.
- Preserve the smooth in-page anchor jumps (`#linked-data-summary`, `#terminology-sources`) in `NdeCompatibility.svelte` by requesting `behavior: 'smooth'` per click, honouring `prefers-reduced-motion`. The URL hash is still updated (so the link stays copy-pasteable) via SvelteKit’s `replaceState` rather than `history.replaceState`, which conflicts with the router.

Scroll-position preservation when navigating back to the search results is unchanged (already handled by the result-cache restore in `datasets/+page.svelte`) and keeps working.

## Verification (Playwright)

- Computed `scroll-behavior` on the listing page is now `auto` (was `smooth`).
- Scroll the list to y≈1500, open a dataset → detail page lands at y=0 with no animation.
- Navigate back → list scroll position restored to y≈1500.
- Click a compatibility anchor link → smooth scroll to the section, hash updated, no SvelteKit router warning.
