### PR TITLE
feat(browser): make persistent URIs green for RDF, advise on missing HTML landing pages

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -287,9 +287,9 @@
   "nde_compat_persistent_heading_pending": "Persistent URIs not yet checked",
   "nde_compat_persistent_heading_sampling_failed": "Persistent URIs could not be checked",
   "nde_compat_state_legend_label": "What the colours mean",
-  "nde_compat_persistent_explanation_persistent": "This dataset’s URIs resolve to a landing page.",
+  "nde_compat_persistent_explanation_persistent": "This dataset’s URIs resolve to a web page or to linked data.",
   "nde_compat_persistent_explanation_resolves": "The URIs resolve, but on a domain that may change, such as a software vendor’s.",
-  "nde_compat_persistent_explanation_unresolved": "Some of this dataset’s sampled URIs do not resolve to a landing page.",
+  "nde_compat_persistent_explanation_unresolved": "Some of this dataset’s sampled URIs do not resolve to a web page or to linked data.",
   "nde_compat_persistent_explanation_pending": "This dataset’s URIs have not been checked for persistence yet.",
   "nde_compat_persistent_explanation_sampling_failed": "We tried to sample this dataset’s URIs, but its source could not be queried this time, so persistence could not be assessed. The check runs again automatically on the next analysis.",
   "nde_compat_persistent_count_unresolved": [
@@ -310,28 +310,12 @@
   "nde_compat_persistent_issued_by": "Issued by {publisher}.",
   "nde_compat_persistent_uses_scheme": "Uses {scheme} identifiers.",
   "nde_compat_persistent_scheme_issued_by": "{scheme}, issued by {publisher}.",
-  "nde_compat_persistent_heading_no_self_reference": "Landing pages do not reference their persistent URI",
-  "nde_compat_persistent_explanation_no_self_reference": "The sampled pages resolve to a landing page, but do not mention their persistent URI, so it cannot be found on the page itself.",
-  "nde_compat_persistent_count_no_self_reference": [
-    {
-      "declarations": [
-        "input count",
-        "input display",
-        "input unreferenced",
-        "local countPlural = count: plural"
-      ],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "{unreferenced} of {display} sampled pages does not reference its persistent URI.",
-        "countPlural=other": "{unreferenced} of {display} sampled pages do not reference their persistent URI."
-      }
-    }
-  ],
+  "nde_compat_persistent_advisory_no_html_landing_pages": "The URIs resolve to linked data but not to a human-readable web page. Consider also serving an HTML landing page.",
   "nde_compat_persistent_reason_no_self_reference": "no self-reference",
   "nde_compat_persistent_reason_http_error": "HTTP error",
   "nde_compat_persistent_reason_timeout": "timeout",
   "nde_compat_persistent_reason_network_error": "network error",
-  "nde_compat_persistent_reason_wrong_content_type": "wrong content type",
+  "nde_compat_persistent_reason_wrong_content_type": "not a web page or linked data",
   "nde_compat_linked_data_heading_conforms": "Provides linked data conforming to the NDE Application Profile",
   "nde_compat_linked_data_heading_not_conforms": "Provides linked data",
   "nde_compat_linked_data_heading_pending": "Linked data not yet assessed",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -287,9 +287,9 @@
   "nde_compat_persistent_heading_pending": "Persistente URI’s nog niet gecontroleerd",
   "nde_compat_persistent_heading_sampling_failed": "Persistente URI’s konden niet worden gecontroleerd",
   "nde_compat_state_legend_label": "Wat de kleuren betekenen",
-  "nde_compat_persistent_explanation_persistent": "De persistente URI’s van deze dataset leiden naar een landingspagina.",
+  "nde_compat_persistent_explanation_persistent": "De persistente URI’s van deze dataset leiden naar een webpagina of naar linked data.",
   "nde_compat_persistent_explanation_resolves": "De URI’s werken nu, maar gebruiken een domein dat kan veranderen, bijvoorbeeld dat van een software-leverancier.",
-  "nde_compat_persistent_explanation_unresolved": "Sommige URI’s uit de steekproef leiden niet naar een landingspagina.",
+  "nde_compat_persistent_explanation_unresolved": "Sommige URI’s uit de steekproef leiden niet naar een webpagina of naar linked data.",
   "nde_compat_persistent_explanation_pending": "De URI’s van deze dataset zijn nog niet op persistentie gecontroleerd.",
   "nde_compat_persistent_explanation_sampling_failed": "We hebben geprobeerd de URI’s van deze dataset te bemonsteren, maar de bron kon deze keer niet worden bevraagd, waardoor de persistentie niet kon worden beoordeeld. De controle wordt automatisch opnieuw uitgevoerd bij de volgende analyse.",
   "nde_compat_persistent_count_unresolved": [
@@ -310,28 +310,12 @@
   "nde_compat_persistent_issued_by": "Uitgegeven door {publisher}.",
   "nde_compat_persistent_uses_scheme": "Gebruikt {scheme}-identifiers.",
   "nde_compat_persistent_scheme_issued_by": "{scheme}, uitgegeven door {publisher}.",
-  "nde_compat_persistent_heading_no_self_reference": "Landingspagina’s verwijzen niet naar hun persistente URI",
-  "nde_compat_persistent_explanation_no_self_reference": "De pagina’s uit de steekproef leiden naar een landingspagina, maar vermelden hun persistente URI niet, waardoor die niet vanaf de pagina zelf te vinden is.",
-  "nde_compat_persistent_count_no_self_reference": [
-    {
-      "declarations": [
-        "input count",
-        "input display",
-        "input unreferenced",
-        "local countPlural = count: plural"
-      ],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "{unreferenced} van {display} pagina’s uit de steekproef verwijst niet naar zijn persistente URI.",
-        "countPlural=other": "{unreferenced} van {display} pagina’s uit de steekproef verwijzen niet naar hun persistente URI."
-      }
-    }
-  ],
+  "nde_compat_persistent_advisory_no_html_landing_pages": "De URI’s leiden naar linked data, maar niet naar een leesbare webpagina. Overweeg om ook een HTML-landingspagina aan te bieden.",
   "nde_compat_persistent_reason_no_self_reference": "geen zelfverwijzing",
   "nde_compat_persistent_reason_http_error": "HTTP-fout",
   "nde_compat_persistent_reason_timeout": "time-out",
   "nde_compat_persistent_reason_network_error": "netwerkfout",
-  "nde_compat_persistent_reason_wrong_content_type": "onjuist content-type",
+  "nde_compat_persistent_reason_wrong_content_type": "geen webpagina of linked data",
   "nde_compat_linked_data_heading_conforms": "Biedt linked data volgens het NDE-applicatieprofiel",
   "nde_compat_linked_data_heading_not_conforms": "Biedt linked data",
   "nde_compat_linked_data_heading_pending": "Linked data nog niet beoordeeld",

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --fail-on-warnings",
+    "check": "paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --fail-on-warnings",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "dev": "vite dev",
     "format": "prettier --write .",

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -305,9 +305,8 @@
               display: sampled.toLocaleString(getLocale()),
             });
           }
-          case 'warning':
-            // The non-durable and sampling-failed warnings carry no count line.
-            return null;
+          // The non-durable and sampling-failed warnings carry no count line, so
+          // they fall through to the `default` below.
           case 'met': {
             // Surface the recognised PID scheme (ARK/Handle) as a bonus, and
             // name the issuing organisation when known (ARK only). The scheme
@@ -668,7 +667,7 @@
                    resolve (so the criterion is met), but to RDF only — no HTML
                    landing page was served. Surfaced as a gentle nudge, distinct
                    from the warning/error tiers, alongside any PID-scheme bonus. -->
-              {#if criterion.advisory === 'no-html-landing-pages'}
+              {#if criterion.key === 'persistent' && criterion.advisory === 'no-html-landing-pages'}
                 <p
                   class="mt-1 flex items-start gap-1 text-sm text-gray-500 dark:text-gray-400"
                 >

--- a/apps/browser/src/lib/components/NdeCompatibility.svelte
+++ b/apps/browser/src/lib/components/NdeCompatibility.svelte
@@ -84,12 +84,9 @@
           case 'met':
             return m.nde_compat_persistent_heading_persistent();
           case 'warning':
-            // Three orange reasons: pages that resolve but do not reference their
-            // PID, a sample that errored, versus a namespace that resolves but is
-            // non-durable.
+            // Two orange reasons: a sample that errored, versus a namespace that
+            // resolves but is non-durable.
             switch (criterion.reason) {
-              case 'no-self-reference':
-                return m.nde_compat_persistent_heading_no_self_reference();
               case 'sampling-failed':
                 return m.nde_compat_persistent_heading_sampling_failed();
               default:
@@ -153,8 +150,6 @@
             return m.nde_compat_persistent_explanation_persistent();
           case 'warning':
             switch (criterion.reason) {
-              case 'no-self-reference':
-                return m.nde_compat_persistent_explanation_no_self_reference();
               case 'sampling-failed':
                 return m.nde_compat_persistent_explanation_sampling_failed();
               default:
@@ -257,7 +252,6 @@
         return [
           entry('met'),
           entry('warning', 'non-durable'),
-          entry('warning', 'no-self-reference'),
           // Errored sampling is a transient condition, so list it only while the
           // criterion is actually in it, like the neutral pending tier below.
           ...(criterion.reason === 'sampling-failed'
@@ -311,21 +305,9 @@
               display: sampled.toLocaleString(getLocale()),
             });
           }
-          case 'warning': {
-            // The non-durable warning carries no count line; the no-self-reference
-            // warning reports how many sampled pages resolve but do not reference
-            // their PID, mirroring the failing-URI list below.
-            if (criterion.reason !== 'no-self-reference') {
-              return null;
-            }
-            const sampled = persistentUris.sampled ?? 0;
-            const unreferenced = persistentUris.failures.length;
-            return m.nde_compat_persistent_count_no_self_reference({
-              count: unreferenced,
-              unreferenced: unreferenced.toLocaleString(getLocale()),
-              display: sampled.toLocaleString(getLocale()),
-            });
-          }
+          case 'warning':
+            // The non-durable and sampling-failed warnings carry no count line.
+            return null;
           case 'met': {
             // Surface the recognised PID scheme (ARK/Handle) as a bonus, and
             // name the issuing organisation when known (ARK only). The scheme
@@ -616,16 +598,15 @@
                 {/if}
               </p>
               {#if detailText}
-                <!-- For the persistent criterion’s failing states (the red “did
-                     not resolve” and orange “does not reference its PID” rows),
-                     the count sentence doubles as the summary of a fold-out that
+                <!-- For the persistent criterion’s red “did not resolve” row, the
+                     count sentence doubles as the summary of a fold-out that
                      reveals exactly which sampled URIs failed, each with its
                      reason. This keeps the row compact until a provider wants the
-                     detail. Gated on the failure reasons so the
+                     detail. Gated on the failure reason so the
                      independently-fetched failures only surface alongside the
                      matching figures, never under a green/neutral row. The reason
                      is text, not colour, for accessibility. -->
-                {#if criterion.key === 'persistent' && (criterion.reason === 'unresolved' || criterion.reason === 'no-self-reference') && persistentUris.failures.length > 0}
+                {#if criterion.key === 'persistent' && criterion.reason === 'unresolved' && persistentUris.failures.length > 0}
                   <details class="group mt-1 text-sm">
                     <summary
                       class="flex cursor-pointer list-none items-center gap-1 font-medium text-gray-700 [&::-webkit-details-marker]:hidden dark:text-gray-300"
@@ -682,6 +663,23 @@
                     {/if}
                   </p>
                 {/if}
+              {/if}
+              <!-- A non-blocking advisory on the green persistent row: the URIs
+                   resolve (so the criterion is met), but to RDF only — no HTML
+                   landing page was served. Surfaced as a gentle nudge, distinct
+                   from the warning/error tiers, alongside any PID-scheme bonus. -->
+              {#if criterion.advisory === 'no-html-landing-pages'}
+                <p
+                  class="mt-1 flex items-start gap-1 text-sm text-gray-500 dark:text-gray-400"
+                >
+                  <InfoCircleSolid
+                    class="mt-0.5 h-3.5 w-3.5 flex-shrink-0"
+                    aria-hidden="true"
+                  />
+                  <span
+                    >{m.nde_compat_persistent_advisory_no_html_landing_pages()}</span
+                  >
+                </p>
               {/if}
             </div>
           </li>

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -516,6 +516,7 @@ async function fetchPersistentUris(
     publisher: null,
     sampled: null,
     resolved: null,
+    htmlLandingPages: null,
     onDisallowList: false,
     // The per-URI failures are fetched separately (fetchPersistentUriFailures)
     // and merged in by fetchDatasetDetail; this query does not read them.
@@ -527,7 +528,7 @@ async function fetchPersistentUris(
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX dqv: <http://www.w3.org/ns/dqv#>
     PREFIX nde: <https://def.nde.nl/metric#>
-    SELECT ?uriSpace ?scheme ?publisher ?sampled ?resolved ?durable ?samplingFailed WHERE {
+    SELECT ?uriSpace ?scheme ?publisher ?sampled ?resolved ?htmlLandingPages ?durable ?samplingFailed WHERE {
       <${datasetUri}> void:subset ?ns .
       ?ns void:uriSpace ?uriSpace .
       OPTIONAL {
@@ -540,6 +541,12 @@ async function fetchPersistentUris(
         ?ns dqv:hasQualityMeasurement [
           dqv:isMeasurementOf nde:subject-uris-resolved ;
           dqv:value ?resolved
+        ]
+      }
+      OPTIONAL {
+        ?ns dqv:hasQualityMeasurement [
+          dqv:isMeasurementOf nde:subject-uris-html-landing-pages ;
+          dqv:value ?htmlLandingPages
         ]
       }
       OPTIONAL {
@@ -577,6 +584,7 @@ async function fetchPersistentUris(
         publisher?: { value: string };
         sampled?: { value: string };
         resolved?: { value: string };
+        htmlLandingPages?: { value: string };
         durable?: { value: string };
         samplingFailed?: { value: string };
       };
@@ -589,6 +597,12 @@ async function fetchPersistentUris(
           : null,
         resolved: binding.resolved?.value
           ? parseInt(binding.resolved.value, 10)
+          : null,
+        // Subset of `resolved` that served an HTML landing page; null when the
+        // DKG has not emitted the measurement (old data), which suppresses the
+        // no-html-landing-pages advisory rather than firing it on absence.
+        htmlLandingPages: binding.htmlLandingPages?.value
+          ? parseInt(binding.htmlLandingPages.value, 10)
           : null,
         // The DKG emits the durability flag as `false` only for a namespace on
         // its disallow list; absence means unflagged. Dormant until the DKG ships

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -19,6 +19,7 @@ import {
   SUBJECT_RESOLUTION_FAILURE_BASE_URI,
   type IiifManifests,
   type LinkedData,
+  normalizePersistentUris,
   type PersistentUriFailure,
   type PersistentUriFailureReason,
   type PersistentUris,
@@ -1266,12 +1267,15 @@ export async function fetchDatasetDetail(
   }
 
   // Merge the separately-fetched per-URI failures into the persistent-URI
-  // figures, so the criterion can split a soft “resolves but no PID reference”
-  // from a hard “did not resolve” and list the failing URIs.
-  const persistentUrisWithFailures: PersistentUris = {
+  // figures, then normalize legacy `no-self-reference` failures into the resolved
+  // count (see normalizePersistentUris): under the current rules a page that
+  // resolves to HTML without referencing its own URI is no longer a failure, so
+  // the state, the count line and the failing-URI list all stay consistent until
+  // the next DKG re-crawl.
+  const persistentUrisWithFailures: PersistentUris = normalizePersistentUris({
     ...persistentUris,
     failures: persistentUriFailures,
-  };
+  });
 
   // Merge classPartition into summary
   const summaryWithClassPartition = summary

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -30,6 +30,7 @@ const pendingPersistent: PersistentUris = {
   publisher: null,
   sampled: null,
   resolved: null,
+  htmlLandingPages: null,
   onDisallowList: false,
   failures: [],
 };
@@ -60,7 +61,7 @@ describe('iiifState', () => {
 });
 
 describe('persistentUrisState', () => {
-  it('is met when all sampled URIs resolve, for a recognised PID scheme', () => {
+  it('is met when all sampled URIs resolve to HTML landing pages, for a recognised PID scheme', () => {
     expect(
       persistentUrisState({
         uriSpace: 'https://n2t.net/ark:/22921/',
@@ -68,6 +69,7 @@ describe('persistentUrisState', () => {
         publisher: 'Gemeentemuseum Het Hannemahuis',
         sampled: 10,
         resolved: 10,
+        htmlLandingPages: 10,
         onDisallowList: false,
         failures: [],
       }),
@@ -82,6 +84,41 @@ describe('persistentUrisState', () => {
         publisher: null,
         sampled: 10,
         resolved: 10,
+        htmlLandingPages: 10,
+        onDisallowList: false,
+        failures: [],
+      }),
+    ).toEqual({ state: 'met' });
+  });
+
+  it('is met with a no-html-landing-pages advisory when the URIs resolve to RDF only', () => {
+    // Every sampled URI dereferences (to RDF, not an HTML page): green, but a
+    // soft advisory nudges the provider to also offer a landing page.
+    expect(
+      persistentUrisState({
+        uriSpace: 'http://data.beeldengeluid.nl/id/program/',
+        scheme: null,
+        publisher: null,
+        sampled: 10,
+        resolved: 10,
+        htmlLandingPages: 0,
+        onDisallowList: false,
+        failures: [],
+      }),
+    ).toEqual({ state: 'met', advisory: 'no-html-landing-pages' });
+  });
+
+  it('does not advise when the landing-page count is unknown (old data)', () => {
+    // No html-landing-pages measurement yet: stay green without the advisory
+    // rather than firing it on a missing count.
+    expect(
+      persistentUrisState({
+        uriSpace: 'http://data.beeldengeluid.nl/id/program/',
+        scheme: null,
+        publisher: null,
+        sampled: 10,
+        resolved: 10,
+        htmlLandingPages: null,
         onDisallowList: false,
         failures: [],
       }),
@@ -96,6 +133,7 @@ describe('persistentUrisState', () => {
         publisher: null,
         sampled: 10,
         resolved: 10,
+        htmlLandingPages: 10,
         onDisallowList: true,
         failures: [],
       }),
@@ -110,6 +148,7 @@ describe('persistentUrisState', () => {
         publisher: 'Stichting Erfgoedpark Batavialand',
         sampled: 10,
         resolved: 0,
+        htmlLandingPages: 0,
         onDisallowList: false,
         failures: [
           { uri: 'https://n2t.net/ark:/53016/1', reason: 'http-error' },
@@ -123,49 +162,16 @@ describe('persistentUrisState', () => {
         publisher: 'Hunebedcentrum',
         sampled: 10,
         resolved: 2,
-        onDisallowList: false,
-        failures: [{ uri: 'https://n2t.net/ark:/32154/1', reason: 'timeout' }],
-      }),
-    ).toEqual({ state: 'failed', reason: 'unresolved' });
-  });
-
-  it('is a warning (no-self-reference) when every failure is a page that resolves but does not reference its PID', () => {
-    expect(
-      persistentUrisState({
-        uriSpace: 'https://example.org/id/',
-        scheme: null,
-        publisher: null,
-        sampled: 10,
-        resolved: 8,
+        htmlLandingPages: 2,
         onDisallowList: false,
         failures: [
-          { uri: 'https://example.org/id/1', reason: 'no-self-reference' },
-          { uri: 'https://example.org/id/2', reason: 'no-self-reference' },
-        ],
-      }),
-    ).toEqual({ state: 'warning', reason: 'no-self-reference' });
-  });
-
-  it('is failed/unresolved when failures mix no-self-reference with a hard failure', () => {
-    expect(
-      persistentUrisState({
-        uriSpace: 'https://example.org/id/',
-        scheme: null,
-        publisher: null,
-        sampled: 10,
-        resolved: 8,
-        onDisallowList: false,
-        failures: [
-          { uri: 'https://example.org/id/1', reason: 'no-self-reference' },
-          { uri: 'https://example.org/id/2', reason: 'network-error' },
+          { uri: 'https://n2t.net/ark:/32154/1', reason: 'wrong-content-type' },
         ],
       }),
     ).toEqual({ state: 'failed', reason: 'unresolved' });
   });
 
-  it('falls back to failed/unresolved when resolution fell short but no per-URI reasons are available yet', () => {
-    // Old DKG data: resolved < sampled with no failure list, so the soft
-    // no-self-reference state cannot be inferred — stays the hard red state.
+  it('is failed/unresolved whenever resolution fell short, regardless of per-URI reasons', () => {
     expect(
       persistentUrisState({
         uriSpace: 'https://example.org/id/',
@@ -173,6 +179,7 @@ describe('persistentUrisState', () => {
         publisher: null,
         sampled: 10,
         resolved: 2,
+        htmlLandingPages: 0,
         onDisallowList: false,
         failures: [],
       }),
@@ -187,6 +194,7 @@ describe('persistentUrisState', () => {
         publisher: null,
         sampled: 10,
         resolved: 3,
+        htmlLandingPages: 0,
         onDisallowList: true,
         failures: [
           { uri: 'https://vendor.example/cms/1', reason: 'http-error' },
@@ -204,6 +212,7 @@ describe('persistentUrisState', () => {
         publisher: null,
         sampled: 0,
         resolved: 0,
+        htmlLandingPages: null,
         onDisallowList: false,
         failures: [],
       }),
@@ -229,6 +238,7 @@ describe('persistentUrisState', () => {
         publisher: null,
         sampled: 10,
         resolved: 10,
+        htmlLandingPages: 10,
         onDisallowList: false,
         failures: [],
         samplingFailed: true,
@@ -244,6 +254,7 @@ describe('persistentUrisState', () => {
         publisher: null,
         sampled: 10,
         resolved: null,
+        htmlLandingPages: null,
         onDisallowList: false,
         failures: [],
       }),
@@ -538,6 +549,7 @@ describe('compatibilityCriteria', () => {
         publisher: 'Gemeentemuseum Het Hannemahuis',
         sampled: 10,
         resolved: 10,
+        htmlLandingPages: 10,
         onDisallowList: false,
         failures: [],
       },
@@ -549,7 +561,7 @@ describe('compatibilityCriteria', () => {
     expect(persistent.state).toBe('met');
   });
 
-  it('carries the persistent no-self-reference warning reason and sample count', () => {
+  it('carries the persistent no-html-landing-pages advisory and sample count on a green row', () => {
     const [, persistent] = compatibilityCriteria({
       isAnalyzed: true,
       registration: null,
@@ -558,20 +570,18 @@ describe('compatibilityCriteria', () => {
         scheme: null,
         publisher: null,
         sampled: 10,
-        resolved: 8,
+        resolved: 10,
+        htmlLandingPages: 0,
         onDisallowList: false,
-        failures: [
-          { uri: 'https://example.org/id/1', reason: 'no-self-reference' },
-          { uri: 'https://example.org/id/2', reason: 'no-self-reference' },
-        ],
+        failures: [],
       },
       linkedData: noLinkedData,
       terms: null,
       iiif: { declared: 0, sampled: null, validated: null },
     });
     expect(persistent.key).toBe('persistent');
-    expect(persistent.state).toBe('warning');
-    expect(persistent.reason).toBe('no-self-reference');
+    expect(persistent.state).toBe('met');
+    expect(persistent.advisory).toBe('no-html-landing-pages');
     expect(persistent.count).toBe(10);
   });
 
@@ -714,6 +724,7 @@ describe('compatibilityCriteria', () => {
           publisher: 'Gemeentemuseum Het Hannemahuis',
           sampled: 10,
           resolved: 10,
+          htmlLandingPages: 10,
           onDisallowList: false,
           failures: [],
         },

--- a/apps/browser/src/lib/services/nde-compatibility.test.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.test.ts
@@ -3,6 +3,7 @@ import {
   compatibilityCriteria,
   iiifState,
   linkedDataState,
+  normalizePersistentUris,
   persistentUrisState,
   registrationState,
   schemaApNdeState,
@@ -259,6 +260,70 @@ describe('persistentUrisState', () => {
         failures: [],
       }),
     ).toEqual({ state: 'failed', reason: 'unresolved' });
+  });
+});
+
+describe('normalizePersistentUris', () => {
+  it('folds legacy no-self-reference failures into the resolved count', () => {
+    // Legacy DKG data: two pages resolved to HTML but did not reference their own
+    // URI, so they were excluded from `resolved` and recorded as failures. Under
+    // the current rules they count as resolved, so the namespace fully resolves.
+    const normalized = normalizePersistentUris({
+      uriSpace: 'https://example.org/id/',
+      scheme: null,
+      publisher: null,
+      sampled: 10,
+      resolved: 8,
+      htmlLandingPages: null,
+      onDisallowList: false,
+      failures: [
+        { uri: 'https://example.org/id/1', reason: 'no-self-reference' },
+        { uri: 'https://example.org/id/2', reason: 'no-self-reference' },
+      ],
+    });
+    expect(normalized.resolved).toBe(10);
+    expect(normalized.failures).toEqual([]);
+    // The whole point: such a dataset is green, not red, before its next re-crawl.
+    expect(persistentUrisState(normalized)).toEqual({ state: 'met' });
+  });
+
+  it('keeps hard failures while folding only the no-self-reference ones', () => {
+    const normalized = normalizePersistentUris({
+      uriSpace: 'https://example.org/id/',
+      scheme: null,
+      publisher: null,
+      sampled: 10,
+      resolved: 8,
+      htmlLandingPages: null,
+      onDisallowList: false,
+      failures: [
+        { uri: 'https://example.org/id/1', reason: 'no-self-reference' },
+        { uri: 'https://example.org/id/2', reason: 'network-error' },
+      ],
+    });
+    expect(normalized.resolved).toBe(9);
+    expect(normalized.failures).toEqual([
+      { uri: 'https://example.org/id/2', reason: 'network-error' },
+    ]);
+    // One real failure remains, so the row stays red and lists only that URI.
+    expect(persistentUrisState(normalized)).toEqual({
+      state: 'failed',
+      reason: 'unresolved',
+    });
+  });
+
+  it('returns re-crawled data unchanged (no no-self-reference failures)', () => {
+    const persistent: PersistentUris = {
+      uriSpace: 'https://example.org/id/',
+      scheme: null,
+      publisher: null,
+      sampled: 10,
+      resolved: 8,
+      htmlLandingPages: 8,
+      onDisallowList: false,
+      failures: [{ uri: 'https://example.org/id/1', reason: 'timeout' }],
+    };
+    expect(normalizePersistentUris(persistent)).toBe(persistent);
   });
 });
 

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -436,6 +436,34 @@ export function iiifState(manifests: IiifManifests): CompatibilityState {
   return 'met';
 }
 
+// Reinterprets legacy DKG measurements under the relaxed resolution semantics
+// this UI now consumes. The DKG used to count a subject URI as resolved only when
+// its page also referenced its own URI; pages that resolved to HTML without that
+// self-reference were recorded as `no-self-reference` failures and left out of
+// `resolved`. Those pages now count as resolved, so fold them back into the
+// numerator and drop them from the failure list. Without this, a dataset that is
+// green under the current rules would briefly turn red — and list pages that did
+// resolve under “did not resolve” — until its next DKG re-crawl rewrites the
+// measurement. Idempotent: re-crawled data carries no `no-self-reference`
+// failures, so it is returned unchanged.
+export function normalizePersistentUris(
+  persistent: PersistentUris,
+): PersistentUris {
+  const noSelfReferenceResolved = persistent.failures.filter(
+    (failure) => failure.reason === 'no-self-reference',
+  ).length;
+  if (noSelfReferenceResolved === 0) {
+    return persistent;
+  }
+  return {
+    ...persistent,
+    resolved: (persistent.resolved ?? 0) + noSelfReferenceResolved,
+    failures: persistent.failures.filter(
+      (failure) => failure.reason !== 'no-self-reference',
+    ),
+  };
+}
+
 // Derives the persistent-URI state from the subject-URI resolution measurement.
 // Persistence is judged by resolution, not by the identifier scheme or by serving
 // an HTML page: a self-minted HTTP namespace that dereferences to RDF or HTML is

--- a/apps/browser/src/lib/services/nde-compatibility.ts
+++ b/apps/browser/src/lib/services/nde-compatibility.ts
@@ -43,11 +43,16 @@ export const QUADS_VALIDATED_METRIC =
 // recorded by the Dataset Knowledge Graph on the dataset’s self-minted subject
 // namespace. `subject-uris-sampled` is the denominator (how many subject URIs
 // were sampled), `subject-uris-resolved` the numerator (how many of those
-// resolved to an HTML landing page).
+// dereferenced to an HTML page or RDF). `subject-uris-html-landing-pages` is the
+// subset of resolved URIs that returned an HTML landing page (an HTML page that
+// references its own URI) — a positive signal that promotes human-readable
+// pages without gating resolution on them.
 export const SUBJECT_URIS_SAMPLED_METRIC =
   'https://def.nde.nl/metric#subject-uris-sampled';
 export const SUBJECT_URIS_RESOLVED_METRIC =
   'https://def.nde.nl/metric#subject-uris-resolved';
+export const SUBJECT_URIS_HTML_LANDING_PAGES_METRIC =
+  'https://def.nde.nl/metric#subject-uris-html-landing-pages';
 
 // Boolean DQV metric the Dataset Knowledge Graph records (`true`) when the
 // subject-URI sample query failed on every attempt — the namespace was selected
@@ -132,12 +137,8 @@ export type LinkedDataFailureReason = 'no-linked-data' | 'empty';
 export type SchemaApNdeFailureReason = 'violations' | 'declared-but-empty';
 
 // Why the persistent-URI criterion is in a non-green state:
-// 'unresolved'        — 🔴 at least one sampled URI did not (properly) resolve
-//                       (a hard failure), or per-URI reasons are not available
-//                       yet so the failure cannot be classified as soft.
-// 'no-self-reference' — 🟠 every failed URI resolves but does not advertise its
-//                       own persistent URI: the pages work, they just do not
-//                       reference their PID.
+// 'unresolved'        — 🔴 at least one sampled URI did not resolve to an HTML
+//                       page or RDF (a hard failure).
 // 'non-durable'       — 🟠 the URIs resolve, but on a namespace the DKG flags as
 //                       a non-durable home (its disallow list).
 // 'sampling-failed'   — 🟠 the namespace was selected and sampling was attempted,
@@ -147,9 +148,15 @@ export type SchemaApNdeFailureReason = 'violations' | 'declared-but-empty';
 //                       not the neutral “not yet checked” of a never-sampled one.
 export type PersistentFailureReason =
   | 'unresolved'
-  | 'no-self-reference'
   | 'non-durable'
   | 'sampling-failed';
+
+// A non-blocking advisory shown alongside a green (`met`) persistent-URI row.
+// 'no-html-landing-pages' — the subject URIs resolve, but none served an HTML
+//                           landing page (they resolve to RDF only). The row
+//                           stays green; the advisory nudges the provider to
+//                           also offer a human-readable landing page.
+export type PersistentAdvisory = 'no-html-landing-pages';
 
 // Why a criterion is in a non-green state. The registration reasons ('gone',
 // 'invalid') carry the dataset’s status; the linked-data reasons say why no
@@ -177,22 +184,23 @@ export interface IiifManifests {
 export type PidScheme = 'ark' | 'handle';
 
 // Why a single sampled subject URI failed, mirroring the Knowledge Graph’s
-// `subject-resolution-failure` concept scheme:
-// 'no-self-reference'  — the page resolves (a 200, text/html response), but its
-//                        body does not advertise the original URI. A soft gap:
-//                        the identifier dereferences, it just is not referenced.
+// `subject-resolution-failure` concept scheme. All are hard failures: the URI
+// did not resolve to an HTML page or RDF.
 // 'http-error'         — a non-2xx HTTP response.
 // 'timeout'            — the request did not complete within the budget.
 // 'network-error'      — the request failed to connect (DNS, TLS, reset, …).
-// 'wrong-content-type' — a 200, but not an HTML landing page.
-// All but 'no-self-reference' are hard failures: the page did not (properly)
-// resolve at all.
+// 'wrong-content-type' — a 2xx that is neither HTML nor RDF (e.g. a JSON or
+//                        plain-text error page).
+// 'no-self-reference'  — legacy: the DKG no longer emits this (an HTML page that
+//                        does not reference its own URI now resolves and is not a
+//                        failure). Retained so historical per-URI failure lists
+//                        still render; it drives no state.
 export type PersistentUriFailureReason =
-  | 'no-self-reference'
   | 'http-error'
   | 'timeout'
   | 'network-error'
-  | 'wrong-content-type';
+  | 'wrong-content-type'
+  | 'no-self-reference';
 
 // A single sampled subject URI that did not resolve, paired with its typed
 // reason. Surfaced on the detail page so providers can see exactly which pages
@@ -205,8 +213,9 @@ export interface PersistentUriFailure {
 // Persistent-URI figures from the Knowledge Graph for the dataset’s most common
 // self-minted subject namespace. The DKG samples subject URIs from that namespace
 // and dereferences them. Persistence is judged by resolution: every sampled URI
-// reaching an HTML landing page is the bar. A recognised PID scheme and its
-// issuing organisation are surfaced as positive embellishments, not as a gate.
+// dereferencing to an HTML page or RDF is the bar. An HTML landing page is
+// promoted but not required; a recognised PID scheme and its issuing organisation
+// are surfaced as positive embellishments, not as a gate.
 // 'uriSpace'      — the namespace that was assessed, or null when the DKG found no
 //                   self-minted namespace to sample (nothing to assess yet).
 // 'scheme'        — the recognised PID scheme (ARK or Handle), or null. Shown as a
@@ -215,19 +224,22 @@ export interface PersistentUriFailure {
 //                   only); null for Handle or when the lookup found none.
 // 'sampled'       — how many subject URIs were sampled (the denominator), or null
 //                   when no resolution measurement has been recorded yet.
-// 'resolved'      — how many of the sampled URIs resolved to an HTML landing page
+// 'resolved'      — how many of the sampled URIs resolved to an HTML page or RDF
 //                   (the numerator); null when no measurement exists.
+// 'htmlLandingPages' — how many of the resolved URIs served an HTML landing page
+//                   (an HTML page that references its own URI). A subset of
+//                   `resolved`; null when no measurement exists. Drives the
+//                   `no-html-landing-pages` advisory (0 of a resolved sample) but
+//                   never the state — resolving to RDF alone is still green.
 // 'onDisallowList' — whether the namespace is on the DKG’s disallow list of known
 //                   non-durable vendor namespaces: it resolves today but is not a
 //                   durable home for the identifiers, so it warns rather than
 //                   passing. False until the DKG emits the marker (see
 //                   dataset-knowledge-graph): the orange tier is dormant until then.
 // 'failures'      — the sampled URIs that did not resolve, each with its typed
-//                   reason. Drives the soft/hard split: when every failure is
-//                   `no-self-reference` the page resolves but does not reference
-//                   its PID (🟠), otherwise at least one page did not resolve
-//                   (🔴). Empty until the DKG ships the per-URI data, so the
-//                   split falls back to the hard red state — matching today.
+//                   reason. All are hard failures (🔴); empty until the DKG ships
+//                   the per-URI data, in which case the count alone drives the red
+//                   state.
 // 'samplingFailed' — whether the DKG recorded a `subject-uris-sampling-failed`
 //                   marker: the namespace was selected and sampling was attempted
 //                   but failed every attempt this run. Distinguishes an errored
@@ -241,6 +253,7 @@ export interface PersistentUris {
   publisher: string | null;
   sampled: number | null;
   resolved: number | null;
+  htmlLandingPages: number | null;
   onDisallowList: boolean;
   failures: PersistentUriFailure[];
   samplingFailed?: boolean;
@@ -302,6 +315,9 @@ export interface CompatibilityCriterion {
   state: CompatibilityState;
   count: number;
   reason?: CompatibilityFailureReason;
+  // A non-blocking advisory shown alongside a `met` (green) row. Only the
+  // persistent criterion sets one (see `PersistentAdvisory`).
+  advisory?: PersistentAdvisory;
 }
 
 export interface CompatibilityInput {
@@ -421,30 +437,31 @@ export function iiifState(manifests: IiifManifests): CompatibilityState {
 }
 
 // Derives the persistent-URI state from the subject-URI resolution measurement.
-// Persistence is judged by resolution, not by the identifier scheme: a self-minted
-// HTTP namespace that resolves to an HTML landing page is just as persistent as an
-// ARK or Handle, so it is `met` (🟢).
+// Persistence is judged by resolution, not by the identifier scheme or by serving
+// an HTML page: a self-minted HTTP namespace that dereferences to RDF or HTML is
+// just as persistent as an ARK or Handle, so it is `met` (🟢).
 //
-// When some sampled URIs did not resolve (`resolved` < `sampled`), the typed
-// per-URI failures split the outcome: if every failure is `no-self-reference`
-// the pages resolve but do not advertise their own PID — a soft `warning` (🟠,
-// 'no-self-reference'); otherwise at least one page did not (properly) resolve,
-// a hard `failed` (🔴, 'unresolved'). With no per-URI reasons yet (old DKG data),
-// the failure cannot be classified as soft, so it falls back to the hard red
-// state — exactly today’s behaviour.
+// When some sampled URIs did not resolve (`resolved` < `sampled`), at least one
+// did not dereference to an HTML page or RDF — a hard `failed` (🔴, 'unresolved').
 //
-// A namespace that fully resolves but is on the DKG’s disallow list of known
-// non-durable vendor namespaces is a `warning` (🟠, 'non-durable'): it works
-// today but is not a durable home for the identifiers. With no ratio, the
-// sampling-failed marker splits the two no-measurement cases: a sample that was
-// attempted and failed this run is a `warning` (🟠, 'sampling-failed') — an error
-// to surface — whereas no marker means the resolution step has not run, or the
-// DKG found no self-minted namespace to sample, so the criterion is neutral
-// pending (⚪): a grey row signalling “this will still be checked”, unlike terms
-// it keeps its place rather than being omitted.
+// A fully-resolving namespace is `met` (🟢), with two refinements: if it is on the
+// DKG’s disallow list of known non-durable vendor namespaces it is a `warning`
+// (🟠, 'non-durable') — it works today but is not a durable home; and if none of
+// the resolved URIs served an HTML landing page (`htmlLandingPages` is 0) the row
+// stays green but carries a non-blocking `no-html-landing-pages` advisory nudging
+// the provider to also offer a human-readable page.
+//
+// With no ratio, the sampling-failed marker splits the two no-measurement cases:
+// a sample that was attempted and failed this run is a `warning` (🟠,
+// 'sampling-failed') — an error to surface — whereas no marker means the
+// resolution step has not run, or the DKG found no self-minted namespace to
+// sample, so the criterion is neutral pending (⚪): a grey row signalling “this
+// will still be checked”, unlike terms it keeps its place rather than being
+// omitted.
 export function persistentUrisState(persistent: PersistentUris): {
   state: CompatibilityState;
   reason?: PersistentFailureReason;
+  advisory?: PersistentAdvisory;
 } {
   if (persistent.sampled === null || persistent.sampled <= 0) {
     return persistent.samplingFailed
@@ -453,17 +470,16 @@ export function persistentUrisState(persistent: PersistentUris): {
   }
   const resolved = persistent.resolved ?? 0;
   if (resolved < persistent.sampled) {
-    const onlyNoSelfReference =
-      persistent.failures.length > 0 &&
-      persistent.failures.every(
-        (failure) => failure.reason === 'no-self-reference',
-      );
-    return onlyNoSelfReference
-      ? { state: 'warning', reason: 'no-self-reference' }
-      : { state: 'failed', reason: 'unresolved' };
+    return { state: 'failed', reason: 'unresolved' };
   }
-  return persistent.onDisallowList
-    ? { state: 'warning', reason: 'non-durable' }
+  if (persistent.onDisallowList) {
+    return { state: 'warning', reason: 'non-durable' };
+  }
+  // Resolves, durable, green. Promote HTML landing pages: when the URIs resolve
+  // but none served one (RDF-only), keep green but advise adding one. A null
+  // count is old data without the measurement — no advisory.
+  return persistent.htmlLandingPages === 0
+    ? { state: 'met', advisory: 'no-html-landing-pages' }
     : { state: 'met' };
 }
 
@@ -524,6 +540,7 @@ export function compatibilityCriteria(
       // sampled) from the prop, not a single count.
       count: input.persistent.sampled ?? 0,
       reason: persistent.reason,
+      advisory: persistent.advisory,
     },
     {
       key: 'linked-data',


### PR DESCRIPTION
## What

Make the persistent-URI criterion green when a dataset’s subject URIs resolve to **RDF or HTML**, not only to an HTML landing page that references its own URI. HTML landing pages are still promoted, via a non-blocking advisory rather than a gate.

## Why

The persistence judgement is owned by the Dataset Knowledge Graph; this PR consumes the relaxed semantics it now emits. A dataset serving good linked data at its subject URIs should be 🟢, while still being nudged toward also offering a human-readable landing page.

## Changes (`apps/browser`)

- `nde-compatibility.ts`: add `htmlLandingPages` to `PersistentUris` and a `PersistentAdvisory`. `persistentUrisState` is `met` (🟢) whenever the URIs resolve, with a `no-html-landing-pages` advisory when none of the resolved URIs served an HTML landing page. The `no-self-reference` warning tier is removed (those cases are now green).
- `dataset-detail.ts`: read the new `subject-uris-html-landing-pages` measurement.
- `NdeCompatibility.svelte`: render the advisory note on the green row; drop the no-self-reference heading/explanation/legend/fold-out paths.
- `messages/en.json` + `nl.json`: add the advisory string, reword the persistent explanations (resolves to a web page or linked data) and the `wrong-content-type` reason, remove the dead no-self-reference keys.

### Legacy data normalization

Before the relaxed DKG semantics, a page that resolved to HTML but did not reference its own URI was recorded as a `no-self-reference` failure and excluded from `subject-uris-resolved`. Such pages now count as resolved, but legacy graphs still hold the old counts until their next re-crawl. To avoid those datasets briefly turning red (and listing pages that did resolve under “did not resolve”) during the rollout:

- `nde-compatibility.ts`: add `normalizePersistentUris()`, applied once in `dataset-detail.ts` where the per-URI failures merge. It folds legacy `no-self-reference` failures back into the resolved count and drops them from the failure list, keeping the state, the count line and the failing-URI fold-out consistent. Idempotent on re-crawled data.
- Guard the `no-html-landing-pages` advisory on the persistent criterion; drop a redundant `warning` case in the persistent count switch; add unit tests for normalization.

### Incidental fix

- `apps/browser/package.json`: the `check` target ran `svelte-check` without generating the gitignored Paraglide output (only the vite build produces it, and `check` — unlike `test`/`typecheck` — has no `dependsOn: build`). On a cache miss it failed with `Cannot find module '$lib/paraglide/runtime'`. The `check` script now compiles Paraglide first, so it is self-contained and deterministic.

## Notes

The index facet (`isPersistentUrisMet`) and the search-indexer need no change — RDF now counts toward `resolved` upstream. Old measurements without the new metric suppress the advisory (no false nudge) and heal on the next DKG re-crawl.

Depends on the matching changes in netwerk-digitaal-erfgoed/dataset-knowledge-graph (emits the metric) and netwerk-digitaal-erfgoed/definitions (vocabulary); this PR degrades gracefully if the metric is absent.
