### PR TITLE
fix(browser): detect catalog by dataset count, not catalog node

### DIFF
--- a/apps/browser/src/lib/components/validation/UrlValidationForm.svelte
+++ b/apps/browser/src/lib/components/validation/UrlValidationForm.svelte
@@ -86,19 +86,18 @@
   let fetchController: AbortController | null = null;
   let innerGoToLine = $state<((line: number) => void) | undefined>(undefined);
 
-  // Acknowledge what was actually fetched: a single dataset description, several,
-  // or a whole data catalog. Falls back to the generic title when the source
-  // could not be parsed or held no datasets.
+  // Acknowledge what was actually fetched: a single dataset description or
+  // several (presented as a data catalog). Falls back to the generic title when
+  // the source could not be parsed or held no datasets.
   const sourceTitle = $derived.by(() => {
     const summary = descriptionSummary;
-    if (!summary) return m.validate_url_source_title();
-    if (summary.isCatalog) {
-      return m.validate_url_source_title_catalog({
-        count: summary.datasetCount,
-      });
+    if (!summary || summary.datasetCount === 0) {
+      return m.validate_url_source_title();
     }
-    if (summary.datasetCount === 0) return m.validate_url_source_title();
-    return m.validate_url_source_title_dataset({ count: summary.datasetCount });
+    if (summary.datasetCount === 1) {
+      return m.validate_url_source_title_dataset({ count: 1 });
+    }
+    return m.validate_url_source_title_catalog({ count: summary.datasetCount });
   });
 
   // Expose a wrapped goToLine: auto-open the accordion and wait for the

--- a/apps/browser/src/lib/components/validation/description-summary.test.ts
+++ b/apps/browser/src/lib/components/validation/description-summary.test.ts
@@ -5,7 +5,6 @@ describe('summarizeDescription', () => {
   it('returns no datasets for empty input', async () => {
     expect(await summarizeDescription('', 'application/ld+json')).toEqual({
       datasetCount: 0,
-      isCatalog: false,
     });
   });
 
@@ -17,11 +16,29 @@ describe('summarizeDescription', () => {
     });
     expect(await summarizeDescription(source, 'application/ld+json')).toEqual({
       datasetCount: 1,
-      isCatalog: false,
     });
   });
 
-  it('detects a data catalog and counts its datasets (JSON-LD)', async () => {
+  it('does not count a back-referenced catalog as extra datasets (JSON-LD)', async () => {
+    // A single dataset that names the catalog it is part of via
+    // schema:includedInDataCatalog must still count as one dataset, not as a
+    // catalog – regression for a single DANS dataset description.
+    const source = JSON.stringify({
+      '@context': 'https://schema.org/',
+      '@type': 'Dataset',
+      '@id': 'https://example.org/dataset',
+      includedInDataCatalog: {
+        '@type': 'DataCatalog',
+        '@id': 'https://example.org/catalog',
+        dataset: [{ '@type': 'Dataset', '@id': 'https://example.org/dataset' }],
+      },
+    });
+    expect(await summarizeDescription(source, 'application/ld+json')).toEqual({
+      datasetCount: 1,
+    });
+  });
+
+  it('counts the datasets inside a data catalog (JSON-LD)', async () => {
     const source = JSON.stringify({
       '@context': { dcat: 'http://www.w3.org/ns/dcat#' },
       '@type': 'dcat:Catalog',
@@ -33,11 +50,10 @@ describe('summarizeDescription', () => {
     });
     expect(await summarizeDescription(source, 'application/ld+json')).toEqual({
       datasetCount: 2,
-      isCatalog: true,
     });
   });
 
-  it('counts distinct datasets and detects a catalog (Turtle)', async () => {
+  it('counts distinct datasets (Turtle)', async () => {
     const source = `
       @prefix dcat: <http://www.w3.org/ns/dcat#> .
       <https://example.org/catalog> a dcat:Catalog ;
@@ -47,11 +63,12 @@ describe('summarizeDescription', () => {
     `;
     expect(await summarizeDescription(source, 'text/turtle')).toEqual({
       datasetCount: 2,
-      isCatalog: true,
     });
   });
 
-  it('reports several dataset descriptions without a catalog node', async () => {
+  it('counts several dataset descriptions without a catalog node (Turtle)', async () => {
+    // A SPARQL CONSTRUCT result returns bare dataset descriptions and no
+    // dcat:Catalog node, yet it is still presented as a catalog by count.
     const source = `
       @prefix schema: <https://schema.org/> .
       <https://example.org/a> a schema:Dataset .
@@ -59,7 +76,6 @@ describe('summarizeDescription', () => {
     `;
     expect(await summarizeDescription(source, 'text/turtle')).toEqual({
       datasetCount: 2,
-      isCatalog: false,
     });
   });
 });

--- a/apps/browser/src/lib/components/validation/description-summary.ts
+++ b/apps/browser/src/lib/components/validation/description-summary.ts
@@ -14,41 +14,35 @@ const DATASET_TYPES = new Set([
   'http://schema.org/Dataset',
 ]);
 
-const CATALOG_TYPES = new Set([
-  'http://www.w3.org/ns/dcat#Catalog',
-  'https://schema.org/DataCatalog',
-  'http://schema.org/DataCatalog',
-]);
-
 export interface DescriptionSummary {
   /** Number of distinct schema:Dataset / dcat:Dataset resources found. */
   datasetCount: number;
-  /** Whether a dcat:Catalog / schema:DataCatalog resource is present. */
-  isCatalog: boolean;
 }
 
 /**
  * Inspect the fetched source so the UI can say whether it retrieved a single
- * dataset description, several, or a whole data catalog. Best effort — unknown
- * formats or parse errors return zero datasets and no catalog.
+ * dataset description or several (a catalog). We only count dataset resources:
+ * a dedicated dcat:Catalog / schema:DataCatalog node is an unreliable signal —
+ * a single dataset commonly back-references the catalog it belongs to via
+ * schema:includedInDataCatalog, and a catalog endpoint may return bare dataset
+ * descriptions with no catalog node at all. Best effort — unknown formats or
+ * parse errors return zero datasets.
  */
 export async function summarizeDescription(
   sourceText: string,
   contentType: ContentType,
 ): Promise<DescriptionSummary> {
-  if (!sourceText.trim()) return { datasetCount: 0, isCatalog: false };
+  if (!sourceText.trim()) return { datasetCount: 0 };
 
   if (contentType === 'application/ld+json') {
     const datasets = new Set<string>();
     let anonymousDatasets = 0;
-    let isCatalog = false;
     walkJsonLd(safeParseJson(sourceText), (node, context) => {
       const type = node['@type'];
       const types = Array.isArray(type) ? type : type ? [type] : [];
       for (const rawType of types) {
         if (typeof rawType !== 'string') continue;
         const iri = expandTerm(rawType, context) ?? rawType;
-        if (CATALOG_TYPES.has(iri)) isCatalog = true;
         if (DATASET_TYPES.has(iri)) {
           const id = node['@id'];
           if (typeof id === 'string') datasets.add(id);
@@ -56,15 +50,13 @@ export async function summarizeDescription(
         }
       }
     });
-    return { datasetCount: datasets.size + anonymousDatasets, isCatalog };
+    return { datasetCount: datasets.size + anonymousDatasets };
   }
 
   const datasets = new Set<string>();
-  let isCatalog = false;
   for (const quad of await parseN3Quads(sourceText, contentType)) {
     if (quad.predicate.value !== RDF_TYPE) continue;
-    if (CATALOG_TYPES.has(quad.object.value)) isCatalog = true;
     if (DATASET_TYPES.has(quad.object.value)) datasets.add(quad.subject.value);
   }
-  return { datasetCount: datasets.size, isCatalog };
+  return { datasetCount: datasets.size };
 }


### PR DESCRIPTION
## What

Follow-up to #2105. The validate page now decides the fetched-source title purely from how many dataset descriptions it found:

- 0 → “Fetched description” (generic fallback)
- 1 → “Fetched dataset description”
- more than 1 → “Fetched data catalog with N dataset descriptions”

The earlier `dcat:Catalog` / `schema:DataCatalog` node detection is removed.

## Why

Test results on #2105 ([comment](https://github.com/netwerk-digitaal-erfgoed/dataset-register/pull/2105#issuecomment-4713139330)) showed the catalog-node signal was unreliable in both directions:

- **False positive** – a single dataset that back-references the catalog it belongs to via `schema:includedInDataCatalog` was walked into and mislabelled as a catalog (e.g. the DANS `nde_metadata.jsonld`).
- **False negative** – a SPARQL CONSTRUCT endpoint (e.g. `data.bibliotheken.nl/sparql`) returns bare `dcat:Dataset` descriptions with no catalog node, so it was not recognised as a catalog.

Counting dataset resources handles every reported source correctly: all four working catalog examples inline three or more typed `Dataset` nodes.

## Known limitation

A catalog that contains exactly one dataset now reads as “Fetched dataset description”. This is an accepted trade-off – the explicit catalog node was a worse signal than the count.

## How

- `description-summary.ts`: count `schema:Dataset` / `dcat:Dataset` resources only; drop `isCatalog` and the catalog type set.
- `UrlValidationForm.svelte`: derive the title from the count.
- Add regression tests for both cases above (JSON-LD back-reference, catalog-less Turtle).
