### PR TITLE
feat(browser): explain a missing Linked Data summary when the source RDF is invalid or unreachable

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -201,6 +201,8 @@
   "detail_about": "About",
   "detail_linked_data_summary_description": "Statistical information about this dataset retrieved from the Knowledge Graph, including the number of triples, entities, properties, and class distribution.",
   "detail_summary_updated": "Last updated {time}",
+  "detail_summary_unavailable_invalid": "No Linked Data summary could be generated: the dataset’s data is not valid RDF.",
+  "detail_summary_unavailable_unreachable": "No Linked Data summary could be generated: the dataset’s data could not be retrieved.",
   "detail_registered_url": "Registered URL",
   "detail_registered_url_description": "URL where the dataset is described.",
   "detail_validate": "Validate",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -201,6 +201,8 @@
   "detail_about": "Onderwerp",
   "detail_linked_data_summary_description": "Statistische informatie over deze dataset opgehaald uit de Dataset Knowledge Graph, inclusief het aantal feiten, entiteiten, eigenschappen en typeverdeling.",
   "detail_summary_updated": "{time} bijgewerkt",
+  "detail_summary_unavailable_invalid": "Er kon geen Linked Data-samenvatting worden gegenereerd: de data van deze dataset is geen geldige RDF.",
+  "detail_summary_unavailable_unreachable": "Er kon geen Linked Data-samenvatting worden gegenereerd: de data van deze dataset kon niet worden opgehaald.",
   "detail_registered_url": "Geregistreerde URL",
   "detail_registered_url_description": "URL waar de dataset wordt beschreven.",
   "detail_validate": "Controleren",

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -252,6 +252,43 @@
         (summary.vocabulary && summary.vocabulary.length > 0)),
   );
 
+  // RDF distributions (downloads or SPARQL endpoints) the Knowledge Graph would
+  // summarise. A dataset offering only non-RDF downloads (CSV, PDF, …) is not
+  // expected to have a Linked Data summary, so the “why is it missing” notice
+  // below is never shown for it.
+  const rdfDistributions = $derived(
+    distributions.filter(
+      (distribution) =>
+        isRdfDistribution(distribution) || isSparqlDistribution(distribution),
+    ),
+  );
+
+  // When there is no summary, explain why — but only when a concrete cause is
+  // known: an RDF distribution that is reachable-but-invalid, or unreachable.
+  // A dataset with no RDF at all, or one whose RDF is still reachable/unprobed
+  // (merely pending or not yet processed), shows nothing rather than a false
+  // failure. Prefers an invalid-RDF cause over a reachability one, as it is the
+  // more specific explanation.
+  const summaryUnavailable = $derived.by(() => {
+    if (summary && hasVoidStats) return undefined;
+    if (rdfDistributions.length === 0) return undefined;
+    const failed =
+      rdfDistributions.find((distribution) => {
+        const usability = usabilityForDistribution(distribution);
+        return usability.state === 'unusable' && usability.cause === 'invalid';
+      }) ??
+      rdfDistributions.find(
+        (distribution) =>
+          usabilityForDistribution(distribution).state === 'unusable',
+      );
+    if (!failed) return undefined;
+    const invalid = usabilityForDistribution(failed).cause === 'invalid';
+    const reason = invalid
+      ? validityReason(validityByUrl.get(failed.accessURL) ?? [])
+      : probeReason(healthByUrl.get(failed.accessURL)?.lastOutcome ?? null);
+    return { invalid, reason };
+  });
+
   // Get registration status (gone, invalid, or null)
   const registrationStatus = $derived(
     getRegistrationStatus(dataset.subjectOf?.additionalType),
@@ -1811,6 +1848,28 @@
           </ul>
         </div>
       {/if}
+    </div>
+  {:else if summaryUnavailable}
+    <!-- No summary, but the dataset offers RDF that failed: explain why, so the
+         absence is not silent (the per-distribution detail is in the list below). -->
+    <div class="mb-8">
+      <h2
+        id="linked-data-summary"
+        class="mb-4 flex scroll-mt-20 items-center gap-2 text-xl font-semibold text-gray-900 lg:scroll-mt-24 dark:text-white"
+      >
+        {m.detail_linked_data_summary()}
+      </h2>
+      <Alert border color="yellow" class="mb-6">
+        {#snippet icon()}
+          <ExclamationCircleOutline class="h-5 w-5" />
+        {/snippet}
+        <p class="font-semibold">
+          {summaryUnavailable.invalid
+            ? m.detail_summary_unavailable_invalid()
+            : m.detail_summary_unavailable_unreachable()}
+        </p>
+        <p>{summaryUnavailable.reason}</p>
+      </Alert>
     </div>
   {/if}
 


### PR DESCRIPTION
## What

When a dataset has no Linked Data summary, the detail page used to just *omit* the summary section — leaving the visitor with no idea why (the original complaint in #2029). This adds an explanatory notice in its place:

> **No Linked Data summary could be generated: the dataset’s data is not valid RDF.**
> This distribution’s content could not be parsed as RDF.

It reuses the existing per-distribution validity/health verdicts (`validityReason` / `probeReason`), so the reason matches the badge on the distribution below — invalid RDF (parse error / empty) or unreachable (e.g. HTTP 500).

## When it shows (and when it deliberately doesn’t)

Only when there is a **concrete cause**: the dataset offers RDF (a download or SPARQL endpoint) and at least one such distribution is `unusable` (invalid or unreachable). Specifically guarded against false alarms:

- **Non-RDF datasets** (CSV/PDF-only) are not expected to have a summary → nothing shown.
- **Pending / not-yet-processed** datasets (RDF still reachable or unprobed) → nothing shown, rather than a spurious failure. This also avoids any flicker during the async health/validity load (everything classifies as `unknown` until the verdicts resolve).

Prefers an invalid-RDF cause over a reachability one, since it’s the more specific explanation.

## Dependency

The notice is driven by the per-distribution validity verdicts + health records. Until those are populated in the served KG (the DKG/infra work tracked separately), datasets without a verdict behave exactly as before (no notice). Once populated, the issue-#2029 datasets (LOD Archiefbeschrijvingen, CBG, Krantenpagina’s → invalid RDF; Akten → HTTP 500) will each explain themselves.

## Validation

`nx build @dataset-register/browser` and the browser test suite (182 tests) pass; new UI strings added to both `en.json` and `nl.json`.
