### PR TITLE
fix(browser): retrieve deep RDF-validity verdicts without a dcat join

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -906,16 +906,33 @@ interface ValidityBinding {
   message?: { value: string };
 }
 
+// The Dataset Knowledge Graph writes RDF-validity verdicts to one named graph per
+// dataset, keyed by the dataset IRI, and stores no dcat:distribution metadata
+// alongside them. This mirrors dataset-knowledge-graph graphIri.ts:
+// base + encodeURIComponent(datasetIri). Kept here so the deep validity query can
+// scope to a dataset without a dcat join the DKG cannot satisfy.
+const DKG_DISTRIBUTION_VALIDITY_GRAPH_BASE =
+  'https://data.netwerkdigitaalerfgoed.nl/dkg/distribution-validity/';
+
+function deepValidityGraphIri(datasetUri: string): string {
+  return DKG_DISTRIBUTION_VALIDITY_GRAPH_BASE + encodeURIComponent(datasetUri);
+}
+
 async function fetchValidityVerdicts(
   datasetUri: string,
   endpoint: string,
   depth: ValidityVerdict['depth'],
 ): Promise<Map<string, ValidityVerdict[]>> {
-  // The register (shallow) stores datasets and validity measurements in named
-  // graphs, so the query must name them — exactly as fetchDistributionHealth
-  // does. The Knowledge Graph (deep) serves the default graph, so its query is
-  // unscoped, matching the other DKG queries in this file. Using GRAPH blocks on
-  // the register endpoint is what makes the shallow rail resolve at all.
+  // The register (shallow) stores the dataset description and its validity
+  // measurements in named graphs, so the query names them and joins through
+  // dcat:distribution / dcat:accessURL, exactly as fetchDistributionHealth does.
+  //
+  // The Knowledge Graph (deep) is different: it writes the validity verdicts for
+  // each dataset to a per-dataset named graph and carries no dcat:distribution
+  // metadata, so that same dcat join matches zero rows there. The deep query
+  // instead scopes to the per-dataset graph and reads the distribution URL
+  // directly from dqv:computedOn (which equals the access URL). See
+  // deepValidityGraphIri.
   const datasetPattern = `
       <${datasetUri}> dcat:distribution ?distribution .
       ?distribution dcat:accessURL ?accessURL .`;
@@ -936,7 +953,8 @@ async function fetchValidityVerdicts(
       }
       GRAPH ?validityGraph {${measurementPattern}
       }`
-      : `${datasetPattern}${measurementPattern}`;
+      : `GRAPH <${deepValidityGraphIri(datasetUri)}> {${measurementPattern}
+      }`;
   const query = `
     PREFIX dcat: <http://www.w3.org/ns/dcat#>
     PREFIX dqv: <http://www.w3.org/ns/dqv#>


### PR DESCRIPTION
## Problem

On a dataset whose only RDF distribution fails to import, the dataset page showed the wrong explanation for the missing Linked Data summary — e.g. "the data could not be fetched / this distribution requires authentication" (the SPARQL endpoint's 403) instead of the actual cause: the dump is invalid RDF.

Root cause: the **deep** validity rail queried the Dataset Knowledge Graph by joining through `<dataset> dcat:distribution` / `dcat:accessURL`. The DKG stores **no** DCAT metadata (0 such triples), so that join matched zero rows and **every** deep verdict was unreachable — the rail had effectively never returned anything. With no deep verdict, the `.rdf` was not classified `invalid`, so the page fell back to the SPARQL endpoint's reachability reason.

The verdict itself was present and correct in the DKG all along — keyed by `dqv:computedOn` in a per-dataset `distribution-validity` named graph — just not retrievable the way the browser asked for it.

## Fix

For the deep rail, scope the query to the DKG's per-dataset distribution-validity graph (`https://data.netwerkdigitaalerfgoed.nl/dkg/distribution-validity/` + `encodeURIComponent(datasetIri)`, matching the producer's `graphIri.ts` scheme) and read the distribution URL directly from `dqv:computedOn`, instead of joining through DCAT metadata the DKG does not hold. The shallow (register) rail is unchanged — the register graph does carry the DCAT distribution chain.

## Verification

Verified in the dev server against the live DKG on `LOD Archiefbeschrijvingen` (Literatuurmuseum): the Linked Data Summary panel now reads

> No Linked Data summary could be generated: the dataset's data is not valid RDF.
> This distribution's content could not be parsed as RDF. 80486:14: disallowed character.

instead of the previous authentication message.

## Notes

- This surfaces the correct, actionable reason for the invalid-RDF datasets discussed in #2029 (it does not resolve their underlying vendor export problems).
- A follow-up remains for the Download button to show a "this distribution is not usable" state when the only download is invalid RDF; this change is the prerequisite (the `.rdf` is now classified `unusable/invalid`).
