### PR TITLE
fix(browser): mark the download button not usable for invalid-RDF distributions

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -136,6 +136,8 @@
   "detail_probe_unavailable_generic": "This distribution is currently unavailable.",
   "detail_download_none_available": "No working download available",
   "detail_download_none_available_tooltip": "None of this dataset’s downloads currently return data, according to the register’s latest check.",
+  "detail_download_not_usable": "Not usable",
+  "detail_download_not_usable_tooltip": "This distribution is not usable: its content is not valid RDF.",
   "detail_media_type": "Media Type",
   "detail_access_url": "Access URL",
   "detail_last_updated": "Last Updated",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -136,6 +136,8 @@
   "detail_probe_unavailable_generic": "Deze distributie is op dit moment niet beschikbaar.",
   "detail_download_none_available": "Geen werkende download beschikbaar",
   "detail_download_none_available_tooltip": "Geen van de downloads van deze dataset geeft op dit moment gegevens terug, volgens de meest recente controle van het register.",
+  "detail_download_not_usable": "Niet bruikbaar",
+  "detail_download_not_usable_tooltip": "Deze distributie is niet bruikbaar: de inhoud is geen geldige RDF.",
   "detail_media_type": "Mediatype",
   "detail_access_url": "Toegangs-URL",
   "detail_last_updated": "Laatst bijgewerkt",

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -210,6 +210,16 @@
     ),
   );
 
+  // True when the only download the button could point at is reachable but serves
+  // invalid RDF. selectPreferredDistribution falls back to such a distribution
+  // only when no valid one exists, so the primary action surfaces a "not usable"
+  // state instead of offering bytes that cannot be parsed. The dropdown still
+  // lists every distribution, so the invalid bytes stay reachable for inspection.
+  const preferredDownloadUnusable = $derived(
+    preferredDownload !== undefined &&
+      invalidUrls.has(preferredDownload.accessURL),
+  );
+
   // Likewise for the Query action: point it at the first reachable SPARQL
   // endpoint; undefined when every endpoint is unavailable, which greys out the
   // primary action. The dropdown still lists each endpoint URL so an unavailable
@@ -1493,7 +1503,7 @@
         <!-- Download dataset split button -->
         {#if downloadDistributions.length > 0}
           <div class="inline-flex rounded-lg shadow-sm" role="group">
-            {#if preferredDownload}
+            {#if preferredDownload && !preferredDownloadUnusable}
               <a
                 href={preferredDownload.accessURL}
                 target="_blank"
@@ -1504,6 +1514,18 @@
                 {m.detail_download_dataset()}
                 <span class="sr-only"> ({m.opens_in_new_tab()})</span>
               </a>
+            {:else if preferredDownloadUnusable}
+              <span
+                id="download-not-usable"
+                class={splitBtnMainDisabledClass}
+                aria-disabled="true"
+              >
+                <DownloadOutline class="me-2 h-4 w-4" />
+                {m.detail_download_not_usable()}
+              </span>
+              <Tooltip triggeredBy="#download-not-usable"
+                >{m.detail_download_not_usable_tooltip()}</Tooltip
+              >
             {:else}
               <span
                 id="download-none-available"


### PR DESCRIPTION
## Problem

When a dataset's only reachable download serves invalid RDF (e.g. an `.rdf` dump that returns HTTP 200 but cannot be parsed), the primary "Download dataset" action still pointed straight at those unparseable bytes, presenting them as a normal download. The visitor had no signal that the file is unusable.

## Fix

Surface a disabled **"Not usable"** state on the download split button when the preferred download is a reachable-but-invalid-RDF distribution, with a tooltip explaining the content is not valid RDF.

- Add a `preferredDownloadUnusable` flag — true when the preferred download is in the invalid-RDF set. `selectPreferredDistribution` only falls back to an invalid distribution when no valid one exists, so this fires precisely when there is no usable download.
- Render the disabled not-usable state in the download split button (mirrors the existing "no working download available" state).
- The dropdown still lists every distribution, so the invalid bytes stay reachable for inspection.
- Add EN/NL messages `detail_download_not_usable` and `detail_download_not_usable_tooltip`.

## Verification

Verified in the dev server with Playwright on `LOD Archiefbeschrijvingen` (Literatuurmuseum), whose only download is an invalid RDF/XML dump:

- Primary action now reads **"Not usable"** (was "Download dataset" linking to the corrupt file).
- Tooltip: "This distribution is not usable: its content is not valid RDF."
- The "Show download options" dropdown remains available.

No console errors.

## Note

Builds on the deep RDF-validity verdict retrieval merged in #2146 — that fix is what classifies the `.rdf` as invalid, which this state depends on.
