### PR TITLE
fix(search-indexer): keep last-good enrichment when the Knowledge Graph returns empty

### DIFF
--- a/packages/search-indexer/src/run-index.ts
+++ b/packages/search-indexer/src/run-index.ts
@@ -37,14 +37,22 @@ export interface RunIndexOptions {
   readonly log?: (message: string) => void;
 }
 
+/**
+ * Why a run left the live index untouched. `concurrent-rebuild`: another rebuild
+ * already held the cross-pod lock. `empty-knowledge-graph`: a configured DKG
+ * returned no enrichment, so the current enriched index was kept rather than
+ * swapped for an enrichment-less one (see {@link runIndex}).
+ */
+export type SkipReason = 'concurrent-rebuild' | 'empty-knowledge-graph';
+
 export type RunIndexResult =
   | {
       readonly mode: 'rebuild';
       readonly collection: string;
       readonly upserted: number;
     }
-  /** Another rebuild for this index was already in flight, so this run was a no-op. */
-  | { readonly mode: 'skipped' };
+  /** The run was a no-op and the live index was left untouched. */
+  | { readonly mode: 'skipped'; readonly reason: SkipReason };
 
 /**
  * Rebuild the Typesense `datasets` index from the register store.
@@ -93,6 +101,30 @@ export async function runIndex(
     source.readQuads(),
     readKnowledgeGraphQuads(options, log),
   ]);
+
+  // Guard a transient or empty Knowledge Graph from stripping every facet off the
+  // live index. The rebuild is a full blue/green swap, so projecting register data
+  // with no DKG enrichment would atomically replace a good, enriched index with an
+  // enrichment-less one for every dataset at once (no terminology-source facet, no
+  // Linked Data summary class data). When a DKG endpoint is configured but returned
+  // nothing — unreachable, or reduced to a bootstrap-only store — while the
+  // register has data and a live index already exists, keep that index instead of
+  // swapping. A run with no DKG endpoint configured, or a cold start with no index
+  // yet, still proceeds register-only. The next run self-heals once the DKG is
+  // back. (See dataset-knowledge-graph#385, which makes the DKG fail loudly rather
+  // than serve empty.)
+  if (
+    options.knowledgeGraphEndpoint !== undefined &&
+    dkgQuads.length === 0 &&
+    registerQuads.length > 0 &&
+    (await collectionExists(client, alias))
+  ) {
+    log(
+      `Rebuild of ${alias} skipped: the Knowledge Graph returned no enrichment; keeping the current index to avoid stripping facets`,
+    );
+    return { mode: 'skipped', reason: 'empty-knowledge-graph' };
+  }
+
   const result = await rebuild(
     client,
     buildCollectionSchema(alias),
@@ -100,7 +132,7 @@ export async function runIndex(
   );
   if (result === null) {
     log(`Rebuild of ${alias} skipped: another rebuild is already running`);
-    return { mode: 'skipped' };
+    return { mode: 'skipped', reason: 'concurrent-rebuild' };
   }
   log(
     `Indexed ${result.imported} datasets; alias ${alias} → ${result.collection}`,
@@ -118,6 +150,24 @@ export async function runIndex(
     collection: result.collection,
     upserted: result.imported,
   };
+}
+
+/**
+ * Whether the search alias already resolves to a live collection. Distinguishes a
+ * cold start (no index yet) from a populated one: an empty Knowledge Graph read
+ * only warrants keeping the current index when there is one to keep, so a first
+ * run still builds register-only rather than skipping into an empty search.
+ */
+async function collectionExists(
+  client: Client,
+  alias: string,
+): Promise<boolean> {
+  try {
+    await client.aliases(alias).retrieve();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/search-indexer/test/run-index.test.ts
+++ b/packages/search-indexer/test/run-index.test.ts
@@ -467,8 +467,10 @@ describe('runIndex acceptance (QLever + Typesense)', () => {
     expect(await search('Mohlmann')).toContain(base('mohlmann'));
   });
 
-  // Runs before the final rebuild: a failed DKG read must not abort the rebuild.
-  it('rebuilds register data even when the DKG endpoint is unreachable', async () => {
+  // Runs before the final (DKG-less) rebuild: a configured DKG that returns
+  // nothing — here an unreachable endpoint — must not strip enrichment off the
+  // live index. The run is skipped and the last-good enriched index is kept (#2151).
+  it('keeps the last-good enriched index when the configured DKG returns nothing', async () => {
     const result = await runIndex({
       sparqlUrl,
       registrationsGraphIri: REGISTRATIONS_GRAPH,
@@ -476,14 +478,36 @@ describe('runIndex acceptance (QLever + Typesense)', () => {
       typesense: connection,
     });
 
-    // Register correctness lands; DKG facets are simply absent this run.
-    expect(result.mode).toBe('rebuild');
+    // The run is a no-op: the previous run’s enriched index stays live and intact,
+    // rather than being swapped for an enrichment-less one.
+    expect(result.mode).toBe('skipped');
+    expect(result).toMatchObject({ reason: 'empty-knowledge-graph' });
     expect(await search('Mohlmann')).toContain(base('mohlmann'));
     const document = (await client
       .collections(SEARCH_COLLECTION_ALIAS)
       .documents(base('mohlmann'))
       .retrieve()) as Record<string, unknown>;
-    expect(document.class).toBeUndefined();
+    expect(document.class).toEqual([PERSON_CLASS]);
+  });
+
+  // A cold start (no live index yet) with a configured but unreachable DKG still
+  // builds register-only: there is no enriched index to protect, so the guard must
+  // not skip into an empty search. Fresh aliases simulate a first run.
+  it('builds register-only on a cold start when the DKG is unreachable', async () => {
+    const result = await runIndex({
+      sparqlUrl,
+      registrationsGraphIri: REGISTRATIONS_GRAPH,
+      knowledgeGraphEndpoint: 'http://127.0.0.1:1/',
+      typesense: connection,
+      collectionAlias: 'datasets_coldstart',
+      labelsAlias: 'labels_coldstart',
+    });
+
+    expect(result.mode).toBe('rebuild');
+    const collection = await client
+      .collections('datasets_coldstart')
+      .retrieve();
+    expect(collection.num_documents).toBe(SEEDS.length);
   });
 
   // Runs last: it mutates the store, then a full rebuild re-derives the index.

--- a/packages/search-indexer/vite.config.ts
+++ b/packages/search-indexer/vite.config.ts
@@ -19,10 +19,10 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
       thresholds: {
         autoUpdate: true,
-        lines: 95.4,
+        lines: 95.58,
         functions: 100,
-        branches: 90.1,
-        statements: 95.48,
+        branches: 90.72,
+        statements: 95.65,
       },
     },
   },


### PR DESCRIPTION
Fix #2151

## Problem

The search indexer builds each Typesense document by merging register quads with DKG enrichment quads, then does a full blue/green rebuild every run. The DKG read is optional and degrades to an empty result on failure or emptiness. So when the DKG was empty – unreachable, or (as in the 2026-06-23 incident) reduced to a single bootstrap triple – the indexer built enrichment-less documents and atomically swapped them over the previously-good ones, stripping the terminology-source facet and Linked Data summary data off **every** dataset at once.

## Fix

Skip the swap and keep the current index when a DKG endpoint is configured but returns no enrichment while the register has data **and a live index already exists**:

- A run with **no** DKG endpoint configured still builds register-only (a deliberately DKG-less deployment).
- A **cold start** with no index yet still builds register-only (`collectionExists` guard), so the guard never skips into an empty search.
- A configured DKG that returns enrichment rebuilds normally.

The next run self-heals once the DKG is back. This complements dataset-knowledge-graph#385 (make the DKG fail loudly rather than serve empty): #385 keeps the DKG from going empty silently; this keeps an empty DKG from reaching users.

`RunIndexResult`'s skipped variant gains a `reason` (`concurrent-rebuild` | `empty-knowledge-graph`) so the two no-op cases are distinguishable in logs/tests. Both `apps/api` and `apps/crawler` call `runIndex` fire-and-forget, so this is not a breaking change for them.

## Tests

- Rewrote the unreachable-DKG test: it now asserts the run is skipped (`reason: empty-knowledge-graph`) and the previously-enriched document is retained (`class` still set), rather than the old behaviour of rebuilding register-only and dropping enrichment.
- Added a cold-start test: a configured-but-unreachable DKG with fresh aliases still rebuilds register-only.
- Coverage thresholds ratcheted up accordingly.
