### PR TITLE
fix(browser): return 404 for dataset IRIs that break the SPARQL query

### DIFF
--- a/apps/browser/src/routes/dataset/+page.server.ts
+++ b/apps/browser/src/routes/dataset/+page.server.ts
@@ -2,11 +2,26 @@ import { fetchDatasetDetail } from '$lib/services/dataset-detail';
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
+// Characters disallowed inside a SPARQL IRIREF (`<...>`): per the grammar, any
+// codepoint ≤ U+0020 (space, tab, newline, controls) and the set <>"{}|^`\.
+// fetchDatasetDetail interpolates the IRI straight into CONSTRUCT queries, so an
+// IRI carrying any of these would produce a syntactically invalid query that
+// throws — surfacing as a 500 instead of a clean “not found”. The usual trigger
+// is a literal `+` in the IRI shared without percent-encoding: URLSearchParams
+// reads `+` as a space (legacy form-encoding), and the original `+` cannot be
+// recovered, so 404 is the best achievable outcome.
+// eslint-disable-next-line no-control-regex -- matching control codepoints is the point
+const ILLEGAL_IRI_CHARS = /[\x00-\x20<>"{}|^`\\]/;
+
 export const load: PageServerLoad = async ({ url }) => {
   const datasetUri = url.searchParams.get('uri');
 
   if (!datasetUri) {
     error(400, 'Missing required query parameter: uri');
+  }
+
+  if (ILLEGAL_IRI_CHARS.test(datasetUri)) {
+    error(404, 'Dataset not found');
   }
 
   return fetchDatasetDetail(datasetUri);

--- a/apps/browser/src/routes/dataset/page.server.test.ts
+++ b/apps/browser/src/routes/dataset/page.server.test.ts
@@ -50,4 +50,25 @@ describe('/dataset loader', () => {
     }
     expect((caught as { status?: number } | undefined)?.status).toBe(400);
   });
+
+  // A literal `+` shared without percent-encoding decodes to a space, yielding an
+  // IRI that is illegal inside a SPARQL IRIREF. Guard with a 404 rather than
+  // letting the malformed query throw a 500.
+  it('throws a 404 when the uri contains a space (decoded from a literal +)', async () => {
+    let caught: unknown;
+    try {
+      await load(
+        makeEvent(
+          '?uri=' +
+            'https://collecties.zuidafrikahuis.nl/AtlantisPubliek/data/dataset/Zuid-Afrikahuis+-+Archieven',
+        ),
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as { status?: number } | undefined)?.status).toBe(404);
+    expect(fetchDatasetDetail).not.toHaveBeenCalledWith(
+      expect.stringContaining(' '),
+    );
+  });
 });


### PR DESCRIPTION
## Problem

The dataset detail page returned an HTTP 500 (rendering as an empty/error page) for dataset IRIs containing a literal `+`, e.g.:

```
/dataset?uri=https://collecties.zuidafrikahuis.nl/AtlantisPubliek/data/dataset/Zuid-Afrikahuis+-+Archieven
```

The dataset exists in the store under its real IRI (with literal `+`). But when the IRI travels through a query string unencoded, `URLSearchParams` decodes `+` as a space (legacy form-encoding), so `url.searchParams.get('uri')` yields `…/Zuid-Afrikahuis - Archieven`. That space-containing string was interpolated straight into the `CONSTRUCT` queries in `fetchDatasetDetail`, producing a syntactically invalid SPARQL query. The `detailLens.query()` call is the one branch of the load’s `Promise.all` not wrapped in `.catch`, so it rejected and the load threw an unhandled 500.

Our own link builders (`datasetDetailHref` → `encodeQueryValue`) already encode `+` → `%2B`, so internally generated links are unaffected; the trigger is an externally shared or hand-built link with a raw `+`. The properly encoded link (`…Zuid-Afrikahuis%2B-%2BArchieven`) already returns 200.

## Fix

Guard the `/dataset` loader: if the IRI contains any character illegal inside a SPARQL IRIREF (codepoints ≤ U+0020 and the set `<>"{}|^` `` ` `` `\`), return a clean `404` instead of letting the malformed query throw a 500. Once `+` has decoded to a space the original IRI is unrecoverable, so 404 is the best achievable outcome — and it also removes a small query-injection surface.

Includes a regression test for the space-from-literal-`+` case.
