### PR TITLE
build(deps): bump fetch-sparql-endpoint to 7.1.1

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -33,7 +33,7 @@
     "@zazuko/prefixes": "^2.6.1",
     "codemirror": "^6.0.2",
     "feed": "^5.2.1",
-    "fetch-sparql-endpoint": "^7.1.0",
+    "fetch-sparql-endpoint": "^7.1.1",
     "flowbite": "^4.0.2",
     "flowbite-svelte": "^2.0.0-next.14",
     "flowbite-svelte-icons": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "@zazuko/prefixes": "^2.6.1",
         "codemirror": "^6.0.2",
         "feed": "^5.2.1",
-        "fetch-sparql-endpoint": "^7.1.0",
+        "fetch-sparql-endpoint": "^7.1.1",
         "flowbite": "^4.0.2",
         "flowbite-svelte": "^2.0.0-next.14",
         "flowbite-svelte-icons": "^3.1.0",
@@ -23583,9 +23583,9 @@
       }
     },
     "node_modules/fetch-sparql-endpoint": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-7.1.0.tgz",
-      "integrity": "sha512-+C5x3uOqumCvyqDkwXZ31len8qsNfBERWvL6ngqO4m1PSmfqmut4A+2bBbBln48Ag4qudUrG+9qZjFvzY66ubw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-7.1.1.tgz",
+      "integrity": "sha512-OslECjEPhhTg2uXJpuKqucOFLkIaK2TkbUjW+fWgHKLsH4kTZ/J7UKid2w6f3dF0MOEqF0gEO5kiUh3pq3uhfA==",
       "license": "MIT",
       "dependencies": {
         "@traqula/parser-sparql-1-2": "^1.0.0",


### PR DESCRIPTION
Bumps `fetch-sparql-endpoint` 7.1.0 → 7.1.1 ahead of Dependabot's 7-day cooldown.

7.1.1 stops `SparqlEndpointFetcher` from setting a manual `Content-Length` header on POST queries (fetch-sparql-endpoint#96). `Content-Length` is a forbidden request header per the WHATWG Fetch spec, which undici ≥ 7.25 rejects with `InvalidArgumentError: invalid content-length header` — the comunica-side cause behind our `undici` override.

The hoisted copy is shared between the direct dependency here in `apps/browser` and comunica's SPARQL client in `@dataset-register/core` (via `@comunica/query-sparql`), so this one bump clears the comunica side for both.

Note: the `undici` override is still required for **testcontainers**, whose Docker client hits the same forbidden-header rejection under undici 8 and has no upstream fix yet.

Context: comunica/comunica#1722.
