### PR TITLE
fix(browser): upgrade adapter-node to 5.5.7 to restore static asset serving

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -51,7 +51,7 @@
     "@flowbite-svelte-plugins/chart": "^0.2.4",
     "@inlang/paraglide-js": "^2.20.0",
     "@playwright/test": "^1.61.0",
-    "@sveltejs/adapter-node": "^5.5.5",
+    "@sveltejs/adapter-node": "^5.5.7",
     "@sveltejs/kit": "^2.66.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tailwindcss/forms": "^0.5.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
         "@flowbite-svelte-plugins/chart": "^0.2.4",
         "@inlang/paraglide-js": "^2.20.0",
         "@playwright/test": "^1.61.0",
-        "@sveltejs/adapter-node": "^5.5.5",
+        "@sveltejs/adapter-node": "^5.5.7",
         "@sveltejs/kit": "^2.66.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@tailwindcss/forms": "^0.5.11",
@@ -17480,9 +17480,9 @@
       }
     },
     "node_modules/@sveltejs/adapter-node": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.5.tgz",
-      "integrity": "sha512-F3zmmy85l21eXzo3FjCR0IVnVokaDU0RNczOorPyxDmhKfFH+biQMoHoOSTjQyUN64MH/MxywGHDn/fZnLVK1Q==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.7.tgz",
+      "integrity": "sha512-uOfc9eVlI3A37RRSaKcgrheBYPrfJwC9VMqDp8x/O6tlKdcLLvHThSWD0KNIbjQ/d+7bwLGx3vx6aowAcRfd2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Problem

The production dataset browser served HTML but returned **404 for every `/_app/immutable/*` asset** (JS, CSS) and other static files. The SvelteKit app therefore never hydrated: server-rendered pages displayed, but everything client-side was dead – the search results list (loaded client-side from Typesense), facets, and the distribution dropdowns. Typesense and the SPARQL endpoint were healthy throughout; only static asset serving was broken.

## Root cause

`@sveltejs/adapter-node@5.5.5` moved the `dir = dirname(import.meta.url)` computation out of the entry module and into a shared chunk that the build emits under `build/server/chunks/`. As a result `dir` resolved two levels too deep, and the static file server looked for `build/server/chunks/client` instead of `build/client`. `fs.existsSync` failed, so `serve()` returned `undefined` and every static request fell through to SSR and 404’d.

This was pulled in by the svelte-group dependency bump that moved adapter-node `5.5.4 → 5.5.5`. The bug reproduces locally with `node build` (no ingress involved), and a clean local production build of adapter-node 5.5.7 serves all assets with HTTP 200.

## Fix

Upgrade `@sveltejs/adapter-node` to `^5.5.7`. From 5.5.6 onward the path computation lives in `env.js` again (emitted at the `build/` top level), so `build/client` and `build/prerendered` resolve correctly while keeping the `server/chunks/` layout. `^5.5.7` cannot resolve back into the broken 5.5.5/5.5.6 floor.

## Verification

- Reproduced the 404 with the previous build (`node build` → `/_app/immutable/*` 404, including `favicon`).
- Rebuilt with 5.5.7 and confirmed `node build` serves `/_app/immutable/entry/*.js` and `/_app/immutable/assets/*.css` with HTTP 200.
- `nx build`, `lint`, `check`, and `test:unit` for `@dataset-register/browser` all pass.
