### PR TITLE
test(browser): add production-server hydration e2e that would have caught the static-asset outage

### DIFF
--- a/apps/browser/e2e/accessibility.spec.ts
+++ b/apps/browser/e2e/accessibility.spec.ts
@@ -1,5 +1,20 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+
+// Navigate to /datasets and wait for the server-rendered shell. We deliberately
+// do NOT wait for the client-side search or facets to resolve: those depend on
+// backend availability (unreliable in CI, where the facet panel can stay in its
+// loading skeleton indefinitely) and aren't needed for these structural a11y
+// checks. The checks hold whether the facet sidebar is still loading or rendered,
+// because the underlying violations they used to catch are now fixed at the
+// source (named slider handles, h2 facet headings). The search box is
+// server-rendered, so waiting for it is deterministic and backend-independent.
+async function gotoDatasets(page: Page) {
+  await page.goto('/datasets');
+  await expect(
+    page.getByRole('searchbox', { name: /datasets/i }),
+  ).toBeVisible();
+}
 
 // Mock SPARQL response for datasets list
 const mockDatasetsListResponse = {
@@ -78,8 +93,7 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Accessibility', () => {
   test('datasets page has no accessibility violations', async ({ page }) => {
-    await page.goto('/datasets');
-    await page.waitForLoadState('load');
+    await gotoDatasets(page);
 
     const results = await new AxeBuilder({ page }).analyze();
 
@@ -95,8 +109,7 @@ test.describe('Accessibility', () => {
   });
 
   test('page has proper heading structure', async ({ page }) => {
-    await page.goto('/datasets');
-    await page.waitForLoadState('load');
+    await gotoDatasets(page);
 
     // Check for main heading
     const h1 = page.locator('h1');
@@ -113,34 +126,33 @@ test.describe('Accessibility', () => {
   });
 
   test('interactive elements are keyboard accessible', async ({ page }) => {
-    await page.goto('/datasets');
-    await page.waitForLoadState('load');
+    await gotoDatasets(page);
 
-    // Find the search input and verify it can receive focus
-    const searchInput = page.getByRole('searchbox');
+    // Target the main dataset search box specifically: once the facets render,
+    // each foldable facet adds its own search input, so a bare getByRole(
+    // 'searchbox') is ambiguous. The main box's placeholder ("Search datasets…"
+    // / "Zoek datasets…") is the only one containing "datasets".
+    const searchInput = page.getByRole('searchbox', { name: /datasets/i });
     await searchInput.focus();
     await expect(searchInput).toBeFocused();
   });
 
   test('page has lang attribute', async ({ page }) => {
-    await page.goto('/datasets');
-    await page.waitForLoadState('load');
+    await gotoDatasets(page);
 
     const lang = await page.getAttribute('html', 'lang');
     expect(lang).toBeTruthy();
   });
 
   test('images have alt text', async ({ page }) => {
-    await page.goto('/datasets');
-    await page.waitForLoadState('load');
+    await gotoDatasets(page);
 
     const imagesWithoutAlt = await page.locator('img:not([alt])').count();
     expect(imagesWithoutAlt).toBe(0);
   });
 
   test('color contrast meets WCAG AA standards', async ({ page }) => {
-    await page.goto('/datasets');
-    await page.waitForLoadState('load');
+    await gotoDatasets(page);
 
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2aa'])
@@ -154,8 +166,7 @@ test.describe('Accessibility', () => {
   });
 
   test('form inputs have associated labels', async ({ page }) => {
-    await page.goto('/datasets');
-    await page.waitForLoadState('load');
+    await gotoDatasets(page);
 
     const results = await new AxeBuilder({ page })
       .withRules(['label'])

--- a/apps/browser/e2e/hydration.spec.ts
+++ b/apps/browser/e2e/hydration.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+// This spec runs against the real adapter-node production server (`node build`),
+// not `vite preview` — see playwright.config.ts. It guards against production
+// builds that render via SSR but fail to serve their /_app client assets, so the
+// app never hydrates and every client-side feature (search, facets, distribution
+// dropdowns) is silently dead. That is exactly what the adapter-node 5.5.5
+// regression did (sveltejs/kit#16095): SSR pages looked fine while the browser
+// 404'd every /_app/immutable/* chunk.
+//
+// We prove hydration by exercising a purely client-side interaction with no
+// backend dependency: the mobile menu toggle. Its click handler and the
+// `{#if mobileMenuOpen}` overlay only work once the client bundle has loaded and
+// hydrated, so if hydration is broken this test fails.
+test.describe('Production hydration', () => {
+  test('mobile menu toggle works, proving the client bundle hydrated', async ({
+    page,
+  }) => {
+    // Narrow viewport so the hamburger (hidden on lg+) is shown. Use a static
+    // route: on /datasets the client-side search rewrites the URL after load,
+    // which trips the layout's auto-close-on-navigation effect and would close
+    // the menu out from under us.
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto('/validate');
+
+    // SSR renders the menu closed; the toggle button is present immediately.
+    await expect(page.getByRole('button', { name: 'Open menu' })).toBeVisible();
+
+    const closeButton = page.getByRole('button', { name: 'Close menu' });
+
+    // The button's accessible name only flips from "Open menu" to "Close menu"
+    // when the client-side `onclick` handler runs and toggles state — i.e. only
+    // once the app has hydrated. SSR always renders it as "Open menu". Retry the
+    // click until hydration wires up the handler: on a healthy build this passes
+    // within a moment; on a build whose /_app assets 404 it never hydrates, the
+    // click does nothing, and this fails at the timeout.
+    await expect(async () => {
+      await page.getByRole('button', { name: 'Open menu' }).click();
+      await expect(closeButton).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 15000 });
+  });
+});

--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -48,6 +48,8 @@
   "facets_size": "Size",
   "facets_size_min": "Min",
   "facets_size_max": "Max",
+  "facets_size_min_label": "Minimum dataset size",
+  "facets_size_max_label": "Maximum dataset size",
   "facets_remove_filter": "Remove filter",
   "facets_search": "Search...",
   "facets_show_more": "Show more",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -48,6 +48,8 @@
   "facets_size": "Grootte",
   "facets_size_min": "Min",
   "facets_size_max": "Max",
+  "facets_size_min_label": "Minimale datasetgrootte",
+  "facets_size_max_label": "Maximale datasetgrootte",
   "facets_remove_filter": "Filter verwijderen",
   "facets_search": "Zoek...",
   "facets_show_more": "Toon meer",

--- a/apps/browser/playwright.config.ts
+++ b/apps/browser/playwright.config.ts
@@ -2,6 +2,18 @@ import { defineConfig, devices } from '@playwright/test';
 
 const isCI = !!process.env.CI;
 
+// In CI we run two servers so we test what we actually ship:
+//   - `vite preview` (port 4173) backs the accessibility specs;
+//   - `node build` (port 4174) is the real adapter-node production server and
+//     backs e2e/hydration.spec.ts. `vite preview` serves /_app assets through
+//     Vite, so it would NOT catch a broken production build (e.g. the
+//     adapter-node 5.5.5 regression that 404'd every /_app asset and left the
+//     app un-hydrated — sveltejs/kit#16095). Only `node build` exercises that path.
+// Locally a single dev server backs both projects.
+const previewURL = 'http://localhost:4173';
+const productionURL = 'http://localhost:4174';
+const devURL = 'http://localhost:5173';
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -11,21 +23,47 @@ export default defineConfig({
   reporter: isCI ? 'github' : 'html',
   timeout: isCI ? 60000 : 30000,
   use: {
-    baseURL: isCI ? 'http://localhost:4173' : 'http://localhost:5173',
     trace: 'on-first-retry',
   },
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      testIgnore: '**/hydration.spec.ts',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: isCI ? previewURL : devURL,
+      },
+    },
+    {
+      name: 'production',
+      testMatch: '**/hydration.spec.ts',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: isCI ? productionURL : devURL,
+      },
     },
   ],
-  webServer: {
-    command: isCI ? 'npm run preview' : 'npm run dev',
-    url: isCI
-      ? 'http://localhost:4173/datasets'
-      : 'http://localhost:5173/datasets',
-    reuseExistingServer: !isCI,
-    timeout: 120000,
-  },
+  webServer: isCI
+    ? [
+        {
+          command: 'npm run preview',
+          url: `${previewURL}/datasets`,
+          reuseExistingServer: false,
+          timeout: 120000,
+        },
+        {
+          command: 'PORT=4174 node build',
+          url: `${productionURL}/datasets`,
+          reuseExistingServer: false,
+          timeout: 120000,
+        },
+      ]
+    : [
+        {
+          command: 'npm run dev',
+          url: `${devURL}/datasets`,
+          reuseExistingServer: true,
+          timeout: 120000,
+        },
+      ],
 });

--- a/apps/browser/src/lib/components/SearchFacet.svelte
+++ b/apps/browser/src/lib/components/SearchFacet.svelte
@@ -135,14 +135,14 @@
 </script>
 
 <div class="mb-6">
-  <h3
+  <h2
     class="relative text-base font-semibold text-gray-900 dark:text-gray-100 mb-3 tracking-tight flex items-center"
   >
     {title}
     {#if explanation}
       <FacetHelper {explanation} />
     {/if}
-  </h3>
+  </h2>
 
   <!-- Search/Filter Input -->
   {#if values.length > FOLD_LIMIT}

--- a/apps/browser/src/lib/components/SizeRangeFacet.svelte
+++ b/apps/browser/src/lib/components/SizeRangeFacet.svelte
@@ -136,14 +136,14 @@
 </script>
 
 <div class="mb-6">
-  <h3
+  <h2
     class="relative text-base font-semibold text-gray-900 dark:text-gray-100 mb-3 tracking-tight flex items-center"
   >
     {m.facets_size()}
     {#if explanation}
       <FacetHelper {explanation} />
     {/if}
-  </h3>
+  </h2>
 
   <div class="space-y-4" class:active={isActive}>
     <!-- Histogram -->
@@ -182,6 +182,7 @@
           pushy
           float
           formatter={pipFormatter}
+          ariaLabels={[m.facets_size_min_label(), m.facets_size_max_label()]}
           on:stop={handleSliderStop}
         />
       {:else}


### PR DESCRIPTION
## Why

The adapter-node 5.5.5 outage (#2163) shipped a production build that rendered via SSR but **404'd every `/_app/immutable/*` asset**, so the app never hydrated and search, facets and distribution dropdowns were silently dead. Our e2e suite did not catch it because it runs against **`vite preview`**, which serves assets through Vite — not the real adapter-node `node build` server where the bug lives.

## What

- Run a second Playwright project, `production`, against the real `node build` server (port 4174). The existing accessibility specs keep running against `vite preview` (port 4173); locally a single dev server backs both.
- Add `e2e/hydration.spec.ts`: at a mobile viewport, open the mobile menu — a purely client-side interaction — and assert the toggle works. The hamburger's accessible name only flips `Open menu` → `Close menu` once the client `onclick` handler runs, i.e. only after the bundle has hydrated. SSR alone can’t make it pass.

## Verification

Built locally and pointed the test at the real server:

- Healthy build (adapter-node 5.5.7): **passes**.
- Build forced onto the broken adapter-node 5.5.5: **fails** (assets 404 → no hydration → toggle never works).

So this test would have caught #2163.

## Note

Stacked on #2164 (deterministic accessibility e2e) so CI is green; please merge #2164 first. GitHub will retarget this PR to `main` automatically once #2164 lands.
