### PR TITLE
test(browser): run e2e on the production server and add a docker:smoke gate

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -99,6 +99,16 @@
         "options": {
           "outputPath": "apps/browser/build"
         }
+      },
+      "docker:smoke": {
+        "executor": "nx:run-commands",
+        "dependsOn": [
+          "docker:build"
+        ],
+        "cache": false,
+        "options": {
+          "command": "./apps/docker-smoke.sh apps-browser 'Listening on' /datasets"
+        }
       }
     }
   }

--- a/apps/browser/playwright.config.ts
+++ b/apps/browser/playwright.config.ts
@@ -2,16 +2,14 @@ import { defineConfig, devices } from '@playwright/test';
 
 const isCI = !!process.env.CI;
 
-// In CI we run two servers so we test what we actually ship:
-//   - `vite preview` (port 4173) backs the accessibility specs;
-//   - `node build` (port 4174) is the real adapter-node production server and
-//     backs e2e/hydration.spec.ts. `vite preview` serves /_app assets through
-//     Vite, so it would NOT catch a broken production build (e.g. the
-//     adapter-node 5.5.5 regression that 404'd every /_app asset and left the
-//     app un-hydrated — sveltejs/kit#16095). Only `node build` exercises that path.
-// Locally a single dev server backs both projects.
-const previewURL = 'http://localhost:4173';
-const productionURL = 'http://localhost:4174';
+// In CI we run the whole suite against the real adapter-node production server
+// (`node build`) — the same artifact we ship in the Docker image — so a broken
+// production build (e.g. the adapter-node 5.5.5 regression that 404'd every
+// /_app asset and left the app un-hydrated, sveltejs/kit#16095) is caught.
+// `vite preview` serves /_app through Vite and would mask that, so we don't use
+// it. Locally we use the dev server for fast iteration; the production build path
+// is exercised in CI (and by the docker:smoke gate against the actual image).
+const ciURL = 'http://localhost:4173';
 const devURL = 'http://localhost:5173';
 
 export default defineConfig({
@@ -23,47 +21,19 @@ export default defineConfig({
   reporter: isCI ? 'github' : 'html',
   timeout: isCI ? 60000 : 30000,
   use: {
+    baseURL: isCI ? ciURL : devURL,
     trace: 'on-first-retry',
   },
   projects: [
     {
       name: 'chromium',
-      testIgnore: '**/hydration.spec.ts',
-      use: {
-        ...devices['Desktop Chrome'],
-        baseURL: isCI ? previewURL : devURL,
-      },
-    },
-    {
-      name: 'production',
-      testMatch: '**/hydration.spec.ts',
-      use: {
-        ...devices['Desktop Chrome'],
-        baseURL: isCI ? productionURL : devURL,
-      },
+      use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: isCI
-    ? [
-        {
-          command: 'npm run preview',
-          url: `${previewURL}/datasets`,
-          reuseExistingServer: false,
-          timeout: 120000,
-        },
-        {
-          command: 'PORT=4174 node build',
-          url: `${productionURL}/datasets`,
-          reuseExistingServer: false,
-          timeout: 120000,
-        },
-      ]
-    : [
-        {
-          command: 'npm run dev',
-          url: `${devURL}/datasets`,
-          reuseExistingServer: true,
-          timeout: 120000,
-        },
-      ],
+  webServer: {
+    command: isCI ? 'PORT=4173 node build' : 'npm run dev',
+    url: `${isCI ? ciURL : devURL}/datasets`,
+    reuseExistingServer: !isCI,
+    timeout: 120000,
+  },
 });

--- a/apps/docker-smoke.sh
+++ b/apps/docker-smoke.sh
@@ -6,11 +6,19 @@
 # `ERR_MODULE_NOT_FOUND` at boot – passes the build yet crashes in production (the
 # #2128 incident). This is the gate that catches that class before it ships.
 #
-# Usage: docker-smoke.sh <image-tag> <startup-log-regex>
+# For HTTP server images an optional <http-path> additionally asserts that the
+# running container serves that path AND a client asset it references (a
+# /_app/immutable/*.js chunk) with HTTP 200. `node build` can boot fine yet 404
+# every /_app asset if the build is broken (the adapter-node 5.5.5 regression,
+# sveltejs/kit#16095); a log-only check would miss that, so we probe real HTTP.
+#
+# Usage: docker-smoke.sh <image-tag> <startup-log-regex> [http-path] [container-port]
 set -euo pipefail
 
 image="$1"
 startup_pattern="$2"
+http_path="${3:-}"
+container_port="${4:-3000}"
 container="smoke-${image}-$$"
 
 cleanup() { docker rm -f "$container" >/dev/null 2>&1 || true; }
@@ -21,13 +29,57 @@ trap cleanup EXIT
 # unreachable URL does not block boot. CRAWLER_SCHEDULE keeps the crawler
 # scheduling (idle) instead of crawling the dummy endpoint on startup. Setting
 # TYPESENSE_* exercises the search-indexer import chain that #2128 broke.
-docker run -d --name "$container" \
-  -e SPARQL_URL=http://example.invalid/sparql \
-  -e SPARQL_ACCESS_TOKEN=dummy \
-  -e CRAWLER_SCHEDULE="0 0 * * *" \
-  -e TYPESENSE_HOST=localhost \
-  -e TYPESENSE_API_KEY=dummy \
-  "$image" >/dev/null
+# Extra args (e.g. a port publish) are forwarded via "$@"; passing none is safe
+# under `set -u`, unlike an empty array on older bash.
+run_container() {
+  docker run -d --name "$container" "$@" \
+    -e SPARQL_URL=http://example.invalid/sparql \
+    -e SPARQL_ACCESS_TOKEN=dummy \
+    -e CRAWLER_SCHEDULE="0 0 * * *" \
+    -e TYPESENSE_HOST=localhost \
+    -e TYPESENSE_API_KEY=dummy \
+    "$image" >/dev/null
+}
+
+# Publish the HTTP port (to a random host port) only when an HTTP probe is asked
+# for, so log-only smokes (crawler, api) keep their original behaviour.
+if [ -n "$http_path" ]; then
+  run_container -p "$container_port"
+else
+  run_container
+fi
+
+# Assert the running container serves <http-path> and a /_app asset it references,
+# both with HTTP 200. Exits the script non-zero on any failure.
+http_check() {
+  local base host_port asset path_code asset_code html
+  host_port="$(docker port "$container" "${container_port}/tcp" | head -1 | sed 's/.*://')"
+  if [ -z "$host_port" ]; then
+    echo "FAIL: $image did not publish container port $container_port"
+    exit 1
+  fi
+  base="http://localhost:${host_port}"
+
+  path_code="$(curl -s -o /dev/null -w '%{http_code}' "${base}${http_path}" || true)"
+  if [ "$path_code" != "200" ]; then
+    echo "FAIL: $image served ${http_path} with HTTP ${path_code:-000} (expected 200)"
+    exit 1
+  fi
+
+  html="$(curl -s "${base}${http_path}" || true)"
+  asset="$(printf '%s' "$html" | grep -oE '/_app/immutable/[^"]+\.js' | head -1 || true)"
+  if [ -z "$asset" ]; then
+    echo "FAIL: $image served ${http_path} but it references no /_app/immutable/*.js asset"
+    exit 1
+  fi
+
+  asset_code="$(curl -s -o /dev/null -w '%{http_code}' "${base}${asset}" || true)"
+  if [ "$asset_code" != "200" ]; then
+    echo "FAIL: $image served the page but 404'd its client asset ${asset} (HTTP ${asset_code:-000}) — broken static serving"
+    exit 1
+  fi
+  echo "PASS: $image serves ${http_path} and ${asset} with HTTP 200"
+}
 
 for _ in $(seq 1 30); do
   logs="$(docker logs "$container" 2>&1)"
@@ -45,6 +97,9 @@ for _ in $(seq 1 30); do
     exit 1
   fi
   if echo "$logs" | grep -qE "$startup_pattern"; then
+    if [ -n "$http_path" ]; then
+      http_check
+    fi
     echo "PASS: $image reached startup (matched /$startup_pattern/)"
     exit 0
   fi

--- a/apps/docker-smoke.sh
+++ b/apps/docker-smoke.sh
@@ -53,7 +53,7 @@ fi
 # both with HTTP 200. Exits the script non-zero on any failure.
 http_check() {
   local base host_port asset path_code asset_code html
-  host_port="$(docker port "$container" "${container_port}/tcp" | head -1 | sed 's/.*://')"
+  host_port="$(docker port "$container" "${container_port}/tcp" | head -1 | sed 's/.*://' || true)"
   if [ -z "$host_port" ]; then
     echo "FAIL: $image did not publish container port $container_port"
     exit 1


### PR DESCRIPTION
## Why

We deploy `adapter-node`'s `node build` artifact (in a Docker image), but our e2e ran against `vite preview` — a dev-only server that serves `/_app` through Vite. That's exactly what hid the adapter-node 5.5.5 outage (#2163): SSR looked fine while the real server 404'd every asset. This makes us test what we actually ship, at two layers.

## Changes

**e2e → production server.** Run the whole Playwright suite against the real `node build` server in CI (port 4173); use the dev server locally for fast iteration. This collapses the preview + production two-project split introduced in #2165 into a single project — simpler config, one server (which also boots ~1.5s faster than `vite preview`), and every test now exercises real adapter-node static serving.

**Add a browser `docker:smoke`.** The browser had no container-level gate (only crawler and api did, and those are log-only). The new gate boots the actual built image and asserts it serves `/datasets` **and** a `/_app/immutable/*.js` chunk it references with **HTTP 200** — catching the 5.5.5 class at the packaging layer (`.dockerignore`, pruned prod deps, alpine), independently of the e2e layer.

`apps/docker-smoke.sh` gains an optional `<http-path>` arg for HTTP-server images; the crawler/api log-only smokes are unchanged. Reworked to avoid an empty-array expansion so it stays safe under `set -u` on bash 3.2 (macOS default).

## Verification (locally, Docker available)

- e2e: 12 tests green against `node build` (single project).
- `docker:smoke`: **passes** on a good image (`serves /datasets and /_app/immutable/entry/start.*.js with HTTP 200`); **fails** on an image built with the broken adapter-node 5.5.5 (`404'd its client asset … — broken static serving`).

## Follow-up
Builds on #2164 and #2165 (now merged): those added the production hydration test and the a11y fixes; this consolidates the e2e onto the production server and adds the container-layer gate.
