### PR TITLE
feat(core): thread distribution-probe onProgress through validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14700,24 +14700,33 @@
       }
     },
     "node_modules/@lde/distribution-health": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@lde/distribution-health/-/distribution-health-0.2.1.tgz",
-      "integrity": "sha512-vYmUSPRhC4A6WTO5FhnbiuH45AWxTSyiSWj/+z4ffpp46R/ZVddd+ij9DcQpM0gWiGQ4bGA/bn0tx2XXA03ibQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@lde/distribution-health/-/distribution-health-0.2.3.tgz",
+      "integrity": "sha512-6uMqgdAA+9/qkg6s8MXJ9E0VwdEo25O6DC2wEOt1zhxt7+/5GAlbEZR3IeCxy1azwi9v8VR87XCwABCQtMinDg==",
       "license": "MIT",
       "dependencies": {
-        "@lde/distribution-probe": "0.2.1",
-        "@lde/sparql-importer": "0.6.5",
+        "@lde/distribution-probe": "^0.2.2",
+        "@lde/sparql-importer": "^0.6.5",
         "tslib": "^2.3.0"
       }
     },
     "node_modules/@lde/distribution-probe": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@lde/distribution-probe/-/distribution-probe-0.2.1.tgz",
-      "integrity": "sha512-JIjZNBM6PT6IgsOcqG0PoxOGk9nTvoQnwhM8aaRo9ERH4FcqcCZ/N+INwiKuDccWbf7rJ8EZ7p4oeaMt3g+ysQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@lde/distribution-probe/-/distribution-probe-0.2.3.tgz",
+      "integrity": "sha512-zeaWM0pEZoC23mCygG+KBDQoKO+0CwmX8EiQr//jPbyttqAXUNMFl02RIjg8dRpbeK5z3OTA6/ncxlABldJgjA==",
       "license": "MIT",
       "dependencies": {
-        "@lde/dataset": "0.7.7",
+        "@lde/dataset": "^0.7.8",
         "rdf-parse": "^5.0.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@lde/distribution-probe/node_modules/@lde/dataset": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@lde/dataset/-/dataset-0.7.8.tgz",
+      "integrity": "sha512-utt83XW0tJgg8tO7mjEJW3fFJzjhYUVOK8Hu7XET2QY88gtPyb28fA5wUnS8dLRmf7EKuVMsGfzWs2jJm4LCyA==",
+      "license": "MIT",
+      "dependencies": {
         "tslib": "^2.3.0"
       }
     },
@@ -14756,27 +14765,27 @@
       "license": "MIT"
     },
     "node_modules/@lde/pipeline": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@lde/pipeline/-/pipeline-0.31.3.tgz",
-      "integrity": "sha512-PybQAgeeNZCmoH6Mr3tPb4FYA7ijSu5tX4aJTvNcCFjhPtx9DdVolUxG44eGUART9i/UWHpKrzQGQz2OEjVk2A==",
+      "version": "0.31.5",
+      "resolved": "https://registry.npmjs.org/@lde/pipeline/-/pipeline-0.31.5.tgz",
+      "integrity": "sha512-diWRe1qm16PgiKi7BTV6+CaYVp+plQPqgvfDJout6H6ktCZfd30WSwPR/QSizN1QlpTT40O/v9aWvGWhGJXcIA==",
       "license": "MIT",
       "dependencies": {
-        "@lde/dataset": "0.7.7",
-        "@lde/dataset-registry-client": "0.8.4",
-        "@lde/distribution-health": "0.2.1",
-        "@lde/distribution-probe": "0.2.1",
-        "@lde/sparql-importer": "0.6.5",
-        "@lde/sparql-server": "0.4.11",
+        "@lde/dataset": "^0.7.7",
+        "@lde/dataset-registry-client": "^0.8.4",
+        "@lde/distribution-health": "^0.2.2",
+        "@lde/distribution-probe": "^0.2.2",
+        "@lde/sparql-importer": "^0.6.5",
+        "@lde/sparql-server": "^0.4.11",
         "@rdfjs/namespace": "^2.0.1",
         "@rdfjs/types": "^2.0.1",
         "@tpluscode/rdf-ns-builders": "^5.0.0",
-        "@traqula/generator-sparql-1-1": "^1.1.5",
+        "@traqula/generator-sparql-1-1": "^1.1.6",
         "@traqula/parser-sparql-1-1": "^1.1.5",
         "@traqula/rules-sparql-1-1": "^1.1.0",
-        "fetch-sparql-endpoint": "^7.1.0",
+        "fetch-sparql-endpoint": "^7.1.1",
         "filenamify-url": "^4.0.0",
         "is-network-error": "^1.3.2",
-        "n3": "^2.0.1",
+        "n3": "^2.1.0",
         "p-retry": "^8.0.0",
         "rdf-string": "^2.0.1",
         "tslib": "^2.3.0"
@@ -27111,9 +27120,9 @@
       "license": "MIT"
     },
     "node_modules/n3": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-2.0.4.tgz",
-      "integrity": "sha512-d2Sr4vvqombySfOARjw5jQky0EYMwkEXuQQjYe2glasDdI3hAT3l00aJZbAmR+AA59eFNjJbDkHCq9l5Dm2DIg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-2.1.0.tgz",
+      "integrity": "sha512-+05H/h40wRyROglcVGrNZAwBu0Nc87luKhiTV95aGBGX1YyITtpwftHwyhT5YoZr4soXJWrzxqC1CHPdGqV63g==",
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
@@ -32650,7 +32659,7 @@
         "@comunica/types": "^5.2.3",
         "@lde/dataset": "^0.7.7",
         "@lde/distribution-health": "^0.2.0",
-        "@lde/distribution-probe": "^0.2.1",
+        "@lde/distribution-probe": "^0.2.2",
         "@lde/pipeline": "^0.31.0",
         "@lde/text-normalization": "^0.1.0",
         "@opentelemetry/api": "^1.9.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "@comunica/types": "^5.2.3",
     "@lde/dataset": "^0.7.7",
     "@lde/distribution-health": "^0.2.0",
-    "@lde/distribution-probe": "^0.2.1",
+    "@lde/distribution-probe": "^0.2.2",
     "@lde/pipeline": "^0.31.0",
     "@lde/text-normalization": "^0.1.0",
     "@opentelemetry/api": "^1.9.1",

--- a/packages/core/src/distribution-probe/probe.ts
+++ b/packages/core/src/distribution-probe/probe.ts
@@ -61,6 +61,14 @@ export interface ProbeSeverities {
   rateLimited: NamedNode;
 }
 
+/**
+ * Notified as the probe stage advances: `completed` of `total` distinct endpoints probed. Fired
+ * once with `(0, total)` before the first probe so a caller can show a determinate indicator from
+ * the start, then once after each probe settles, ending at `(total, total)`. `total` counts only
+ * the endpoints actually probed (representatives with a parsable URL), not synthetic candidates.
+ */
+export type ProbeProgressListener = (completed: number, total: number) => void;
+
 export interface DistributionProbeStageOptions {
   /**
    * When set, each failing probe is assessed against this store and emitted only once the
@@ -186,7 +194,10 @@ export class DistributionProbeStage {
     };
   }
 
-  public async run(input: DatasetCore): Promise<Quad[]> {
+  public async run(
+    input: DatasetCore,
+    onProgress?: ProbeProgressListener,
+  ): Promise<Quad[]> {
     const candidates = collectDistributions(input);
     if (candidates.length === 0) return [];
 
@@ -212,7 +223,7 @@ export class DistributionProbeStage {
     // Probe every distinct endpoint — bounding total fan-out and the per-host burst so a
     // catalogue with many distributions on one server does not trip its rate limiter — then
     // evaluate each result into a verdict (and health/validity records).
-    const evaluated = await this.probeGroups(groups);
+    const evaluated = await this.probeGroups(groups, onProgress);
 
     const quads: Quad[] = [];
     for (let index = 0; index < groups.length; index++) {
@@ -244,7 +255,10 @@ export class DistributionProbeStage {
     return quads;
   }
 
-  private async probeGroups(groups: ProbeGroup[]): Promise<
+  private async probeGroups(
+    groups: ProbeGroup[],
+    onProgress?: ProbeProgressListener,
+  ): Promise<
     Array<{
       verdict: ProbeVerdict;
       record: DistributionHealthRecord | null;
@@ -267,6 +281,9 @@ export class DistributionProbeStage {
         (entry): entry is { index: number; distribution: Distribution } =>
           entry.distribution !== null,
       );
+    // Announce the total up front — probeMany only reports after each probe settles — so a caller
+    // can render a determinate indicator from 0 before the first endpoint responds.
+    onProgress?.(0, probeable.length);
     const results = await probeMany(
       probeable.map((entry) => entry.distribution),
       {
@@ -274,6 +291,7 @@ export class DistributionProbeStage {
         validateRdfContent: true,
         concurrency: this.probeConcurrency,
         perHostConcurrency: this.probePerHostConcurrency,
+        onProgress,
       },
     );
     const resultByGroup: (ProbeResultType | null)[] = new Array(

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -8,10 +8,21 @@ import type { ValidationReport } from 'shacl-engine';
 import { Validator as ShaclValidator } from 'shacl-engine';
 import { validations as sparqlValidations } from 'shacl-engine/sparql.js';
 import { standardizeSchemaOrgPrefix } from './transform.ts';
-import type { DistributionProbeStage } from './distribution-probe/probe.ts';
+import type {
+  DistributionProbeStage,
+  ProbeProgressListener,
+} from './distribution-probe/probe.ts';
 
 export interface Validator {
-  validate(datasets: DatasetCore): Promise<ValidationResult>;
+  /**
+   * Validate the dataset(s). `onProgress`, when given, is forwarded to the distribution probe
+   * stage so a caller can report progress while many distributions are checked; validators that
+   * do no probing (e.g. {@link ShaclEngineValidator}) ignore it.
+   */
+  validate(
+    datasets: DatasetCore,
+    onProgress?: ProbeProgressListener,
+  ): Promise<ValidationResult>;
 }
 
 /**
@@ -66,12 +77,16 @@ export class CompositeValidator implements Validator {
     private readonly probeStage: DistributionProbeStage,
   ) {}
 
-  public async validate(input: DatasetCore): Promise<ValidationResult> {
+  public async validate(
+    input: DatasetCore,
+    onProgress?: ProbeProgressListener,
+  ): Promise<ValidationResult> {
     const shaclResult = await this.shacl.validate(input);
     if (shaclResult.state !== 'valid') return shaclResult;
 
     const probeQuads = await this.probeStage.run(
       standardizeSchemaOrgPrefix(input),
+      onProgress,
     );
     if (probeQuads.length === 0) return shaclResult;
 

--- a/packages/core/test/distribution-probe.test.ts
+++ b/packages/core/test/distribution-probe.test.ts
@@ -338,6 +338,52 @@ describe('DistributionProbeStage', () => {
     expect(resultPath?.object.equals(dcat('accessURL'))).toBe(true);
   });
 
+  it('forwards probe progress, announcing the total before the first probe', async () => {
+    // Two distinct SPARQL endpoints on different hosts → two probes. The stage announces
+    // (0, total) up front, then probeMany reports (1, total) and (2, total) as they settle.
+    for (const host of ['a.example', 'b.example']) {
+      nock(`https://${host}`)
+        .post('/sparql')
+        .reply(200, '{"head":{"vars":[]},"results":{"bindings":[]}}', {
+          'Content-Type': 'application/sparql-results+json',
+        });
+    }
+
+    const dataset = factory.dataset();
+    const datasetNode = factory.namedNode('https://example.org/d-progress');
+    for (const host of ['a.example', 'b.example']) {
+      const distributionNode = factory.blankNode();
+      dataset.add(
+        factory.quad(datasetNode, dcat('distribution'), distributionNode),
+      );
+      dataset.add(
+        factory.quad(
+          distributionNode,
+          dcat('accessURL'),
+          factory.namedNode(`https://${host}/sparql`),
+        ),
+      );
+      dataset.add(
+        factory.quad(
+          distributionNode,
+          dct('conformsTo'),
+          factory.namedNode('https://www.w3.org/TR/sparql11-protocol/'),
+        ),
+      );
+    }
+
+    const calls: Array<[number, number]> = [];
+    await new DistributionProbeStage().run(dataset, (completed, total) =>
+      calls.push([completed, total]),
+    );
+
+    expect(calls).toEqual([
+      [0, 2],
+      [1, 2],
+      [2, 2],
+    ]);
+  });
+
   it('emits a sh:Warning, not a sh:Violation, for an HTTP 429 probe result', async () => {
     // A 429 means the Register was rate-limited while probing, not that the publisher’s
     // distribution is faulty, so it must never invalidate the dataset — even here on the strict


### PR DESCRIPTION
## What

Threads an optional `onProgress(completed, total)` callback through the `Validator` interface → `CompositeValidator` → `DistributionProbeStage.run` → `probeMany`. The stage announces `(0, total)` before the first probe, so a caller can render a **determinate** progress indicator while a catalogue's distributions are checked.

This is the foundation (part 1) for surfacing **validation progress** in the UI — validating a catalogue with many distributions can take a while (especially with the per-host probe cap throttling the burst), and the validate page currently just spins. The API streaming and the Validate-URL button fill follow in subsequent PRs.

## Dependency dedup

Bumps `@lde/distribution-probe` to `0.2.3` (for the `onProgress` option, ldelements/lde#527) plus `@lde/distribution-health@0.2.3` and `@lde/pipeline@0.31.5`, which now **caret-pin** `distribution-probe` (ldelements/lde#528).

That matters: before #528 those two pinned `distribution-probe` to an exact version, so consuming a newer probe here would have forced a second copy of the package and broken `@lde/distribution-health`'s `probeResultToVerdict()` — it does an `instanceof ProbeResultType` that silently fails across two copies (a dual-package hazard). With caret pins the tree dedupes to a **single** `distribution-probe`. The lockfile change is minimal (only these three resolve to new versions).

## Tests

- New: the stage forwards progress — `(0, N)` up front, then once per probe, ending at `(N, N)`.
- Full `@dataset-register/core` suite green (111 tests).
