### PR TITLE
feat(validate): stream URL validation progress over Server-Sent Events

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "@dataset-register/search-indexer": "*",
     "@fastify/bearer-auth": "^10.1.2",
     "@fastify/cors": "^11.0.0",
+    "@fastify/sse": "^0.4.0",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",
     "@lde/fastify-rdf": "^0.4.6",

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,6 +1,7 @@
 import fastify, {
   FastifyError,
   FastifyInstance,
+  FastifyPluginAsync,
   FastifyReply,
   FastifyServerOptions,
 } from 'fastify';
@@ -15,10 +16,12 @@ import {
   FetchError,
   HttpError,
   NoDatasetFoundAtUrl,
+  ProbeProgressListener,
   RatingStore,
   Registration,
   registrationsCounter,
   RegistrationStore,
+  serializeQuads,
   validationsCounter,
   Validator,
 } from '@dataset-register/core';
@@ -28,10 +31,16 @@ import { Server } from 'http';
 import * as psl from 'psl';
 import fastifySwagger from '@fastify/swagger';
 import fastifyCors from '@fastify/cors';
+import fastifySse from '@fastify/sse';
 import fastifyRdf from '@lde/fastify-rdf';
 import fastifySwaggerUi from '@fastify/swagger-ui';
 import type { DatasetCore } from '@rdfjs/types';
 import { dirname } from 'node:path';
+
+/** Whether the client asked for a Server-Sent Events response. */
+function wantsEventStream(accept: string | undefined): boolean {
+  return accept?.includes('text/event-stream') ?? false;
+}
 
 export async function server(
   datasetStore: DatasetStore,
@@ -87,6 +96,13 @@ export async function server(
       }
       return reply.code(error.statusCode ?? 500).send(error);
     });
+
+  // Await so the plugin’s `onRoute` hook is installed before the routes below
+  // are registered; otherwise the `{ sse: true }` wrapper never wraps them.
+  // @fastify/sse@0.4.0 ships ESM-style `export default` types in a CJS package,
+  // so under nodenext the default import mistypes as the module namespace; at
+  // runtime it is the plugin, so cast to the expected plugin type.
+  await server.register(fastifySse as unknown as FastifyPluginAsync);
 
   const datasetsRequest = {
     schema: {
@@ -169,6 +185,83 @@ export async function server(
     }
   }
 
+  /**
+   * Stream validation over Server-Sent Events: a `progress` event per probed
+   * distribution, then a final `report` event (the JSON-LD SHACL report) or an
+   * `error` event when no dataset was found. Assumes the dataset was already
+   * resolved.
+   *
+   * Frames go through `@fastify/sse` (`reply.sse`), which formats them, manages
+   * the `text/event-stream` headers, and closes the stream when the handler
+   * returns — all on the managed reply, so CORS and the other hooks still run.
+   */
+  async function validateStreaming(
+    reply: FastifyReply,
+    dataset: DatasetCore,
+    url: URL,
+  ): Promise<number> {
+    // `reply.sse.send` is async and not internally queued, but the probe emits
+    // progress from a synchronous callback, so chain the writes to keep frames
+    // ordered and ensure they are all flushed before the route wrapper closes.
+    let writes = Promise.resolve();
+    const send = (message: { event: string; data: unknown }) => {
+      writes = writes.then(() => reply.sse.send(message));
+      return writes;
+    };
+
+    const onProgress: ProbeProgressListener = (completed, total) => {
+      void send({ event: 'progress', data: { completed, total } });
+    };
+
+    try {
+      const validation = await validator.validate(dataset, onProgress);
+
+      if (validation.state === 'no-dataset') {
+        const error = new NoDatasetFoundAtUrl(url);
+        void send({
+          event: 'error',
+          data: {
+            statusCode: 406,
+            title: error.message,
+            description: error.cause,
+          },
+        });
+        await writes;
+        return 406;
+      }
+
+      // Both `valid` and `invalid` carry the SHACL report; the browser reads
+      // sh:conforms to tell them apart, exactly as on the non-streaming path.
+      // Send the parsed JSON-LD so the plugin's default serializer encodes it
+      // like every other frame (no per-frame string/object special-casing).
+      void send({
+        event: 'report',
+        data: JSON.parse(
+          await serializeQuads(validation.errors, 'application/ld+json'),
+        ),
+      });
+      await writes;
+      // Mirror the non-streaming status so validationsCounter stays comparable
+      // across the streaming and one-shot paths.
+      return validation.state === 'invalid' ? 400 : 200;
+    } catch (error) {
+      // validator.validate threw, or a frame write failed (e.g. the client
+      // disconnected). The response is already streaming, so surface the cause
+      // as an error frame instead of a silent close, and report 500 — what the
+      // non-streaming path's error handler would have recorded.
+      reply.log.error(error, 'Streaming validation failed');
+      try {
+        await reply.sse.send({
+          event: 'error',
+          data: { statusCode: 500, title: 'Validation failed' },
+        });
+      } catch {
+        // The connection is already gone; nothing more we can send.
+      }
+      return 500;
+    }
+  }
+
   async function domainIsAllowed(url: URL): Promise<boolean> {
     const result = psl.parse(url.hostname);
     if (result.error || result.domain === null) {
@@ -227,24 +320,49 @@ export async function server(
     return reply;
   });
 
-  server.put('/datasets/validate', datasetsRequest, async (request, reply) => {
-    const url = new URL((request.body as { '@id': string })['@id']);
-    request.log.info(url.toString());
-    const resolved = await resolveDataset(url, reply);
+  server.put(
+    '/datasets/validate',
+    {
+      ...datasetsRequest,
+      // `@fastify/sse` only engages for `Accept: text/event-stream` requests and
+      // calls the original handler unchanged otherwise, so the default JSON-LD
+      // response stays byte-for-byte identical for existing clients.
+      sse: { heartbeat: false },
+    },
+    async (request, reply) => {
+      const url = new URL((request.body as { '@id': string })['@id']);
+      request.log.info(url.toString());
+      const resolved = await resolveDataset(url, reply);
 
-    if (resolved) {
-      await validate(resolved.data, reply, resolved.url);
-    }
-    validationsCounter.add(1, {
-      status: reply.statusCode,
-    });
-    request.log.info(
-      `Validated at ${Math.round(
-        process.memoryUsage().rss / 1024 / 1024,
-      )} MB memory`,
-    );
-    return reply;
-  });
+      // `wantsEventStream` must match the Accept check `@fastify/sse` uses to set
+      // up `reply.sse`; keep them in sync. On a stream the wire status is always
+      // 200, so take the logical status from `validateStreaming` for the metric.
+      let streaming = false;
+      let status = reply.statusCode;
+      if (resolved && wantsEventStream(request.headers.accept)) {
+        streaming = true;
+        status = await validateStreaming(reply, resolved.data, resolved.url);
+      } else if (resolved) {
+        await validate(resolved.data, reply, resolved.url);
+        status = reply.statusCode;
+      }
+      validationsCounter.add(1, {
+        status,
+      });
+      request.log.info(
+        `Validated at ${Math.round(
+          process.memoryUsage().rss / 1024 / 1024,
+        )} MB memory`,
+      );
+
+      // For a stream, return nothing so the @fastify/sse wrapper closes it;
+      // otherwise return the reply as usual.
+      if (streaming) {
+        return;
+      }
+      return reply;
+    },
+  );
 
   server.post(
     '/datasets/validate',

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -3,7 +3,13 @@ import type { Mock } from 'vitest';
 import { FastifyInstance } from 'fastify';
 import { Server } from 'http';
 import { server } from '../src/server.js';
-import { readUrl, ShaclEngineValidator } from '@dataset-register/core';
+import {
+  readUrl,
+  ShaclEngineValidator,
+  type InvalidDataset,
+  type Valid,
+  type Validator,
+} from '@dataset-register/core';
 import {
   file,
   MockAllowedRegistrationDomainStore,
@@ -17,6 +23,28 @@ import { dirname } from 'path';
 
 let httpServer: FastifyInstance<Server>;
 const registrationStore = new MockRegistrationStore();
+
+/**
+ * Parse a Server-Sent Events stream body into its individual events. This is
+ * an intentionally independent parser (the browser client has its own in
+ * validation.ts) so the test validates the server's wire format on its own
+ * terms rather than through the client's parsing assumptions.
+ */
+function parseSse(body: string): { event: string; data: string }[] {
+  return body
+    .split('\n\n')
+    .filter((block) => block.trim() !== '')
+    .map((block) => {
+      const event = /^event: (.*)$/m.exec(block)?.[1] ?? 'message';
+      const data = block
+        .split('\n')
+        .filter((line) => line.startsWith('data: '))
+        .map((line) => line.slice('data: '.length))
+        .join('\n');
+      return { event, data };
+    });
+}
+
 describe('Server', () => {
   beforeAll(async () => {
     const shacl = await readUrl('../../requirements/shacl.ttl');
@@ -193,6 +221,205 @@ describe('Server', () => {
     );
     console.log(response.body);
     expect(response.payload).not.toEqual('');
+  });
+
+  it('streams progress events then a report when the client accepts text/event-stream', async () => {
+    const shacl = await readUrl('../../requirements/shacl.ttl');
+    const progressingValidator: Validator = {
+      async validate(_input, onProgress) {
+        onProgress?.(0, 2);
+        onProgress?.(1, 2);
+        onProgress?.(2, 2);
+        // `readUrl` yields a DatasetCore; cast to the report's richer Dataset
+        // type — the streaming path only iterates its quads.
+        return { state: 'valid', errors: shacl } as Valid;
+      },
+    };
+    const streamingServer = await server(
+      new MockDatasetStore(),
+      registrationStore,
+      new MockAllowedRegistrationDomainStore(),
+      progressingValidator,
+      shacl,
+      '/',
+      { logger: false },
+    );
+    nock('https://example.com/')
+      .get('/streamed')
+      .reply(200, '<https://example.com/s> <https://example.com/p> "o" .', {
+        'Content-Type': 'text/turtle',
+      });
+
+    const response = await streamingServer.inject({
+      method: 'PUT',
+      url: '/datasets/validate',
+      headers: {
+        'Content-Type': 'application/ld+json',
+        Accept: 'text/event-stream',
+      },
+      payload: JSON.stringify({ '@id': 'https://example.com/streamed' }),
+    });
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['content-type']).toContain('text/event-stream');
+
+    const events = parseSse(response.payload);
+    const progress = events.filter((event) => event.event === 'progress');
+    expect(progress.map((event) => JSON.parse(event.data))).toEqual([
+      { completed: 0, total: 2 },
+      { completed: 1, total: 2 },
+      { completed: 2, total: 2 },
+    ]);
+
+    const report = events.find((event) => event.event === 'report');
+    expect(report).toBeDefined();
+    expect(Array.isArray(JSON.parse(report?.data ?? ''))).toBe(true);
+  });
+
+  it('streams an error event when no dataset is found and the client accepts text/event-stream', async () => {
+    const shacl = await readUrl('../../requirements/shacl.ttl');
+    const noDatasetValidator: Validator = {
+      async validate() {
+        return { state: 'no-dataset' };
+      },
+    };
+    const streamingServer = await server(
+      new MockDatasetStore(),
+      registrationStore,
+      new MockAllowedRegistrationDomainStore(),
+      noDatasetValidator,
+      shacl,
+      '/',
+      { logger: false },
+    );
+    nock('https://example.com/')
+      .get('/empty')
+      .reply(200, '<https://example.com/s> <https://example.com/p> "o" .', {
+        'Content-Type': 'text/turtle',
+      });
+
+    const response = await streamingServer.inject({
+      method: 'PUT',
+      url: '/datasets/validate',
+      headers: {
+        'Content-Type': 'application/ld+json',
+        Accept: 'text/event-stream',
+      },
+      payload: JSON.stringify({ '@id': 'https://example.com/empty' }),
+    });
+
+    expect(response.headers['content-type']).toContain('text/event-stream');
+    const error = parseSse(response.payload).find(
+      (event) => event.event === 'error',
+    );
+    expect(error).toBeDefined();
+    expect(JSON.parse(error?.data ?? '{}').title).toEqual(
+      'No dataset found at URL https://example.com/empty',
+    );
+  });
+
+  it('ends the stream cleanly when validation throws mid-stream', async () => {
+    const shacl = await readUrl('../../requirements/shacl.ttl');
+    const failingValidator: Validator = {
+      async validate(_input, onProgress) {
+        onProgress?.(0, 1);
+        throw new Error('probe exploded');
+      },
+    };
+    const streamingServer = await server(
+      new MockDatasetStore(),
+      registrationStore,
+      new MockAllowedRegistrationDomainStore(),
+      failingValidator,
+      shacl,
+      '/',
+      { logger: false },
+    );
+    nock('https://example.com/')
+      .get('/boom')
+      .reply(200, '<https://example.com/s> <https://example.com/p> "o" .', {
+        'Content-Type': 'text/turtle',
+      });
+
+    const response = await streamingServer.inject({
+      method: 'PUT',
+      url: '/datasets/validate',
+      headers: {
+        'Content-Type': 'application/ld+json',
+        Accept: 'text/event-stream',
+      },
+      payload: JSON.stringify({ '@id': 'https://example.com/boom' }),
+    });
+
+    // The partial progress was delivered, then an error frame surfaces the
+    // failure (instead of a silent close), and no report frame is sent.
+    const events = parseSse(response.payload);
+    expect(events.some((event) => event.event === 'progress')).toBe(true);
+    expect(events.some((event) => event.event === 'report')).toBe(false);
+    const error = events.find((event) => event.event === 'error');
+    expect(error).toBeDefined();
+    expect(JSON.parse(error?.data ?? '{}').statusCode).toEqual(500);
+  });
+
+  it('streams a report (not a 4xx) for an invalid dataset over text/event-stream', async () => {
+    const shacl = await readUrl('../../requirements/shacl.ttl');
+    const invalidValidator: Validator = {
+      async validate(_input, onProgress) {
+        onProgress?.(0, 1);
+        // `readUrl` yields a DatasetCore; the streaming path only iterates it.
+        return { state: 'invalid', errors: shacl } as InvalidDataset;
+      },
+    };
+    const streamingServer = await server(
+      new MockDatasetStore(),
+      registrationStore,
+      new MockAllowedRegistrationDomainStore(),
+      invalidValidator,
+      shacl,
+      '/',
+      { logger: false },
+    );
+    nock('https://example.com/')
+      .get('/invalid')
+      .reply(200, '<https://example.com/s> <https://example.com/p> "o" .', {
+        'Content-Type': 'text/turtle',
+      });
+
+    const response = await streamingServer.inject({
+      method: 'PUT',
+      url: '/datasets/validate',
+      headers: {
+        'Content-Type': 'application/ld+json',
+        Accept: 'text/event-stream',
+      },
+      payload: JSON.stringify({ '@id': 'https://example.com/invalid' }),
+    });
+
+    // Like the valid case, invalid datasets stream a report frame; the browser
+    // reads sh:conforms to tell them apart.
+    expect(response.headers['content-type']).toContain('text/event-stream');
+    const report = parseSse(response.payload).find(
+      (event) => event.event === 'report',
+    );
+    expect(report).toBeDefined();
+    expect(Array.isArray(JSON.parse(report?.data ?? ''))).toBe(true);
+  });
+
+  it('returns a normal error response (not a stream) when an event-stream request cannot resolve the URL', async () => {
+    nock('https://example.com/').get('/404-stream').reply(404);
+    const response = await httpServer.inject({
+      method: 'PUT',
+      url: '/datasets/validate',
+      headers: {
+        'Content-Type': 'application/ld+json',
+        Accept: 'text/event-stream',
+      },
+      payload: JSON.stringify({ '@id': 'https://example.com/404-stream' }),
+    });
+    // Resolution errors arrive as plain HTTP so the browser falls back to its
+    // one-shot parser, exactly as for non-streaming requests.
+    expect(response.statusCode).toEqual(404);
+    expect(response.headers['content-type']).not.toContain('text/event-stream');
   });
 
   it('validates JSON-LD dataset description in request body', async () => {

--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -16,10 +16,10 @@ export default defineConfig(() => ({
       provider: 'v8' as const,
       thresholds: {
         autoUpdate: true,
-        lines: 97.36,
+        lines: 97.91,
         functions: 100,
-        branches: 85.71,
-        statements: 97.36,
+        branches: 88.23,
+        statements: 97.93,
       },
     },
   },

--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -444,6 +444,7 @@
   "validate_editor_copied": "Copied",
   "validate_format_unsupported": "Automatic formatting isn’t available for this content type.",
   "validate_running": "Validating…",
+  "validate_checking": "Checking {completed} / {total}",
   "validate_parse_failed_title": "Couldn’t parse your input",
   "validate_result_not_found_title": "No datasets found at URL",
   "validate_result_not_found_body": "The Dataset Register couldn’t resolve this URL. Check that it is publicly reachable and returns a dataset description.",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -444,6 +444,7 @@
   "validate_editor_copy": "Kopiëren",
   "validate_editor_copied": "Gekopieerd",
   "validate_running": "Bezig met valideren…",
+  "validate_checking": "Bezig met controleren {completed} / {total}",
   "validate_parse_failed_title": "Kan invoer niet verwerken",
   "validate_result_not_found_title": "Geen datasets gevonden op URL",
   "validate_result_not_found_body": "Het Datasetregister kan deze URL niet ophalen. Controleer of deze publiek bereikbaar is en een datasetbeschrijving teruggeeft.",

--- a/apps/browser/src/lib/components/validation/UrlValidationForm.svelte
+++ b/apps/browser/src/lib/components/validation/UrlValidationForm.svelte
@@ -10,6 +10,7 @@
     checkDomainAllowed,
     validateByUrl,
     type UrlValidationOutcome,
+    type ValidationProgress,
   } from '$lib/services/validation.js';
   import CodeEditor from './CodeEditor.svelte';
   import {
@@ -49,6 +50,7 @@
 
   let url = $state('');
   let submitting = $state(false);
+  let progress = $state<ValidationProgress | null>(null);
   let domainAllowed = $state<boolean | 'unknown'>('unknown');
   let submitController: AbortController | null = null;
   let checkController: AbortController | null = null;
@@ -222,6 +224,7 @@
     const controller = new AbortController();
     submitController = controller;
     submitting = true;
+    progress = null;
     hasSubmitted = true;
     hideFetched = false;
     onStart();
@@ -236,7 +239,13 @@
           ? false
           : undefined;
     try {
-      const outcome = await validateByUrl(submittedUrl, controller.signal);
+      const outcome = await validateByUrl(
+        submittedUrl,
+        controller.signal,
+        (update) => {
+          if (!controller.signal.aborted) progress = update;
+        },
+      );
       if (!controller.signal.aborted) {
         hideFetched = outcome.kind === 'no-dataset';
         onOutcome(outcome, submittedUrl, allowedNow);
@@ -254,7 +263,10 @@
         );
       }
     } finally {
-      if (!controller.signal.aborted) submitting = false;
+      if (!controller.signal.aborted) {
+        submitting = false;
+        progress = null;
+      }
     }
   }
 
@@ -267,6 +279,17 @@
   });
 
   const isValidUrl = $derived(parseUrl(url) !== null);
+
+  // Single source of truth for "we have a determinate progress to show": the
+  // fill, the label, and the percent all key off this one value.
+  const activeProgress = $derived(
+    progress !== null && progress.total > 0 ? progress : null,
+  );
+  const progressPercent = $derived(
+    activeProgress
+      ? Math.round((activeProgress.completed / activeProgress.total) * 100)
+      : 0,
+  );
 </script>
 
 <form class="space-y-3" onsubmit={submit}>
@@ -286,17 +309,48 @@
     <button
       type="submit"
       disabled={!isValidUrl || submitting}
-      class="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-700 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:bg-blue-400 disabled:cursor-not-allowed dark:bg-blue-600 dark:hover:bg-blue-700 dark:disabled:bg-blue-900 dark:disabled:text-blue-300 cursor-pointer"
+      aria-busy={submitting}
+      class="relative inline-flex items-center justify-center gap-2 overflow-hidden rounded-lg bg-blue-700 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:bg-blue-400 disabled:cursor-not-allowed dark:bg-blue-600 dark:hover:bg-blue-700 dark:disabled:bg-blue-900 dark:disabled:text-blue-300 cursor-pointer"
     >
-      {#if submitting}
+      {#if activeProgress}
+        <!-- Determinate fill: a darker overlay keeps the white label well above
+             the WCAG AA contrast minimum across the whole button. role +
+             aria-value* expose the progress to assistive tech (the visible
+             label is decorative and hidden from it to avoid double-announcing). -->
         <span
-          class="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white/50 border-t-white"
-          aria-hidden="true"
+          class="absolute inset-y-0 left-0 bg-blue-900/50 transition-[width] duration-300 ease-out"
+          style="width: {progressPercent}%"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={activeProgress.total}
+          aria-valuenow={activeProgress.completed}
+          aria-valuetext={m.validate_checking({
+            completed: activeProgress.completed,
+            total: activeProgress.total,
+          })}
         ></span>
-        {m.validate_running()}
-      {:else}
-        {m.validate_url_submit()}
       {/if}
+      <span
+        class="relative inline-flex items-center gap-2"
+        aria-hidden={!!activeProgress}
+      >
+        {#if submitting}
+          <span
+            class="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white/50 border-t-white"
+            aria-hidden="true"
+          ></span>
+          {#if activeProgress}
+            {m.validate_checking({
+              completed: activeProgress.completed,
+              total: activeProgress.total,
+            })}
+          {:else}
+            {m.validate_running()}
+          {/if}
+        {:else}
+          {m.validate_url_submit()}
+        {/if}
+      </span>
     </button>
   </div>
 

--- a/apps/browser/src/lib/services/validation.test.ts
+++ b/apps/browser/src/lib/services/validation.test.ts
@@ -1,5 +1,126 @@
-import { describe, expect, it } from 'vitest';
-import { fetchErrorReason } from './validation.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchErrorReason,
+  validateByUrl,
+  type ValidationProgress,
+} from './validation.js';
+
+/** Build a streaming SSE Response from raw event frames. */
+function sseResponse(frames: string[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const frame of frames) controller.enqueue(encoder.encode(frame));
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+describe('validateByUrl streaming', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('reports progress then resolves to the report when the server streams', async () => {
+    const report = [
+      {
+        '@id': '_:b0',
+        '@type': ['http://www.w3.org/ns/shacl#ValidationReport'],
+        'http://www.w3.org/ns/shacl#conforms': [{ '@value': true }],
+      },
+    ];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        sseResponse([
+          'event: progress\ndata: {"completed":0,"total":2}\n\n',
+          'event: progress\ndata: {"completed":1,"total":2}\n\n',
+          'event: progress\ndata: {"completed":2,"total":2}\n\n',
+          `event: report\ndata: ${JSON.stringify(report)}\n\n`,
+        ]),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const progress: ValidationProgress[] = [];
+    const outcome = await validateByUrl(
+      'https://example.com/dataset',
+      undefined,
+      (update) => progress.push(update),
+    );
+
+    expect(progress).toEqual([
+      { completed: 0, total: 2 },
+      { completed: 1, total: 2 },
+      { completed: 2, total: 2 },
+    ]);
+    expect(outcome.kind).toBe('report');
+    expect(fetchMock.mock.calls[0][1].headers.Accept).toBe('text/event-stream');
+  });
+
+  it('falls back to the one-shot response when the server does not stream', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ title: 'No dataset found at URL …' }), {
+        status: 406,
+        headers: { 'Content-Type': 'application/ld+json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const progress: ValidationProgress[] = [];
+    const outcome = await validateByUrl(
+      'https://example.com/dataset',
+      undefined,
+      (update) => progress.push(update),
+    );
+
+    expect(progress).toEqual([]);
+    expect(outcome.kind).toBe('no-dataset');
+  });
+
+  it('maps a non-406 SSE error frame to a generic error outcome', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        sseResponse([
+          'event: progress\ndata: {"completed":0,"total":1}\n\n',
+          `event: error\ndata: ${JSON.stringify({ statusCode: 500, title: 'Validation failed' })}\n\n`,
+        ]),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const progress: ValidationProgress[] = [];
+    const outcome = await validateByUrl(
+      'https://example.com/dataset',
+      undefined,
+      (update) => progress.push(update),
+    );
+
+    expect(progress).toEqual([{ completed: 0, total: 1 }]);
+    expect(outcome).toEqual({ kind: 'error', message: 'Validation failed' });
+  });
+
+  it('maps a 406 SSE error frame to a no-dataset outcome', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        sseResponse([
+          `event: error\ndata: ${JSON.stringify({ statusCode: 406, title: 'No dataset found at URL …' })}\n\n`,
+        ]),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const progress: ValidationProgress[] = [];
+    const outcome = await validateByUrl(
+      'https://example.com/dataset',
+      undefined,
+      (update) => progress.push(update),
+    );
+
+    expect(outcome.kind).toBe('no-dataset');
+  });
+});
 
 describe('fetchErrorReason', () => {
   it('extracts the reason from a CouldNotFetchUrl title', () => {

--- a/apps/browser/src/lib/services/validation.ts
+++ b/apps/browser/src/lib/services/validation.ts
@@ -35,20 +35,48 @@ export type InlineValidationOutcome =
   | { kind: 'no-dataset'; details?: ApiErrorDetails }
   | { kind: 'error'; message: string };
 
+/** Progress of a streamed URL validation: distributions probed so far. */
+export interface ValidationProgress {
+  completed: number;
+  total: number;
+}
+
 export async function validateByUrl(
   url: string,
   signal?: AbortSignal,
+  onProgress?: (progress: ValidationProgress) => void,
 ): Promise<UrlValidationOutcome> {
   const response = await fetch(`${PUBLIC_API_ENDPOINT}/datasets/validate`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/ld+json',
-      Accept: 'application/ld+json',
+      // Ask for a progress stream only when the caller wants progress updates;
+      // other callers keep the simpler one-shot JSON-LD response.
+      Accept: onProgress ? 'text/event-stream' : 'application/ld+json',
     },
     body: JSON.stringify({ '@id': url }),
     signal,
   });
 
+  // The server streams progress only when it accepted the request and chose to;
+  // resolve errors (404/406) still arrive as plain HTTP, so fall back on those.
+  const contentType = response.headers.get('content-type') ?? '';
+  if (
+    onProgress &&
+    response.ok &&
+    contentType.includes('text/event-stream') &&
+    response.body
+  ) {
+    return readValidationStream(response.body, onProgress);
+  }
+
+  return readUrlValidationResponse(response);
+}
+
+/** Parse the one-shot (non-streaming) validation response by status code. */
+async function readUrlValidationResponse(
+  response: Response,
+): Promise<UrlValidationOutcome> {
   if (response.status === 404) {
     return { kind: 'not-found', details: await readHydraError(response) };
   }
@@ -67,6 +95,82 @@ export async function validateByUrl(
     kind: 'error',
     message: `Unexpected response ${response.status} from validation API`,
   };
+}
+
+/**
+ * Read a Server-Sent Events stream of `progress` frames followed by a final
+ * `report` (JSON-LD SHACL report) or `error` (no dataset found) frame.
+ */
+async function readValidationStream(
+  body: ReadableStream<Uint8Array>,
+  onProgress: (progress: ValidationProgress) => void,
+): Promise<UrlValidationOutcome> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let outcome: UrlValidationOutcome | null = null;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    let boundary: number;
+    while ((boundary = buffer.indexOf('\n\n')) !== -1) {
+      const frame = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      const frameOutcome = handleSseFrame(frame, onProgress);
+      if (frameOutcome) outcome = frameOutcome;
+    }
+  }
+
+  return (
+    outcome ?? {
+      kind: 'error',
+      message: 'Validation stream ended without a report',
+    }
+  );
+}
+
+/**
+ * Handle one SSE frame. `progress` frames invoke {@link onProgress} and return
+ * null; terminal frames return the outcome to resolve with.
+ */
+function handleSseFrame(
+  frame: string,
+  onProgress: (progress: ValidationProgress) => void,
+): UrlValidationOutcome | null {
+  let event = 'message';
+  const dataLines: string[] = [];
+  for (const line of frame.split('\n')) {
+    if (line.startsWith('event: ')) event = line.slice('event: '.length);
+    else if (line.startsWith('data: '))
+      dataLines.push(line.slice('data: '.length));
+  }
+  const data = dataLines.join('\n');
+  if (data === '') return null;
+
+  if (event === 'progress') {
+    onProgress(JSON.parse(data) as ValidationProgress);
+    return null;
+  }
+  if (event === 'report') {
+    return { kind: 'report', report: parseShaclReport(JSON.parse(data)) };
+  }
+  if (event === 'error') {
+    const payload = JSON.parse(data) as { statusCode?: number };
+    const details = toHydraError(payload);
+    if (details?.title?.startsWith(COULD_NOT_FETCH_URL_PREFIX)) {
+      return { kind: 'fetch-failed', details };
+    }
+    // 406 is the no-dataset case; any other status (e.g. 500 when validation
+    // threw mid-stream) is a generic error rather than a missing dataset.
+    if (payload.statusCode === 406) {
+      return { kind: 'no-dataset', details };
+    }
+    return { kind: 'error', message: details?.title ?? 'Validation failed' };
+  }
+  return null;
 }
 
 export async function validateInline(

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@dataset-register/search-indexer": "*",
         "@fastify/bearer-auth": "^10.1.2",
         "@fastify/cors": "^11.0.0",
+        "@fastify/sse": "^0.4.0",
         "@fastify/swagger": "^9.7.0",
         "@fastify/swagger-ui": "^6.0.0",
         "@lde/fastify-rdf": "^0.4.6",
@@ -13879,6 +13880,21 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@fastify/sse": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@fastify/sse/-/sse-0.4.0.tgz",
+      "integrity": "sha512-bBV96iT2kHEw6h3i8IMkZGaqA7Gk81ugUzTNctXuE6N2BEC/qBnUuzlD/O17V43OkJP73h0/kf3Bp/asXlSuFA==",
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "fastify": "^5.x"
       }
     },
     "node_modules/@fastify/static": {
@@ -32672,6 +32688,7 @@
         "n3": "^2.0.4",
         "rdf-dereference": "^5.0.0",
         "rdf-ext": "^2.6.0",
+        "rdf-serialize": "^5.1.0",
         "shacl-engine": "^1.0.2",
         "tslib": "^2.3.0"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,7 @@
     "n3": "^2.0.4",
     "rdf-dereference": "^5.0.0",
     "rdf-ext": "^2.6.0",
+    "rdf-serialize": "^5.1.0",
     "shacl-engine": "^1.0.2",
     "tslib": "^2.3.0"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export * from './instrumentation.ts';
 export * from './literal.ts';
 export * from './query.ts';
 export * from './rate.ts';
+export * from './rdf-serialize.ts';
 export * from './registration.ts';
 export * from './search/class-groups.ts';
 export * from './search/compatibility.ts';

--- a/packages/core/src/rdf-serialize.ts
+++ b/packages/core/src/rdf-serialize.ts
@@ -1,4 +1,7 @@
 import { Writer } from 'n3';
+import { Readable } from 'node:stream';
+import { text } from 'node:stream/consumers';
+import { rdfSerializer } from 'rdf-serialize';
 import type { Quad } from '@rdfjs/types';
 
 /**
@@ -19,4 +22,16 @@ export function quadsToNTriples(quads: Quad[]): Promise<string> {
       }
     });
   });
+}
+
+/**
+ * Serialize quads to a string in the given RDF content type (e.g.
+ * `application/ld+json`). Uses `rdf-serialize`, which — unlike the N3 `Writer`
+ * above — supports JSON-LD, and Node's stream consumer to collect the result.
+ */
+export function serializeQuads(
+  quads: Iterable<Quad>,
+  contentType: string,
+): Promise<string> {
+  return text(rdfSerializer.serialize(Readable.from(quads), { contentType }));
 }

--- a/packages/core/test/rdf-serialize.test.ts
+++ b/packages/core/test/rdf-serialize.test.ts
@@ -1,0 +1,37 @@
+import factory from 'rdf-ext';
+import { quadsToNTriples, serializeQuads } from '../src/rdf-serialize.js';
+
+const quad = factory.quad(
+  factory.namedNode('https://example.com/s'),
+  factory.namedNode('https://example.com/p'),
+  factory.literal('o'),
+);
+
+describe('serializeQuads', () => {
+  it('serializes quads to JSON-LD', async () => {
+    const nodes = JSON.parse(
+      await serializeQuads(factory.dataset([quad]), 'application/ld+json'),
+    ) as Array<Record<string, unknown>>;
+    expect(Array.isArray(nodes)).toBe(true);
+    expect(nodes[0]['@id']).toBe('https://example.com/s');
+  });
+
+  it('serializes quads to other content types, such as N-Triples', async () => {
+    const result = await serializeQuads(
+      factory.dataset([quad]),
+      'application/n-triples',
+    );
+    expect(result).toContain(
+      '<https://example.com/s> <https://example.com/p> "o" .',
+    );
+  });
+});
+
+describe('quadsToNTriples', () => {
+  it('serializes quads to an N-Triples string', async () => {
+    const result = await quadsToNTriples([quad]);
+    expect(result).toContain(
+      '<https://example.com/s> <https://example.com/p> "o" .',
+    );
+  });
+});

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -23,9 +23,9 @@ export default defineConfig(() => ({
       thresholds: {
         autoUpdate: true,
         lines: 97.61,
-        functions: 96.41,
+        functions: 96.42,
         branches: 90.42,
-        statements: 97.05,
+        statements: 97.06,
       },
     },
   },


### PR DESCRIPTION
Validating a catalogue with many distributions is slow — each distribution is probed, throttled by the per-host cap — so the **Validate URL** button only showed an indeterminate spinner. This adds a determinate progress indicator: `Checking N / M` with a fill that tracks distributions probed.

The lower layers (`@lde/distribution-probe`'s `probeMany(onProgress)` and the core threading through `Validator.validate → CompositeValidator → DistributionProbeStage`) already shipped. This PR adds the two remaining layers: the API streaming endpoint and the browser button.

## API

- `PUT /datasets/validate` gains a `text/event-stream` branch. It emits a `progress` event per probed distribution (`{ completed, total }`, determinate from the first frame), then a terminal `report` event (the JSON-LD SHACL report) or an `error` event when no dataset is found.
- The default `application/ld+json` response is **byte-for-byte unchanged**, so existing clients are unaffected.
- The events are streamed with the official **`@fastify/sse`** plugin (`reply.sse`), which formats the frames, manages the `text/event-stream` headers, and runs on the managed reply so `@fastify/cors` and the other hooks keep working — no hand-rolled SSE framing, CORS, or raw socket handling. The plugin's route wrapper does the `Accept` negotiation itself, so the default path is untouched and `Accept: text/event-stream` requests that fail to resolve a URL still get a normal HTTP error (which the browser's fallback handles).
- A validation that throws mid-stream logs the cause and ends the stream cleanly, so the connection never hangs.
- The report frame is serialized with a new shared `serializeQuads(quads, contentType)` helper in `@dataset-register/core` (`rdf-serialize` + `node:stream/consumers`), placed alongside the existing `quadsToNTriples` so all RDF-to-string serialization lives in one module. No Fastify coupling, no hand-rolled stream collection.

## Browser

- `validateByUrl(url, signal, onProgress?)` requests `text/event-stream` when a progress callback is given, parses the SSE frames, and falls back to the existing one-shot `application/ld+json` request when the server does not stream (e.g. resolve errors that arrive as plain HTTP).
- The **Validate URL** button shows a determinate fill behind the label plus a `Checking {completed} / {total}` message (new Paraglide message, `en` + `nl`). The fill uses a darker overlay so the white label stays above the WCAG AA contrast minimum.

## Tests

- API: streaming yields `progress` frames then a `report`; no-dataset yields an `error` frame; a mid-stream throw ends the stream without a report; the default path is untouched.
- Browser: stream parsing drives `onProgress` and resolves to the report; the one-shot fallback is used when the server does not stream.

Verification was done via the unit tests on both layers (plus `svelte-check`); no live browser run.
