### PR TITLE
fix(core): percent-encode IRIREF-illegal characters in registration URLs

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export * from './search/field-registry.ts';
 export * from './search/media-types.ts';
 export * from './search/synonyms.ts';
 export * from './sparql.ts';
+export * from './sparql-iri.ts';
 export * from './transform.ts';
 export * from './validation-report.ts';
 export * from './validator.ts';

--- a/packages/core/src/registration.ts
+++ b/packages/core/src/registration.ts
@@ -4,6 +4,7 @@ import {
   REGISTRATION_STATUS_BASE_URI,
   REGISTRATION_WARNING_COUNT_PREDICATE,
 } from './constants.js';
+import { sparqlIri } from './sparql-iri.js';
 
 export class Registration {
   private _dateRead?: Date;
@@ -118,7 +119,7 @@ export interface AllowedRegistrationDomainStore {
 }
 
 export function toRdf(registration: Registration) {
-  const iri = factory.namedNode(registration.url.toString());
+  const iri = factory.namedNode(sparqlIri(registration.url));
 
   const quads = [
     factory.quad(
@@ -154,7 +155,7 @@ export function toRdf(registration: Registration) {
         factory.quad(
           factory.namedNode(datasetIri.toString()),
           factory.namedNode('https://schema.org/subjectOf'),
-          factory.namedNode(registration.url.toString()),
+          iri,
         ),
       ];
       if (registration.dateRead !== undefined) {

--- a/packages/core/src/sparql-iri.ts
+++ b/packages/core/src/sparql-iri.ts
@@ -1,0 +1,48 @@
+/**
+ * Percent-encode the characters that are illegal in a SPARQL/Turtle IRIREF
+ * (`<…>`). RFC 3987 already forbids these in an IRI, but the WHATWG URL parser
+ * leaves some of them – notably `{` and `}` – un-encoded in the query component.
+ * A registration URL that inlines a SPARQL CONSTRUCT (e.g.
+ * `…/sparql?query=CONSTRUCT { ?s ?p ?o } …`) therefore keeps literal braces and
+ * breaks any SPARQL update or N-Triples document that embeds the URL as `<…>`.
+ *
+ * Encoding is idempotent for already-valid IRIs: `%` is itself a legal IRIREF
+ * character, so an existing `%20` is left untouched while a literal space becomes
+ * `%20`. Applying this consistently when writing and when querying keeps the two
+ * forms identical, so a registration submitted with literal braces still matches
+ * on lookup and delete.
+ */
+export function sparqlIri(value: URL | string): string {
+  const iri = typeof value === 'string' ? value : value.toString();
+  let encoded = '';
+  for (const character of iri) {
+    if (
+      character.charCodeAt(0) <= 0x20 ||
+      ILLEGAL_IRI_CHARACTERS.has(character)
+    ) {
+      encoded += '%'.concat(
+        character.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0'),
+      );
+    } else {
+      encoded += character;
+    }
+  }
+  return encoded;
+}
+
+/**
+ * Characters that are illegal in a SPARQL/Turtle IRIREF (`<…>`) outside the
+ * U+0000–U+0020 control range: angle brackets, double quote, braces, pipe,
+ * caret, backtick and backslash.
+ */
+const ILLEGAL_IRI_CHARACTERS = new Set([
+  '<',
+  '>',
+  '"',
+  '{',
+  '}',
+  '|',
+  '^',
+  '`',
+  '\\',
+]);

--- a/packages/core/src/sparql.ts
+++ b/packages/core/src/sparql.ts
@@ -3,6 +3,7 @@ import { QueryEngine } from '@comunica/query-sparql';
 import type { BindingsStream } from '@comunica/types';
 import { Parser } from 'n3';
 import { quadsToNTriples } from './rdf-serialize.js';
+import { sparqlIri } from './sparql-iri.js';
 import {
   AllowedRegistrationDomainStore,
   Registration,
@@ -195,15 +196,16 @@ export class SparqlRegistrationStore implements RegistrationStore {
   }
 
   async findByUrl(url: URL): Promise<Registration | undefined> {
+    const iri = sparqlIri(url);
     const result = await this.client.query(`
       PREFIX schema: <https://schema.org/>
 
       SELECT ?datePosted ?validUntil ?dataset WHERE {
         GRAPH <${this.graphIri}> {
-          <${url}> a schema:EntryPoint ;
+          <${iri}> a schema:EntryPoint ;
             schema:datePosted ?datePosted .
-          OPTIONAL { <${url}> schema:validUntil ?validUntil . }
-          OPTIONAL { <${url}> schema:about ?dataset . }
+          OPTIONAL { <${iri}> schema:validUntil ?validUntil . }
+          OPTIONAL { <${iri}> schema:about ?dataset . }
         }
       }
     `);
@@ -229,6 +231,7 @@ export class SparqlRegistrationStore implements RegistrationStore {
   }
 
   async store(registration: Registration): Promise<void> {
+    const iri = sparqlIri(registration.url);
     const quads = toRdf(registration);
     const triples = await quadsToNTriples(quads);
 
@@ -236,20 +239,20 @@ export class SparqlRegistrationStore implements RegistrationStore {
     // Need to delete both the registration and any dataset relationships it created
     const sparqlUpdate = `
       PREFIX schema: <https://schema.org/>
-      
+
       WITH <${this.graphIri}>
       DELETE {
-        <${registration.url}> ?p ?o .
+        <${iri}> ?p ?o .
         ?dataset ?dp ?do .
       }
       WHERE {
         {
-          <${registration.url}> ?p ?o .
+          <${iri}> ?p ?o .
         } UNION {
-          ?dataset schema:subjectOf <${registration.url}> .
+          ?dataset schema:subjectOf <${iri}> .
           ?dataset ?dp ?do .
         } UNION {
-          <${registration.url}> schema:about ?dataset .
+          <${iri}> schema:about ?dataset .
           ?dataset ?dp ?do .
         }
       };
@@ -264,22 +267,23 @@ export class SparqlRegistrationStore implements RegistrationStore {
   }
 
   async delete(url: URL): Promise<void> {
+    const iri = sparqlIri(url);
     await this.client.update(`
       PREFIX schema: <https://schema.org/>
 
       WITH <${this.graphIri}>
       DELETE {
-        <${url}> ?p ?o .
+        <${iri}> ?p ?o .
         ?dataset ?dp ?do .
       }
       WHERE {
         {
-          <${url}> ?p ?o .
+          <${iri}> ?p ?o .
         } UNION {
-          ?dataset schema:subjectOf <${url}> .
+          ?dataset schema:subjectOf <${iri}> .
           ?dataset ?dp ?do .
         } UNION {
-          <${url}> schema:about ?dataset .
+          <${iri}> schema:about ?dataset .
           ?dataset ?dp ?do .
         }
       }`);

--- a/packages/core/test/sparql-iri.test.ts
+++ b/packages/core/test/sparql-iri.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { sparqlIri } from '../src/sparql-iri.js';
+
+describe('sparqlIri', () => {
+  it('percent-encodes the braces and spaces of an inlined SPARQL CONSTRUCT', () => {
+    const url = new URL(
+      'http://api.bibliotheken.nl/datasets/KB/Production/sparql?query=CONSTRUCT%20{%20?s%20?p%20?o%20.%20}%20WHERE%20{%20GRAPH%20%3Chttp://data.bibliotheken.nl/datasetbeschrijvingen%3E%20{%20?s%20?p%20?o%20.%20}%20}',
+    );
+
+    const encoded = sparqlIri(url);
+
+    expect(encoded).not.toMatch(/[{}]/);
+    expect(encoded).toContain('CONSTRUCT%20%7B%20?s');
+  });
+
+  it('encodes every IRIREF-illegal character, including control characters', () => {
+    expect(sparqlIri('a b')).toBe('a%20b');
+    expect(sparqlIri('a\tb')).toBe('a%09b');
+    expect(sparqlIri('a<b>c"d{e}f|g^h`i\\j')).toBe(
+      'a%3Cb%3Ec%22d%7Be%7Df%7Cg%5Eh%60i%5Cj',
+    );
+  });
+
+  it('leaves a valid IRI untouched and is idempotent', () => {
+    const valid = 'https://example.org/path?a=1&b=2#frag';
+    expect(sparqlIri(valid)).toBe(valid);
+    expect(sparqlIri(sparqlIri('a {b}'))).toBe('a%20%7Bb%7D');
+  });
+
+  it('accepts both URL and string input', () => {
+    expect(sparqlIri(new URL('https://example.org/x'))).toBe(
+      'https://example.org/x',
+    );
+    expect(sparqlIri('https://example.org/x')).toBe('https://example.org/x');
+  });
+});

--- a/packages/core/test/sparql.test.ts
+++ b/packages/core/test/sparql.test.ts
@@ -363,6 +363,52 @@ describe('SPARQL', () => {
       expect(found).toBeUndefined();
     });
 
+    // A SPARQL registration URL may contain characters that are illegal in a
+    // SPARQL/Turtle IRIREF – notably the literal braces and spaces of an inlined
+    // CONSTRUCT query (e.g. KB’s `…/sparql?query=CONSTRUCT { ?s ?p ?o } …`). The
+    // WHATWG URL parser leaves `{`/`}` un-encoded in the query component, so the
+    // store must percent-encode them before embedding the URL as `<…>`, both when
+    // writing and when querying, or store/find/delete all fail to parse.
+    it('round-trips a registration whose URL contains IRIREF-illegal characters', async () => {
+      const url = new URL(
+        'http://api.bibliotheken.nl/datasets/KB/Production/sparql?query=CONSTRUCT%20{%20?s%20?p%20?o%20.%20}%20WHERE%20{%20GRAPH%20%3Chttp://data.bibliotheken.nl/datasetbeschrijvingen%3E%20{%20?s%20?p%20?o%20.%20}%20}',
+      );
+      const registration = createTestRegistration(
+        url.toString(),
+        new Date('2025-01-01T10:00:00Z'),
+        undefined,
+        new Date('2025-01-15T08:30:00Z'),
+        [new URL('https://example.org/dataset/1')],
+      );
+
+      await registrationStore.store(registration);
+
+      // The IRI is persisted in its IRIREF-safe form: the literal braces are
+      // percent-encoded as %7B/%7D, never stored raw.
+      const stored = await sparqlClient.query(`
+        PREFIX schema: <https://schema.org/>
+        SELECT ?s WHERE {
+          GRAPH <${registrationsGraphIri}> { ?s a schema:EntryPoint }
+        }
+      `);
+      const storedIri = (await stored.toArray())[0]!.get('s')!.value;
+      expect(storedIri).not.toMatch(/[{}]/);
+      expect(storedIri).toContain('CONSTRUCT%20%7B%20?s');
+
+      const found = await registrationStore.findByUrl(url);
+      expect(found).toBeDefined();
+      // findByUrl echoes back the URL it was queried with, so callers keep the
+      // original literal-brace form; lookup still matches because sparqlIri() is
+      // idempotent across the original and percent-encoded forms.
+      expect(found!.url.toString()).toBe(url.toString());
+      expect(found!.datasets.map((d) => d.toString())).toContain(
+        'https://example.org/dataset/1',
+      );
+
+      await registrationStore.delete(url);
+      expect(await registrationStore.findByUrl(url)).toBeUndefined();
+    });
+
     it('should delete a registration and its linked datasets', async () => {
       const datasets = [
         new URL('https://example.org/dataset/1'),


### PR DESCRIPTION
## Problem

`SparqlRegistrationStore.store`, `findByUrl` and `delete` (and therefore the `POST`/`DELETE /datasets` API endpoints) interpolate the registration URL straight into SPARQL as `<${url}>`. A registration URL that inlines a SPARQL CONSTRUCT — e.g. KB’s `…/sparql?query=CONSTRUCT { ?s ?p ?o } WHERE { … }` — keeps **literal `{` and `}`**, because the WHATWG URL parser does not percent-encode braces in a URL’s query component. Those braces (and spaces, `<`, `>`, etc.) are illegal in a SPARQL/Turtle IRIREF, so every store/find/delete on such a URL fails to parse and returns HTTP 500 (`unexpected character: ->p<-`).

N3.js does not escape these characters either, so the `INSERT` path is broken in the same way — which is why the only such registration that currently exists was stored with the braces already percent-encoded as `%7B`/`%7D`.

## Fix

- Add `sparqlIri()` (`packages/core/src/sparql-iri.ts`), which percent-encodes the characters illegal in a SPARQL/Turtle IRIREF: `< > " { } | ^ ` `` ` `` ` \` and the `U+0000–U+0020` control range.
- Apply it at every point where a registration URL is embedded as `<…>`:
  - `toRdf()` — the `schema:EntryPoint` subject and the `schema:subjectOf` object (storage side).
  - `SparqlRegistrationStore.findByUrl`, `store`’s `DELETE` clause, and `delete` (query side).
- Encoding is idempotent for already-valid IRIs (`%` is itself legal, so `%20` is left untouched while a literal space becomes `%20`). For the KB URL it produces exactly the `%7B`/`%7D` canonical form already stored, so existing registrations keep matching on lookup and delete.

`validationReportGraphIri` was already safe (it uses `encodeURIComponent`). Dataset IRIs come from parsed RDF (already valid) and are matched via variables rather than interpolated, so they are untouched.

## Tests

- `sparql.test.ts`: a store → findByUrl → delete round-trip for a brace-bearing KB-style URL. Fails before the fix with the parse error; passes after.
- `sparql-iri.test.ts`: unit coverage for the encoder (braces, control characters, the full illegal set, idempotency, and URL/string input).
