### PR TITLE
perf(browser): stream Knowledge Graph analysis off the detail-page critical path

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -401,20 +401,36 @@ export type TemporalCoverage =
   | { kind: 'period'; iri?: string; start?: string; end?: string }
   | { kind: 'literal'; value: string };
 
-export interface DatasetDetailResult {
-  dataset: DatasetDetail;
-  distributions: DistributionDetail[];
-  totalDistributions: number;
+// The Dataset Knowledge Graph analysis: everything the page derives from the DKG
+// (QLever), as opposed to the authoritative register record (the DR SPARQL
+// store). Bundled behind one streamed promise (DatasetDetailResult.analysis) so
+// the page shell renders from the register alone — the DKG queries are the slow,
+// supplementary part and never block the first paint. The boundary is exactly
+// DR-sync / DKG-async: every field here comes from PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT
+// (linkedData.declared is the one exception — derived from the register's
+// distributions, passed in — kept here because it belongs to the same criterion).
+export interface DatasetAnalysis {
   summary: DatasetSummary | null;
   // When the Knowledge Graph last generated the summary (ISO dateTime from the
   // DKG's PROV-O provenance), or null when no provenance has been recorded.
   summaryGeneratedAt: string | null;
   linksets: Linkset[];
-  temporalCoverages: TemporalCoverage[];
   iiifManifests: IiifManifests;
   persistentUris: PersistentUris;
   linkedData: LinkedData;
   terms: TermLinks | null;
+}
+
+export interface DatasetDetailResult {
+  dataset: DatasetDetail;
+  distributions: DistributionDetail[];
+  totalDistributions: number;
+  temporalCoverages: TemporalCoverage[];
+  // The Knowledge Graph analysis, streamed off the critical path (see
+  // DatasetAnalysis). The page renders the register record immediately and fills
+  // in the linked-data summary, class/property partitions and NDE-compatibility
+  // criteria once this resolves.
+  analysis: Promise<DatasetAnalysis>;
   resolvedTerms: Promise<Record<string, string>>;
   // Per-distribution health from the register's own probe, keyed by access URL.
   // An unawaited promise so SvelteKit streams it: the page renders immediately
@@ -1105,18 +1121,6 @@ export async function fetchDatasetDetail(
     sources: [PUBLIC_SPARQL_ENDPOINT],
   });
 
-  const summaryLens = createLens(DatasetSummarySchema, {
-    sources: [PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT],
-  });
-
-  const linksLens = createLens(LinksetSchema, {
-    sources: [PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT],
-  });
-
-  const classPartitionLens = createLens(ClassPartitionSchema, {
-    sources: [PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT],
-  });
-
   const distributionLens = createLens(DetailDistributionSchema, {
     sources: [PUBLIC_SPARQL_ENDPOINT],
   });
@@ -1222,9 +1226,81 @@ export async function fetchDatasetDetail(
     }
   `;
 
+  const [datasets, distributions, totalDistributions, temporalCoverages] =
+    await Promise.all([
+      detailLens.query(datasetQuery),
+      distributionLens.query(distributionQuery),
+      fetchDistributionCount(distributionCountQuery),
+      fetchTemporalCoverage(datasetUri),
+    ]);
+
+  const dataset = datasets.find((d) => d.$id === datasetUri) ?? datasets[0];
+  if (!dataset) {
+    error(404, 'Dataset not found');
+  }
+
+  // The Knowledge Graph analysis is the slow, supplementary part of the page, so
+  // fire it unawaited and stream it (see DatasetAnalysis): the register record
+  // above renders immediately and the analysis fills in once it resolves. The
+  // Linked-data declared-flag needs the register's distributions, passed in.
+  const analysis = fetchDatasetAnalysis(datasetUri, distributions);
+
+  // Resolve term URIs (e.g. spatial/temporal) to human-readable labels
+  // via the Network of Terms API. Returned as an unawaited promise so
+  // SvelteKit can stream the result without blocking the page response.
+  const temporalIris = temporalCoverages.flatMap((coverage) =>
+    coverage.kind === 'iri' || (coverage.kind === 'period' && coverage.iri)
+      ? [(coverage as { iri: string }).iri].filter(isUri)
+      : [],
+  );
+  const termUris = [
+    ...(dataset.spatial?.filter(isUri) ?? []),
+    ...temporalIris,
+    ...(dataset.theme?.filter(isUri) ?? []),
+  ];
+  const resolvedTerms =
+    termUris.length > 0
+      ? lookupTermLabels(termUris, getLocale())
+      : Promise.resolve({});
+
+  return {
+    dataset,
+    distributions,
+    totalDistributions,
+    temporalCoverages,
+    analysis,
+    resolvedTerms,
+    distributionHealth,
+    distributionValidity,
+    // The registration's warning count (from its last crawl); 0 when the
+    // registration recorded none or predates warning storage.
+    warningCount: dataset.subjectOf?.warningCount ?? 0,
+  };
+}
+
+// Fetches the Dataset Knowledge Graph analysis (see DatasetAnalysis) for a
+// dataset, off the page's critical path. Every query here hits the Knowledge
+// Graph (QLever); the register's `distributions` are passed in only so the
+// Linked-data criterion can report whether a linked-data distribution is
+// declared. Fields are empty/indeterminate when the dataset has not been
+// analyzed yet.
+async function fetchDatasetAnalysis(
+  datasetUri: string,
+  distributions: DistributionDetail[],
+): Promise<DatasetAnalysis> {
+  const summaryLens = createLens(DatasetSummarySchema, {
+    sources: [PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT],
+  });
+  const linksLens = createLens(LinksetSchema, {
+    sources: [PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT],
+  });
+  const classPartitionLens = createLens(ClassPartitionSchema, {
+    sources: [PUBLIC_KNOWLEDGE_GRAPH_ENDPOINT],
+  });
+
   // Custom CONSTRUCT that sidesteps ldkit's auto-generated findByIri query, for
-  // the same reason as datasetQuery above: ldkit places every property under
-  // OPTIONAL in a single BGP, so the three independent multi-valued properties
+  // the same reason as datasetQuery: ldkit places every property under OPTIONAL
+  // in a single BGP, so the three independent multi-valued properties
   // (propertyPartition, vocabulary, dataDump) Cartesian-product against each
   // other. The Knowledge Graph runs on QLever, which does not deduplicate
   // CONSTRUCT output, so that product is emitted on the wire: on a rich dataset
@@ -1272,22 +1348,15 @@ export async function fetchDatasetDetail(
   `;
 
   const [
-    datasets,
-    distributions,
-    totalDistributions,
     summary,
     linksets,
     classPartitionResult,
     summaryGeneratedAt,
-    temporalCoverages,
     iiifManifests,
     persistentUris,
     persistentUriFailures,
     schemaApNdeConformance,
   ] = await Promise.all([
-    detailLens.query(datasetQuery),
-    distributionLens.query(distributionQuery),
-    fetchDistributionCount(distributionCountQuery),
     summaryLens
       .query(datasetSummaryQuery)
       .then((results) => results[0] ?? null)
@@ -1311,19 +1380,22 @@ export async function fetchDatasetDetail(
         );
         return null;
       }),
-    classPartitionLens.findByIri(datasetUri),
+    // Caught so a Knowledge Graph failure degrades to “no class partition” (the
+    // widget simply doesn't render) instead of rejecting the whole analysis
+    // promise and blanking the streamed section.
+    classPartitionLens.findByIri(datasetUri).catch((e: unknown) => {
+      console.error(
+        'Class partition query failed:',
+        e instanceof Error ? e.message : e,
+      );
+      return null;
+    }),
     fetchSummaryGeneratedAt(datasetUri),
-    fetchTemporalCoverage(datasetUri),
     fetchIiifManifests(datasetUri),
     fetchPersistentUris(datasetUri),
     fetchPersistentUriFailures(datasetUri),
     fetchSchemaApNdeConformance(datasetUri),
   ]);
-
-  const dataset = datasets.find((d) => d.$id === datasetUri) ?? datasets[0];
-  if (!dataset) {
-    error(404, 'Dataset not found');
-  }
 
   // Merge the separately-fetched per-URI failures into the persistent-URI
   // figures, then normalize legacy `no-self-reference` failures into the resolved
@@ -1375,42 +1447,14 @@ export async function fetchDatasetDetail(
             summaryWithClassPartition.distinctObjectsURI ?? null,
         };
 
-  // Resolve term URIs (e.g. spatial/temporal) to human-readable labels
-  // via the Network of Terms API. Returned as an unawaited promise so
-  // SvelteKit can stream the result without blocking the page response.
-  const temporalIris = temporalCoverages.flatMap((coverage) =>
-    coverage.kind === 'iri' || (coverage.kind === 'period' && coverage.iri)
-      ? [(coverage as { iri: string }).iri].filter(isUri)
-      : [],
-  );
-  const termUris = [
-    ...(dataset.spatial?.filter(isUri) ?? []),
-    ...temporalIris,
-    ...(dataset.theme?.filter(isUri) ?? []),
-  ];
-  const resolvedTerms =
-    termUris.length > 0
-      ? lookupTermLabels(termUris, getLocale())
-      : Promise.resolve({});
-
   return {
-    dataset,
-    distributions,
-    totalDistributions,
     summary: summaryWithClassPartition,
     summaryGeneratedAt,
     linksets: linksets ?? [],
-    temporalCoverages,
     iiifManifests,
     persistentUris: persistentUrisWithFailures,
     linkedData,
     terms,
-    resolvedTerms,
-    distributionHealth,
-    distributionValidity,
-    // The registration's warning count (from its last crawl); 0 when the
-    // registration recorded none or predates warning storage.
-    warningCount: dataset.subjectOf?.warningCount ?? 0,
   };
 }
 

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -65,14 +65,10 @@
   const dataset = $derived(data.dataset);
   const distributions = $derived(data.distributions);
   const totalDistributions = $derived(data.totalDistributions);
-  const summary = $derived(data.summary);
-  const summaryGeneratedAt = $derived(data.summaryGeneratedAt);
-  const linksets = $derived(data.linksets);
   const temporalCoverages = $derived(data.temporalCoverages);
-  const iiifManifests = $derived(data.iiifManifests);
-  const persistentUris = $derived(data.persistentUris);
-  const linkedData = $derived(data.linkedData);
-  const terms = $derived(data.terms);
+  // summary, summaryGeneratedAt, linksets, iiifManifests, persistentUris,
+  // linkedData and terms now arrive via the streamed data.analysis promise (see
+  // DatasetAnalysis) and are read inside the {#await} block in the template.
   const registrationHasWarnings = $derived(data.warningCount > 0);
 
   // SEO: canonical and hreflang URLs
@@ -251,16 +247,23 @@
       dataset.creator[0].$id === dataset.publisher.$id,
   );
 
-  const hasVoidStats = $derived(
-    summary &&
+  // summary now arrives via the streamed data.analysis promise, so the
+  // summary-derived values below are plain functions called inside the {#await}
+  // block (with {@const}) rather than top-level $derived. Svelte still tracks any
+  // reactive signals these read (e.g. the streamed health/validity maps), so the
+  // results update as those resolve.
+  function computeHasVoidStats(summary: DatasetSummary | null): boolean {
+    return !!(
+      summary &&
       (summary.triples != null ||
         summary.distinctSubjects != null ||
         summary.properties != null ||
         summary.distinctObjectsURI != null ||
         summary.distinctObjectsLiteral != null ||
         (summary.classPartition && summary.classPartition.length > 0) ||
-        (summary.vocabulary && summary.vocabulary.length > 0)),
-  );
+        (summary.vocabulary && summary.vocabulary.length > 0))
+    );
+  }
 
   // RDF distributions (downloads or SPARQL endpoints) the Knowledge Graph would
   // summarise. A dataset offering only non-RDF downloads (CSV, PDF, …) is not
@@ -279,7 +282,10 @@
   // (merely pending or not yet processed), shows nothing rather than a false
   // failure. Prefers an invalid-RDF cause over a reachability one, as it is the
   // more specific explanation.
-  const summaryUnavailable = $derived.by(() => {
+  function computeSummaryUnavailable(
+    summary: DatasetSummary | null,
+    hasVoidStats: boolean,
+  ) {
     if (summary && hasVoidStats) return undefined;
     if (rdfDistributions.length === 0) return undefined;
     const failed =
@@ -297,7 +303,7 @@
       ? validityReason(validityByUrl.get(failed.accessURL) ?? [])
       : probeReason(healthByUrl.get(failed.accessURL)?.lastOutcome ?? null);
     return { invalid, reason };
-  });
+  }
 
   // Get registration status (gone, invalid, or null)
   const registrationStatus = $derived(
@@ -378,7 +384,7 @@
   }
 
   // Table data for all class partitions with nested property partitions
-  const classPartitionTable = $derived.by(() => {
+  function buildClassPartitionTable(summary: DatasetSummary | null) {
     if (!summary?.classPartition?.length) return undefined;
 
     const sorted = mergeClassPartitions(summary.classPartition).sort(
@@ -424,7 +430,7 @@
       }),
       total,
     };
-  });
+  }
 
   const splitBtnMainClass =
     'inline-flex items-center rounded-s-lg bg-blue-700 px-4 py-2 text-sm font-medium text-white hover:bg-blue-800 focus:z-10 focus:ring-2 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800';
@@ -1576,324 +1582,356 @@
     </div>
   {/if}
 
-  <!-- NDE compatibility (“vinkjes”) -->
-  <NdeCompatibility
-    isAnalyzed={isAnalyzed(summary)}
-    {registrationStatus}
-    {registrationHasWarnings}
-    {persistentUris}
-    {terms}
-    {iiifManifests}
-    {linkedData}
-    validateHref={dataset.subjectOf?.$id
-      ? localizeHref(`/validate?url=${encodeUrlParam(dataset.subjectOf.$id)}`)
-      : null}
-  />
+  <!-- The Knowledge Graph analysis (NDE-compatibility criteria + the VoID
+       linked-data summary) streams in after the register record above; see
+       DatasetAnalysis. The shell renders immediately and this section fills in
+       once data.analysis resolves. -->
+  {#await data.analysis then analysis}
+    {@const summary = analysis.summary}
+    {@const summaryGeneratedAt = analysis.summaryGeneratedAt}
+    {@const linksets = analysis.linksets}
+    {@const iiifManifests = analysis.iiifManifests}
+    {@const persistentUris = analysis.persistentUris}
+    {@const linkedData = analysis.linkedData}
+    {@const terms = analysis.terms}
+    {@const hasVoidStats = computeHasVoidStats(summary)}
+    {@const classPartitionTable = buildClassPartitionTable(summary)}
+    {@const summaryUnavailable = computeSummaryUnavailable(
+      summary,
+      hasVoidStats,
+    )}
+    <!-- NDE compatibility (“vinkjes”) -->
+    <NdeCompatibility
+      isAnalyzed={isAnalyzed(summary)}
+      {registrationStatus}
+      {registrationHasWarnings}
+      {persistentUris}
+      {terms}
+      {iiifManifests}
+      {linkedData}
+      validateHref={dataset.subjectOf?.$id
+        ? localizeHref(`/validate?url=${encodeUrlParam(dataset.subjectOf.$id)}`)
+        : null}
+    />
 
-  <!-- VoID Summary Section -->
-  {#if summary && hasVoidStats}
-    <div class="mb-8">
-      <h2
-        id="linked-data-summary"
-        class="mb-4 flex scroll-mt-20 flex-wrap items-center gap-2 text-xl font-semibold text-gray-900 lg:scroll-mt-24 dark:text-white"
-      >
-        {m.detail_linked_data_summary()}
-        <span id="tooltip-linked-data-summary" class="cursor-pointer">
-          <InfoCircleSolid
-            class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
-          />
-        </span>
-        <Tooltip triggeredBy="#tooltip-linked-data-summary"
-          >{m.detail_linked_data_summary_description()}</Tooltip
+    <!-- VoID Summary Section -->
+    {#if summary && hasVoidStats}
+      <div class="mb-8">
+        <h2
+          id="linked-data-summary"
+          class="mb-4 flex scroll-mt-20 flex-wrap items-center gap-2 text-xl font-semibold text-gray-900 lg:scroll-mt-24 dark:text-white"
         >
-        {#if summaryGeneratedAt}
-          <span
-            id="summary-generated-relative"
-            class="ml-auto cursor-default text-sm font-normal text-gray-600 dark:text-gray-400"
-          >
-            {m.detail_summary_updated({
-              time: getRelativeTimeString(new Date(summaryGeneratedAt)),
-            })}
+          {m.detail_linked_data_summary()}
+          <span id="tooltip-linked-data-summary" class="cursor-pointer">
+            <InfoCircleSolid
+              class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+            />
           </span>
-          <Tooltip triggeredBy="#summary-generated-relative">
-            {new Date(summaryGeneratedAt).toLocaleDateString(getLocale(), {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })}
-          </Tooltip>
-        {/if}
-      </h2>
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <!-- Merged: Triples + Subjects + Avg Triples Per Subject -->
-        {#if (summary.triples !== undefined && summary.triples !== null) || (summary.distinctSubjects !== undefined && summary.distinctSubjects !== null)}
-          <div
-            class="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
+          <Tooltip triggeredBy="#tooltip-linked-data-summary"
+            >{m.detail_linked_data_summary_description()}</Tooltip
           >
-            <div class="space-y-3">
-              {#if summary.distinctSubjects !== undefined && summary.distinctSubjects !== null}
-                <div>
-                  <div class="text-3xl font-bold text-gray-900 dark:text-white">
-                    {summary.distinctSubjects.toLocaleString(getLocale())}
+          {#if summaryGeneratedAt}
+            <span
+              id="summary-generated-relative"
+              class="ml-auto cursor-default text-sm font-normal text-gray-600 dark:text-gray-400"
+            >
+              {m.detail_summary_updated({
+                time: getRelativeTimeString(new Date(summaryGeneratedAt)),
+              })}
+            </span>
+            <Tooltip triggeredBy="#summary-generated-relative">
+              {new Date(summaryGeneratedAt).toLocaleDateString(getLocale(), {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </Tooltip>
+          {/if}
+        </h2>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <!-- Merged: Triples + Subjects + Avg Triples Per Subject -->
+          {#if (summary.triples !== undefined && summary.triples !== null) || (summary.distinctSubjects !== undefined && summary.distinctSubjects !== null)}
+            <div
+              class="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
+            >
+              <div class="space-y-3">
+                {#if summary.distinctSubjects !== undefined && summary.distinctSubjects !== null}
+                  <div>
+                    <div
+                      class="text-3xl font-bold text-gray-900 dark:text-white"
+                    >
+                      {summary.distinctSubjects.toLocaleString(getLocale())}
+                    </div>
+                    <div class="text-sm text-gray-600 dark:text-gray-400">
+                      {m.detail_subjects()}
+                    </div>
                   </div>
-                  <div class="text-sm text-gray-600 dark:text-gray-400">
-                    {m.detail_subjects()}
-                  </div>
-                </div>
-              {/if}
-              {#if summary.triples !== undefined && summary.triples !== null}
-                <div class="border-t border-gray-200 dark:border-gray-700 pt-3">
-                  <div class="text-3xl font-bold text-gray-900 dark:text-white">
-                    {summary.triples.toLocaleString(getLocale())}
-                  </div>
-                  <div class="text-sm text-gray-600 dark:text-gray-400">
-                    {m.detail_triples()}
-                  </div>
-                </div>
-              {/if}
-              {#if summary.triples !== undefined && summary.triples !== null && summary.distinctSubjects !== undefined && summary.distinctSubjects !== null && summary.distinctSubjects > 0}
-                <div class="border-t border-gray-200 dark:border-gray-700 pt-3">
+                {/if}
+                {#if summary.triples !== undefined && summary.triples !== null}
                   <div
-                    class="text-2xl font-semibold text-blue-700 dark:text-blue-300"
+                    class="border-t border-gray-200 dark:border-gray-700 pt-3"
                   >
-                    {(
-                      summary.triples / summary.distinctSubjects
-                    ).toLocaleString(getLocale(), {
-                      minimumFractionDigits: 1,
-                      maximumFractionDigits: 1,
-                    })}
+                    <div
+                      class="text-3xl font-bold text-gray-900 dark:text-white"
+                    >
+                      {summary.triples.toLocaleString(getLocale())}
+                    </div>
+                    <div class="text-sm text-gray-600 dark:text-gray-400">
+                      {m.detail_triples()}
+                    </div>
                   </div>
-                  <div class="text-xs text-gray-600 dark:text-gray-400">
-                    {m.detail_avg_triples_per_subject()}
+                {/if}
+                {#if summary.triples !== undefined && summary.triples !== null && summary.distinctSubjects !== undefined && summary.distinctSubjects !== null && summary.distinctSubjects > 0}
+                  <div
+                    class="border-t border-gray-200 dark:border-gray-700 pt-3"
+                  >
+                    <div
+                      class="text-2xl font-semibold text-blue-700 dark:text-blue-300"
+                    >
+                      {(
+                        summary.triples / summary.distinctSubjects
+                      ).toLocaleString(getLocale(), {
+                        minimumFractionDigits: 1,
+                        maximumFractionDigits: 1,
+                      })}
+                    </div>
+                    <div class="text-xs text-gray-600 dark:text-gray-400">
+                      {m.detail_avg_triples_per_subject()}
+                    </div>
                   </div>
-                </div>
-              {/if}
+                {/if}
+              </div>
             </div>
-          </div>
-        {/if}
+          {/if}
 
-        {#if summary.properties !== undefined && summary.properties !== null}
-          <div
-            class="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
-          >
-            <div class="text-3xl font-bold text-gray-900 dark:text-white">
-              {summary.properties.toLocaleString(getLocale())}
-            </div>
-            <div class="text-sm text-gray-600 dark:text-gray-400">
-              {m.detail_properties()}
-            </div>
-          </div>
-        {/if}
-
-        {#if summary.distinctObjectsURI !== undefined || summary.distinctObjectsLiteral !== undefined}
-          {@const totalObjects =
-            (summary.distinctObjectsURI || 0) +
-            (summary.distinctObjectsLiteral || 0)}
-          {@const literalsCount = summary.distinctObjectsLiteral || 0}
-          {@const urisCount = summary.distinctObjectsURI || 0}
-          {@const literalsPercent =
-            totalObjects > 0 ? (literalsCount / totalObjects) * 100 : 0}
-          {@const urisPercent =
-            totalObjects > 0 ? (urisCount / totalObjects) * 100 : 0}
-          {#if totalObjects > 0}
+          {#if summary.properties !== undefined && summary.properties !== null}
             <div
               class="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
             >
               <div class="text-3xl font-bold text-gray-900 dark:text-white">
-                {totalObjects.toLocaleString(getLocale())}
+                {summary.properties.toLocaleString(getLocale())}
               </div>
-              <div class="text-sm text-gray-600 dark:text-gray-400 mb-3">
-                {m.detail_objects()}
-              </div>
-
-              <!-- Horizontal bar chart -->
-              <div class="mt-4 space-y-3">
-                <div class="flex h-8 overflow-hidden rounded-lg">
-                  {#if literalsCount > 0}
-                    <div
-                      class="flex items-center justify-center bg-blue-500 text-white text-xs font-semibold tabular-nums transition-all"
-                      style="width: {literalsPercent}%"
-                      title="{m.detail_literals()}: {literalsCount.toLocaleString(
-                        getLocale(),
-                      )} ({literalsPercent.toLocaleString(getLocale(), {
-                        minimumFractionDigits: 1,
-                        maximumFractionDigits: 1,
-                      })}%)"
-                    >
-                      {#if literalsPercent > 10}
-                        {literalsPercent.toLocaleString(getLocale(), {
-                          maximumFractionDigits: 0,
-                        })}%
-                      {/if}
-                    </div>
-                  {/if}
-                  {#if urisCount > 0}
-                    <div
-                      class="flex items-center justify-center bg-cyan-500 text-white text-xs font-semibold tabular-nums transition-all"
-                      style="width: {urisPercent}%"
-                      title="{m.detail_uris()}: {urisCount.toLocaleString(
-                        getLocale(),
-                      )} ({urisPercent.toLocaleString(getLocale(), {
-                        minimumFractionDigits: 1,
-                        maximumFractionDigits: 1,
-                      })}%)"
-                    >
-                      {#if urisPercent > 10}
-                        {urisPercent.toLocaleString(getLocale(), {
-                          maximumFractionDigits: 0,
-                        })}%
-                      {/if}
-                    </div>
-                  {/if}
-                </div>
-
-                <!-- Legend -->
-                <div class="flex flex-wrap gap-4 text-xs">
-                  <div class="flex items-center gap-2">
-                    <div class="h-3 w-3 rounded bg-blue-500"></div>
-                    <span class="text-gray-700 dark:text-gray-300">
-                      {m.detail_literals()}: {literalsCount.toLocaleString(
-                        getLocale(),
-                      )}
-                    </span>
-                  </div>
-                  <div class="flex items-center gap-2">
-                    <div class="h-3 w-3 rounded bg-cyan-500"></div>
-                    <span class="text-gray-700 dark:text-gray-300">
-                      {m.detail_uris()}: {urisCount.toLocaleString(getLocale())}
-                    </span>
-                  </div>
-                </div>
+              <div class="text-sm text-gray-600 dark:text-gray-400">
+                {m.detail_properties()}
               </div>
             </div>
           {/if}
+
+          {#if summary.distinctObjectsURI !== undefined || summary.distinctObjectsLiteral !== undefined}
+            {@const totalObjects =
+              (summary.distinctObjectsURI || 0) +
+              (summary.distinctObjectsLiteral || 0)}
+            {@const literalsCount = summary.distinctObjectsLiteral || 0}
+            {@const urisCount = summary.distinctObjectsURI || 0}
+            {@const literalsPercent =
+              totalObjects > 0 ? (literalsCount / totalObjects) * 100 : 0}
+            {@const urisPercent =
+              totalObjects > 0 ? (urisCount / totalObjects) * 100 : 0}
+            {#if totalObjects > 0}
+              <div
+                class="rounded-lg border border-gray-200 bg-white p-4 shadow dark:border-gray-700 dark:bg-gray-800"
+              >
+                <div class="text-3xl font-bold text-gray-900 dark:text-white">
+                  {totalObjects.toLocaleString(getLocale())}
+                </div>
+                <div class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                  {m.detail_objects()}
+                </div>
+
+                <!-- Horizontal bar chart -->
+                <div class="mt-4 space-y-3">
+                  <div class="flex h-8 overflow-hidden rounded-lg">
+                    {#if literalsCount > 0}
+                      <div
+                        class="flex items-center justify-center bg-blue-500 text-white text-xs font-semibold tabular-nums transition-all"
+                        style="width: {literalsPercent}%"
+                        title="{m.detail_literals()}: {literalsCount.toLocaleString(
+                          getLocale(),
+                        )} ({literalsPercent.toLocaleString(getLocale(), {
+                          minimumFractionDigits: 1,
+                          maximumFractionDigits: 1,
+                        })}%)"
+                      >
+                        {#if literalsPercent > 10}
+                          {literalsPercent.toLocaleString(getLocale(), {
+                            maximumFractionDigits: 0,
+                          })}%
+                        {/if}
+                      </div>
+                    {/if}
+                    {#if urisCount > 0}
+                      <div
+                        class="flex items-center justify-center bg-cyan-500 text-white text-xs font-semibold tabular-nums transition-all"
+                        style="width: {urisPercent}%"
+                        title="{m.detail_uris()}: {urisCount.toLocaleString(
+                          getLocale(),
+                        )} ({urisPercent.toLocaleString(getLocale(), {
+                          minimumFractionDigits: 1,
+                          maximumFractionDigits: 1,
+                        })}%)"
+                      >
+                        {#if urisPercent > 10}
+                          {urisPercent.toLocaleString(getLocale(), {
+                            maximumFractionDigits: 0,
+                          })}%
+                        {/if}
+                      </div>
+                    {/if}
+                  </div>
+
+                  <!-- Legend -->
+                  <div class="flex flex-wrap gap-4 text-xs">
+                    <div class="flex items-center gap-2">
+                      <div class="h-3 w-3 rounded bg-blue-500"></div>
+                      <span class="text-gray-700 dark:text-gray-300">
+                        {m.detail_literals()}: {literalsCount.toLocaleString(
+                          getLocale(),
+                        )}
+                      </span>
+                    </div>
+                    <div class="flex items-center gap-2">
+                      <div class="h-3 w-3 rounded bg-cyan-500"></div>
+                      <span class="text-gray-700 dark:text-gray-300">
+                        {m.detail_uris()}: {urisCount.toLocaleString(
+                          getLocale(),
+                        )}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            {/if}
+          {/if}
+        </div>
+
+        <!-- Classes Section with Property Partitions -->
+        {#if classPartitionTable}
+          <ClassPropertiesWidget
+            {classPartitionTable}
+            globalPropertyPartitions={summary.propertyPartition}
+          />
+        {/if}
+
+        <!-- Vocabularies Section -->
+        {#if summary.vocabulary && summary.vocabulary.length > 0}
+          <div class="mt-6">
+            <h3
+              class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
+            >
+              {m.detail_vocabularies()}
+              <span id="tooltip-vocabularies" class="cursor-pointer">
+                <InfoCircleSolid
+                  class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+                />
+              </span>
+              <Tooltip triggeredBy="#tooltip-vocabularies"
+                >{m.detail_vocabularies_description()}</Tooltip
+              >
+            </h3>
+            <ul class="space-y-2">
+              {#each summary.vocabulary as vocab (vocab)}
+                <li class="flex items-center gap-2 text-sm">
+                  <svg
+                    class="w-4 h-4 text-gray-600 dark:text-gray-400 flex-shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                    />
+                  </svg>
+                  <a
+                    href={vocab}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-blue-600 hover:underline dark:text-blue-400 break-all"
+                  >
+                    {vocab}
+                    <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                  </a>
+                </li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
+
+        <!-- Terminology Sources Section -->
+        {#if linksets.length > 0}
+          <div
+            id="terminology-sources"
+            class="mt-6 scroll-mt-20 lg:scroll-mt-24"
+          >
+            <h3
+              class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
+            >
+              {m.detail_terminology_sources()}
+              <span id="tooltip-terminology-sources" class="cursor-pointer">
+                <InfoCircleSolid
+                  class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+                />
+              </span>
+              <Tooltip triggeredBy="#tooltip-terminology-sources"
+                >{m.detail_terminology_sources_description()}</Tooltip
+              >
+            </h3>
+            <ul class="space-y-2">
+              {#each linksets as linkset (linkset.$id)}
+                {#if linkset.objectsTarget}
+                  <li class="flex items-center gap-2 text-sm">
+                    <a
+                      href={localizeHref(
+                        `/datasets?terminologySource=${encodeURIComponent(linkset.objectsTarget.$id)}`,
+                      )}
+                      class="inline-flex items-center gap-1.5 text-blue-600 hover:underline dark:text-blue-400 break-all"
+                    >
+                      <SearchOutline class="w-4 h-4 flex-shrink-0" />
+                      {linkset.objectsTarget.title
+                        ? getLocalizedValue(linkset.objectsTarget.title)
+                        : linkset.objectsTarget.$id}
+                    </a>
+                    {#if linkset.triples !== undefined && linkset.triples !== null}
+                      <span class="text-gray-500 dark:text-gray-400">
+                        ({linkset.triples.toLocaleString(getLocale())}
+                        {m.dataset_triples({ count: linkset.triples })})
+                      </span>
+                    {/if}
+                  </li>
+                {/if}
+              {/each}
+            </ul>
+          </div>
         {/if}
       </div>
-
-      <!-- Classes Section with Property Partitions -->
-      {#if classPartitionTable}
-        <ClassPropertiesWidget
-          {classPartitionTable}
-          globalPropertyPartitions={summary.propertyPartition}
-        />
-      {/if}
-
-      <!-- Vocabularies Section -->
-      {#if summary.vocabulary && summary.vocabulary.length > 0}
-        <div class="mt-6">
-          <h3
-            class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
-          >
-            {m.detail_vocabularies()}
-            <span id="tooltip-vocabularies" class="cursor-pointer">
-              <InfoCircleSolid
-                class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
-              />
-            </span>
-            <Tooltip triggeredBy="#tooltip-vocabularies"
-              >{m.detail_vocabularies_description()}</Tooltip
-            >
-          </h3>
-          <ul class="space-y-2">
-            {#each summary.vocabulary as vocab (vocab)}
-              <li class="flex items-center gap-2 text-sm">
-                <svg
-                  class="w-4 h-4 text-gray-600 dark:text-gray-400 flex-shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                  />
-                </svg>
-                <a
-                  href={vocab}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="text-blue-600 hover:underline dark:text-blue-400 break-all"
-                >
-                  {vocab}
-                  <span class="sr-only"> ({m.opens_in_new_tab()})</span>
-                </a>
-              </li>
-            {/each}
-          </ul>
-        </div>
-      {/if}
-
-      <!-- Terminology Sources Section -->
-      {#if linksets.length > 0}
-        <div id="terminology-sources" class="mt-6 scroll-mt-20 lg:scroll-mt-24">
-          <h3
-            class="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white"
-          >
-            {m.detail_terminology_sources()}
-            <span id="tooltip-terminology-sources" class="cursor-pointer">
-              <InfoCircleSolid
-                class="h-5 w-5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
-              />
-            </span>
-            <Tooltip triggeredBy="#tooltip-terminology-sources"
-              >{m.detail_terminology_sources_description()}</Tooltip
-            >
-          </h3>
-          <ul class="space-y-2">
-            {#each linksets as linkset (linkset.$id)}
-              {#if linkset.objectsTarget}
-                <li class="flex items-center gap-2 text-sm">
-                  <a
-                    href={localizeHref(
-                      `/datasets?terminologySource=${encodeURIComponent(linkset.objectsTarget.$id)}`,
-                    )}
-                    class="inline-flex items-center gap-1.5 text-blue-600 hover:underline dark:text-blue-400 break-all"
-                  >
-                    <SearchOutline class="w-4 h-4 flex-shrink-0" />
-                    {linkset.objectsTarget.title
-                      ? getLocalizedValue(linkset.objectsTarget.title)
-                      : linkset.objectsTarget.$id}
-                  </a>
-                  {#if linkset.triples !== undefined && linkset.triples !== null}
-                    <span class="text-gray-500 dark:text-gray-400">
-                      ({linkset.triples.toLocaleString(getLocale())}
-                      {m.dataset_triples({ count: linkset.triples })})
-                    </span>
-                  {/if}
-                </li>
-              {/if}
-            {/each}
-          </ul>
-        </div>
-      {/if}
-    </div>
-  {:else if summaryUnavailable}
-    <!-- No summary, but the dataset offers RDF that failed: explain why, so the
+    {:else if summaryUnavailable}
+      <!-- No summary, but the dataset offers RDF that failed: explain why, so the
          absence is not silent (the per-distribution detail is in the list below). -->
-    <div class="mb-8">
-      <h2
-        id="linked-data-summary"
-        class="mb-4 flex scroll-mt-20 items-center gap-2 text-xl font-semibold text-gray-900 lg:scroll-mt-24 dark:text-white"
-      >
-        {m.detail_linked_data_summary()}
-      </h2>
-      <Alert border color="yellow" class="mb-6">
-        {#snippet icon()}
-          <ExclamationCircleOutline class="h-5 w-5" />
-        {/snippet}
-        <p class="font-semibold">
-          {summaryUnavailable.invalid
-            ? m.detail_summary_unavailable_invalid()
-            : m.detail_summary_unavailable_unreachable()}
-        </p>
-        <p>{summaryUnavailable.reason}</p>
-      </Alert>
-    </div>
-  {/if}
+      <div class="mb-8">
+        <h2
+          id="linked-data-summary"
+          class="mb-4 flex scroll-mt-20 items-center gap-2 text-xl font-semibold text-gray-900 lg:scroll-mt-24 dark:text-white"
+        >
+          {m.detail_linked_data_summary()}
+        </h2>
+        <Alert border color="yellow" class="mb-6">
+          {#snippet icon()}
+            <ExclamationCircleOutline class="h-5 w-5" />
+          {/snippet}
+          <p class="font-semibold">
+            {summaryUnavailable.invalid
+              ? m.detail_summary_unavailable_invalid()
+              : m.detail_summary_unavailable_unreachable()}
+          </p>
+          <p>{summaryUnavailable.reason}</p>
+        </Alert>
+      </div>
+    {/if}
+  {/await}
 
   <!-- Registration Section -->
   <div class="mb-8">


### PR DESCRIPTION
## Problem

Even with the summary query fixed (#2179), the detail page's first paint waits on the Dataset Knowledge Graph. Profiling showed the register's own queries are fast (~0.3s) but the page blocks on ~8 KG queries (VoID summary, class/property partitions, term linksets, IIIF, persistent-URIs, SCHEMA-AP conformance), which on the production pod cost several seconds. None of that is the authoritative record — it's derived enrichment.

## Change

Split the load on the **DR-sync / DKG-async boundary**:

- **Register store (synchronous, in the SSR shell):** dataset description, distributions, distribution count, temporal coverage. TTFB now depends only on these.
- **Knowledge Graph (streamed):** all analysis is bundled into one unawaited `analysis` promise (`DatasetAnalysis`) on the load result — the same pattern `distributionHealth`/`distributionValidity` already use — and consumed in the page behind `{#await data.analysis}`. The linked-data summary, class & properties widget, and the NDE-compatibility criteria fill in once it resolves.

Implementation notes:

- Extracted `fetchDatasetAnalysis(datasetUri, distributions)` which runs the eight KG queries and derives `linkedData`/`terms`. The register's `distributions` are passed in only for the Linked-data "declared" flag.
- The three `summary`-derived values (`hasVoidStats`, `summaryUnavailable`, `classPartitionTable`) became plain functions called via `{@const}` inside the await block. Svelte 5 still tracks the reactive signals they read (the streamed health/validity maps), so `summaryUnavailable` keeps updating as those resolve.
- The class-partition query is now caught, so a KG failure degrades to a missing widget instead of rejecting the streamed section. This is strictly more resilient than before, where an uncaught class-partition failure 500'd the whole page.

## Measurements (local, rich dataset — Gouda Tijdmachine)

| | before | after |
| --- | --- | --- |
| full-HTML TTFB | ~0.9s | **~0.2s** |
| `__data.json` TTFB | ~0.9s | **~0.16s** |

The analysis still appears in the server-rendered HTML (SvelteKit streams the resolved promise into the same response), so crawlers reading the full response still get it. Non-existent datasets still 404 quickly.

## Notes

- The large `+page.svelte` diff is mostly the prettier re-indent from wrapping the existing markup in `{#await}`; review with whitespace-insensitive diff.
- Builds on the summary UNION query from #2179 (already merged).

Refs #2175.
