### PR TITLE
feat(browser): show a loading indicator while the analysis streams in

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -111,6 +111,7 @@
   "detail_triples": "Triples",
   "detail_distributions": "Distributions",
   "detail_linked_data_summary": "Linked Data Summary",
+  "detail_analysis_loading": "Loading Linked Data summary...",
   "detail_registration": "Registration",
   "detail_class": "Class",
   "detail_classes": "Classes",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -111,6 +111,7 @@
   "detail_triples": "Feiten",
   "detail_distributions": "Distributies",
   "detail_linked_data_summary": "Linked Data-samenvatting",
+  "detail_analysis_loading": "Linked Data-samenvatting laden...",
   "detail_registration": "Registratie",
   "detail_class": "Type",
   "detail_classes": "Typen",

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -1586,7 +1586,34 @@
        linked-data summary) streams in after the register record above; see
        DatasetAnalysis. The shell renders immediately and this section fills in
        once data.analysis resolves. -->
-  {#await data.analysis then analysis}
+  {#await data.analysis}
+    <!-- Skeleton placeholder while the streamed analysis loads, matching the
+         search page's shimmer style: a row for the criteria “vinkjes” and a few
+         lines for the linked-data summary. The label is screen-reader-only; the
+         bars are decorative. -->
+    <div class="mb-8" role="status" aria-live="polite">
+      <span class="sr-only">{m.detail_analysis_loading()}</span>
+      <div class="mb-6 flex flex-wrap gap-3" aria-hidden="true">
+        {#each [1, 2, 3, 4] as pill (pill)}
+          <div
+            class="h-8 w-32 animate-shimmer rounded-full bg-gradient-to-r from-gray-300 to-gray-200 dark:from-gray-700 dark:to-gray-600"
+          ></div>
+        {/each}
+      </div>
+      <div
+        class="mb-4 h-7 w-2/5 animate-shimmer rounded bg-gradient-to-r from-gray-300 to-gray-200 dark:from-gray-700 dark:to-gray-600"
+        aria-hidden="true"
+      ></div>
+      <div
+        class="mb-2.5 h-4 animate-shimmer rounded bg-gradient-to-r from-gray-300 to-gray-200 dark:from-gray-700 dark:to-gray-600"
+        aria-hidden="true"
+      ></div>
+      <div
+        class="h-4 w-3/5 animate-shimmer rounded bg-gradient-to-r from-gray-300 to-gray-200 dark:from-gray-700 dark:to-gray-600"
+        aria-hidden="true"
+      ></div>
+    </div>
+  {:then analysis}
     {@const summary = analysis.summary}
     {@const summaryGeneratedAt = analysis.summaryGeneratedAt}
     {@const linksets = analysis.linksets}


### PR DESCRIPTION
## Change

#2180 streams the Knowledge Graph analysis (NDE-compatibility criteria + Linked Data summary) behind `{#await data.analysis}`, but used the `then`-only shorthand — so that section was simply blank until the analysis resolved. This adds a pending block: a small spinner and a translated label (`detail_analysis_loading`, en/nl), announced via `role="status"` / `aria-live="polite"`, so the wait is visible instead of a gap.

Verified the indicator renders in the streamed SSR shell and is replaced once `data.analysis` resolves.

## Notes

- Follow-up to #2180 (which introduced the streamed analysis section).
- Partially addresses the wait-feedback ask in #2175 (for the analysis section specifically).

Refs #2175.
