### PR TITLE
fix(browser): make a11y e2e tests hermetic to stop flaky page.goto timeouts

### DIFF
--- a/apps/browser/e2e/accessibility.spec.ts
+++ b/apps/browser/e2e/accessibility.spec.ts
@@ -1,5 +1,6 @@
-import { test, expect, type Page } from '@playwright/test';
+import { type Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+import { test, expect } from './fixtures';
 
 // Navigate to /datasets and wait for the server-rendered shell. We deliberately
 // do NOT wait for the client-side search or facets to resolve: those depend on

--- a/apps/browser/e2e/fixtures.ts
+++ b/apps/browser/e2e/fixtures.ts
@@ -1,0 +1,33 @@
+import { test as base, expect } from '@playwright/test';
+
+// Playwright's page.goto() and waitForLoadState('load') wait for the `load`
+// event, which only fires once every subresource settles. The app's shared
+// layout links external resources from its <head> — the Google Fonts stylesheet
+// plus its font files, and the remote favicons on datasetregister.netwerk‐
+// digitaalerfgoed.nl. CI egress to those hosts is intermittently slow, so `load`
+// could take longer than the 60s test timeout and fail with “page.goto: Test
+// timeout exceeded”, even though the page itself is fully rendered. That was the
+// sole cause of the flaky e2e failures.
+//
+// Abort every external (non-localhost) HTTP(S) request up front so the suite is
+// hermetic and never waits on a third-party host. Aborted requests resolve
+// immediately as failed, so `load` fires promptly. Per-test SPARQL mocks are
+// registered later (in a beforeEach) and take precedence over this catch-all, so
+// they keep working.
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.route('**/*', (route) => {
+      const url = new URL(route.request().url());
+      const isLocal =
+        url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+      const isHttp = url.protocol === 'http:' || url.protocol === 'https:';
+      if (!isLocal && isHttp) {
+        return route.abort();
+      }
+      return route.continue();
+    });
+    await use(page);
+  },
+});
+
+export { expect };

--- a/apps/browser/e2e/hydration.spec.ts
+++ b/apps/browser/e2e/hydration.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 // This spec runs against the real adapter-node production server (`node build`),
 // not `vite preview` — see playwright.config.ts. It guards against production


### PR DESCRIPTION
## Problem

The `test` job intermittently fails on the `Run E2E tests` step, always with the same signature — never a real assertion:

```
page.goto: Test timeout of 60000ms exceeded
```

It hit `apps/browser/e2e/accessibility.spec.ts` on both the datasets list page (which has no backend dependency) and the detail page, so the backend was never the cause. The recurring `Distribution … query failed: fetch failed` log lines are a red herring: those SSR SPARQL calls fail fast in CI and the page still renders.

## Root cause

`page.goto()` and `waitForLoadState('load')` wait for the `load` event, which only fires once every subresource settles. The shared layout (`apps/browser/src/routes/+layout.svelte`) links external resources from its `<head>`:

- the Google Fonts stylesheet `https://fonts.googleapis.com/css2?family=Poppins…` plus its font files, and
- remote favicons on `datasetregister.netwerkdigitaalerfgoed.nl`.

When CI egress to those third-party hosts is slow or throttled, `load` never fires within the 60s test timeout, even though the page itself is fully rendered — so `page.goto` times out.

## Fix

Add a shared Playwright fixture (`apps/browser/e2e/fixtures.ts`) that aborts every external (non-localhost) HTTP(S) request. Aborted requests resolve immediately as failed, so `load` fires promptly and the suite becomes hermetic — it never waits on a third-party host. Per-test SPARQL mocks are registered later (in `beforeEach`) and take precedence over this catch-all, so they keep working.

Both `accessibility.spec.ts` and `hydration.spec.ts` now import `test`/`expect` from the fixture.

## Verification

- `npx playwright test accessibility.spec.ts` → 11 passed locally, including the WCAG color-contrast checks (unaffected by the missing web font).
- `nx run-many -t lint check build -p @dataset-register/browser` → all green.

This unblocks the open Dependabot PRs (#2181, #2183) whose only failure was this flaky step.
