### PR TITLE
refactor(browser): drop cookie locale strategy, rely on URL only

### DIFF
--- a/apps/browser/vite.config.ts
+++ b/apps/browser/vite.config.ts
@@ -10,7 +10,14 @@ export default defineConfig({
     sveltekit(),
     paraglideVitePlugin({
       project: './project.inlang',
-      strategy: ['url', 'cookie', 'baseLocale'],
+      // URL-only locale: the prefix (/en/…) or its absence (base locale nl)
+      // fully determines the language. No cookie strategy, so a bare URL renders
+      // one deterministic locale — the single source of truth. This keeps links
+      // shareable/cacheable per URL and avoids the ambiguity where a cookie could
+      // make the same URL render either language. Language switching stays
+      // URL-based (see LanguageToggle), and internal links carry the locale via
+      // localizeHref, so the choice persists through navigation.
+      strategy: ['url', 'baseLocale'],
       outdir: './src/lib/paraglide',
     }),
   ],


### PR DESCRIPTION
## Change

Drop the `cookie` strategy from Paraglide so the **URL alone determines the language**:

```ts
strategy: ['url', 'baseLocale']   // was ['url', 'cookie', 'baseLocale']
```

`/en/…` renders English; the un-prefixed path renders the base locale (nl).

## Why

The cookie was doing very little, and it made the same URL ambiguous (a cookie could make `/dataset?…` render either language):

- Language switching already navigates **by URL** (`LanguageToggle` → `localizeHref(page.url, { locale })`).
- Internal links carry the locale via `localizeHref` (used across the layout, detail page, search page, and cards), so the chosen language persists through navigation without the cookie.
- Nothing reads the locale cookie directly, and `getLocale()` resolves from the URL on both server and client.

Making locale URL-deterministic keeps pages shareable/cacheable per URL (no cookie-keying / `Vary`), is better for SEO (the canonical URL isn't cookie-dependent; hreflang alternates are already emitted), and removes the render-ambiguity.

## Trade-off

A returning visitor who previously chose a non-base locale and then opens a **bare** (un-prefixed) URL in a new session now gets nl instead of their remembered language. Within a session and for any shared `/en/…` link, the language still persists via the URL.

## Verification

Smoke-tested the production build:
- bare URL → nl; `/en/…` → en.
- bare URL **with** a `PARAGLIDE_LOCALE=en` cookie → nl (cookie now ignored, as intended).
- toggle on the nl page links to `/en/…`; the `/en/` page shows EN active.

Typecheck clean, 192 unit tests pass.
