### PR TITLE
fix: correct root package.json license to EUPL-1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@dataset-register/source",
   "version": "0.0.0",
   "private": true,
-  "license": "MIT",
+  "license": "EUPL-1.2",
   "workspaces": [
     "apps/*",
     "packages/*"


### PR DESCRIPTION
## Summary

- Root `package.json` declared `"license": "MIT"`, while `LICENSE.md` and `codemeta.json` both specify EUPL-1.2 – the license actually applied to this repo.
- Updates `package.json` to `"license": "EUPL-1.2"` so all three sources agree.

Fix #2190
