### PR TITLE
fix(browser): return 503 instead of crashing when the register is unreachable

### DIFF
--- a/apps/browser/e2e/accessibility.spec.ts
+++ b/apps/browser/e2e/accessibility.spec.ts
@@ -1,6 +1,17 @@
-import { type Page } from '@playwright/test';
+import { type Page, type Response } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import { test, expect } from './fixtures';
+
+// The dataset detail route renders via SSR against the live SPARQL endpoint
+// (page.route only mocks browser requests, not server-side fetches). Depending on
+// whether CI can reach the endpoint, the response is 404 (dataset not found) or a
+// deliberate 503 (backend temporarily unavailable) — both are handled error pages.
+// The regression this guards against (issue #1860) is an unhandled 500 crash, so
+// 500 specifically must never occur.
+function expectHandledResponse(response: Response | null) {
+  const httpStatus = response?.status() ?? 0;
+  expect(httpStatus === 503 || httpStatus < 500).toBe(true);
+}
 
 // Navigate to /datasets and wait for the server-rendered shell. We deliberately
 // do NOT wait for the client-side search or facets to resolve: those depend on
@@ -188,11 +199,7 @@ test.describe('Accessibility - Dataset Detail Page', () => {
     const response = await page.goto(
       '/dataset?uri=https%3A%2F%2Fexample.org%2Fdataset%2F1',
     );
-    // SSR hits the live SPARQL endpoint (page.route only intercepts browser
-    // requests), so this URI returns a 404 "not found" page. Assert that the
-    // route does not crash (5xx) — see issue #1860 for the kind of regression
-    // this guards against.
-    expect(response?.status()).toBeLessThan(500);
+    expectHandledResponse(response);
     await page.waitForLoadState('load');
 
     const results = await new AxeBuilder({ page })
@@ -214,11 +221,7 @@ test.describe('Accessibility - Dataset Detail Page', () => {
     const response = await page.goto(
       '/dataset?uri=https%3A%2F%2Fexample.org%2Fdataset%2F1',
     );
-    // SSR hits the live SPARQL endpoint (page.route only intercepts browser
-    // requests), so this URI returns a 404 "not found" page. Assert that the
-    // route does not crash (5xx) — see issue #1860 for the kind of regression
-    // this guards against.
-    expect(response?.status()).toBeLessThan(500);
+    expectHandledResponse(response);
     await page.waitForLoadState('load');
 
     // Check for main heading (h1 with dataset title)
@@ -239,11 +242,7 @@ test.describe('Accessibility - Dataset Detail Page', () => {
     const response = await page.goto(
       '/dataset?uri=https%3A%2F%2Fexample.org%2Fdataset%2F1',
     );
-    // SSR hits the live SPARQL endpoint (page.route only intercepts browser
-    // requests), so this URI returns a 404 "not found" page. Assert that the
-    // route does not crash (5xx) — see issue #1860 for the kind of regression
-    // this guards against.
-    expect(response?.status()).toBeLessThan(500);
+    expectHandledResponse(response);
     await page.waitForLoadState('load');
 
     // Find a link and verify it can receive focus
@@ -256,11 +255,7 @@ test.describe('Accessibility - Dataset Detail Page', () => {
     const response = await page.goto(
       '/dataset?uri=https%3A%2F%2Fexample.org%2Fdataset%2F1',
     );
-    // SSR hits the live SPARQL endpoint (page.route only intercepts browser
-    // requests), so this URI returns a 404 "not found" page. Assert that the
-    // route does not crash (5xx) — see issue #1860 for the kind of regression
-    // this guards against.
-    expect(response?.status()).toBeLessThan(500);
+    expectHandledResponse(response);
     await page.waitForLoadState('load');
 
     const results = await new AxeBuilder({ page })

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -1242,7 +1242,23 @@ export async function fetchDatasetDetail(
       distributionLens.query(distributionQuery),
       fetchDistributionCount(distributionCountQuery),
       fetchTemporalCoverage(datasetUri),
-    ]);
+    ]).catch((e: unknown) => {
+      // The register lens queries hit the SPARQL endpoint directly and have no
+      // internal fallback (unlike the count/temporal fetches, which catch and
+      // return empty). If the endpoint is unreachable or returns a malformed
+      // response the Promise rejects here; surface it as a deliberate 503 so the
+      // route renders a handled “temporarily unavailable” page instead of
+      // crashing with an unhandled 500 (see issue #1860). A genuinely missing
+      // dataset comes back as an empty result set and is handled as 404 below.
+      console.error(
+        `Register queries failed for <${datasetUri}>:`,
+        e instanceof Error ? e.message : e,
+      );
+      error(
+        503,
+        'The dataset register is temporarily unavailable. Please try again shortly.',
+      );
+    });
 
   const dataset = datasets.find((d) => d.$id === datasetUri) ?? datasets[0];
   if (!dataset) {


### PR DESCRIPTION
## Problem

The dataset detail page's SSR `load` runs the register lens queries directly against the SPARQL endpoint (`detailLens.query` / `distributionLens.query`). Unlike the distribution-count and temporal-coverage fetches — which catch and return empty — these have **no internal fallback**. When the endpoint is unreachable the `Promise.all` rejects, the rejection propagates out of `load`, and SvelteKit renders an **unhandled 500**. (A genuinely missing dataset comes back as an *empty result set* and is correctly handled as a 404.)

This was:
- **The last e2e flake source.** The detail-page a11y tests SSR against the live endpoint (`page.route` only mocks browser requests, not server-side fetches). When CI couldn't reach SPARQL, the route 500'd and the tests failed non-deterministically — e.g. the transient failure seen on #2188.
- **A real production risk.** A transient SPARQL blip would serve visitors a 500 crash instead of a graceful page — exactly the regression the `#1860` guard exists to prevent.

## Fix

Catch the register-query rejection and surface a deliberate **503 “temporarily unavailable”**, so the route renders a handled error page instead of crashing. A missing dataset still returns 404 (unchanged).

The detail-page tests now accept the reachability-dependent outcome — 404 when the endpoint is reachable, 503 when it isn't — via a shared `expectHandledResponse` helper, while still failing on an unhandled 500 (so the `#1860` guard is preserved and made more specific).

## Why 503 (not 404) on unreachability

The dataset may well exist — we just can't reach the store. 503 tells crawlers “transient, retry”; a 404 would wrongly signal the dataset is gone. 503 is a *handled* response (renders the error page), not a crash.

## Verification

- Built with `PUBLIC_SPARQL_ENDPOINT` pointed at a closed port → detail route returns **HTTP 503** (previously 500); `/datasets` still 200.
- `CI=1` production e2e against the live endpoint → all detail-page tests pass (404 path).
- `svelte-check`: 0 errors; `vite build` clean; eslint clean.
