### PR TITLE
fix(search-indexer): read IIIF measurements via the void:subset/dqv path

### DIFF
--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -462,18 +462,17 @@ async function fetchIiifManifests(datasetUri: string): Promise<IiifManifests> {
     PREFIX dqv: <http://www.w3.org/ns/dqv#>
     PREFIX nde: <https://def.nde.nl/metric#>
     SELECT ?declared ?sampled ?validated WHERE {
-      <${datasetUri}> void:subset [
-        dct:conformsTo <${IIIF_PRESENTATION_API}> ;
-        void:entities ?declared
-      ] .
+      <${datasetUri}> void:subset ?iiifSubset .
+      ?iiifSubset dct:conformsTo <${IIIF_PRESENTATION_API}> ;
+        void:entities ?declared .
       OPTIONAL {
-        <${datasetUri}> dqv:hasQualityMeasurement [
+        ?iiifSubset dqv:hasQualityMeasurement [
           dqv:isMeasurementOf nde:manifests-sampled ;
           dqv:value ?sampled
         ]
       }
       OPTIONAL {
-        <${datasetUri}> dqv:hasQualityMeasurement [
+        ?iiifSubset dqv:hasQualityMeasurement [
           dqv:isMeasurementOf nde:manifests-validated ;
           dqv:value ?validated
         ]

--- a/packages/search-indexer/src/dkg-source.ts
+++ b/packages/search-indexer/src/dkg-source.ts
@@ -54,8 +54,16 @@ export class DkgSource {
           ?dataset void:subset ?iiifSubset .
           ?iiifSubset dct:conformsTo <${IIIF_PRESENTATION_API}> ; void:entities ?iiifEntities .
         }
-        UNION { ?dataset dqv:hasQualityMeasurement [ dqv:isMeasurementOf metric:manifests-sampled ; dqv:value ?manifestsSampled ] }
-        UNION { ?dataset dqv:hasQualityMeasurement [ dqv:isMeasurementOf metric:manifests-validated ; dqv:value ?manifestsValidated ] }
+        UNION {
+          ?dataset void:subset ?iiifSubset .
+          ?iiifSubset dct:conformsTo <${IIIF_PRESENTATION_API}> ;
+            dqv:hasQualityMeasurement [ dqv:isMeasurementOf metric:manifests-sampled ; dqv:value ?manifestsSampled ] .
+        }
+        UNION {
+          ?dataset void:subset ?iiifSubset .
+          ?iiifSubset dct:conformsTo <${IIIF_PRESENTATION_API}> ;
+            dqv:hasQualityMeasurement [ dqv:isMeasurementOf metric:manifests-validated ; dqv:value ?manifestsValidated ] .
+        }
         UNION { ?dataset dqv:hasQualityMeasurement [ dqv:isMeasurementOf metric:quads-validated ; dqv:value ?quadsValidated ] }
         UNION { ?dataset dqv:hasQualityMeasurement [ dqv:isMeasurementOf metric:schema-ap-nde-sample-conformance ; dqv:value ?schemaApNdeConformant ] }
         UNION { ?dataset dqv:hasQualityMeasurement [ dqv:isMeasurementOf metric:subject-uris-sampled ; dqv:value ?subjectUrisSampled ] }

--- a/packages/search-indexer/test/run-index.test.ts
+++ b/packages/search-indexer/test/run-index.test.ts
@@ -165,11 +165,18 @@ const IIIF_PRESENTATION_API = 'http://iiif.io/api/presentation/';
 const XSD_BOOLEAN = 'http://www.w3.org/2001/XMLSchema#boolean';
 
 /** A `dqv:hasQualityMeasurement` of a metric carrying a typed value, keyed to a
- *  fresh measurement node so several metrics coexist on one dataset. */
-function measurement(slug: string, metric: string, value: string): string {
-  const measurementNode = `${base(slug)}/measurement/${metric}`;
+ *  fresh measurement node so several metrics coexist on one subject. Defaults to
+ *  hanging the measurement off the dataset; pass `subject` to attach it to a
+ *  subset (the IIIF measurements hang off the IIIF `void:subset`). */
+function measurement(
+  slug: string,
+  metric: string,
+  value: string,
+  subject: string = base(slug),
+): string {
+  const measurementNode = `${subject}/measurement/${metric}`;
   return `
-    <${base(slug)}> <${DQV}hasQualityMeasurement> <${measurementNode}> .
+    <${subject}> <${DQV}hasQualityMeasurement> <${measurementNode}> .
     <${measurementNode}> <${DQV}isMeasurementOf> <${METRIC}${metric}> ;
       <${DQV}value> ${value} .`;
 }
@@ -183,8 +190,8 @@ function dqvInsertQuery(slug: string): string {
     <${iri}> <${VOID}subset> <${iiifSubset}> .
     <${iiifSubset}> <${DCT}conformsTo> <${IIIF_PRESENTATION_API}> ;
       <${VOID}entities> 5 .
-    ${measurement(slug, 'manifests-sampled', '5')}
-    ${measurement(slug, 'manifests-validated', '5')}
+    ${measurement(slug, 'manifests-sampled', '5', iiifSubset)}
+    ${measurement(slug, 'manifests-validated', '5', iiifSubset)}
     ${measurement(slug, 'quads-validated', '42')}
     ${measurement(slug, 'schema-ap-nde-sample-conformance', `"true"^^<${XSD_BOOLEAN}>`)}
     ${measurement(slug, 'subject-uris-sampled', '10')}


### PR DESCRIPTION
Migrates the IIIF validation measurements (`manifests-sampled`, `manifests-validated`) from the transitional dataset-level `dqv:hasQualityMeasurement` link to the `void:subset` → `dqv:hasQualityMeasurement` path.

The Dataset Knowledge Graph now hangs these measurements off the IIIF capability subset — the same node that already carries `dcterms:conformsTo <http://iiif.io/api/presentation/>` and `void:entities`. It currently emits **both** links (dataset-level and subset-level) for backward compatibility; this migrates our consumers to the subset path so the DKG can drop the dataset-level link.

## Changes

- **`packages/search-indexer/src/dkg-source.ts`** — the listing/enrichment CONSTRUCT: scope both manifest-measurement UNION branches to `?iiifSubset`, re-binding the subset per branch and guarding it with `dct:conformsTo <iiif>` so a dataset's *other* subsets (media, subject namespaces) cannot supply the values.
- **`apps/browser/src/lib/services/dataset-detail.ts`** (`fetchIiifManifests`) — bind the IIIF subset to a variable and read `manifests-sampled` / `manifests-validated` off it instead of off the dataset.
- **`packages/search-indexer/test/run-index.test.ts`** — the QLever acceptance fixture now attaches the manifest measurements to the IIIF subset, matching the new DKG output; the existing test exercises the migrated query end-to-end.

## Notes

The issue named `apps/browser/src/lib/services/datasets.ts` as the second consumer, but the listing path has since moved to the Typesense search index — the SPARQL query that reads these measurements now lives in the `search-indexer`'s `dkg-source.ts`, which is what this migrates. `datasets.ts` reads the indexed `iiif` / `iiif_manifest_count` fields and needs no change.

The `void:subset` structure only appears after a full DKG run has produced it, which has now happened; both links are present in the live graph, so this is safe to deploy.

Fix #2048
