### PR TITLE
fix: release requirements, browser, and core independently

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "include-component-in-tag": true,
   "include-v-in-tag": false,
   "bump-minor-pre-major": true,
+  "separate-pull-requests": true,
   "packages": {
     "requirements": {
       "release-type": "simple",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,13 @@
   "include-v-in-tag": false,
   "bump-minor-pre-major": true,
   "separate-pull-requests": true,
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "dataset-register-app",
+      "components": ["browser", "core"]
+    }
+  ],
   "packages": {
     "requirements": {
       "release-type": "simple",


### PR DESCRIPTION
## Summary

- `requirements` is released independently from `browser`/`core` (`separate-pull-requests: true`), matching how it's always been pushed.
- `browser` and `core` are grouped via the `linked-versions` plugin so they share one release PR and version number — both feed the public `/changes` changelog page, so it makes sense for them to release together rather than as three separate PRs.
- Replaces #2201, which bundled all three components into a single PR before this fix landed.
