### PR TITLE
feat(core): warn on bare compression and non-IANA x- media types in encodingFormat

### DIFF
--- a/packages/core/test/datasets/dataset-schema-org-bare-compression-distribution.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-bare-compression-distribution.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "name": "Alba amicorum van de Koninklijke Bibliotheek",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://example.com/publisher",
+    "name": "Koninklijke Bibliotheek"
+  },
+  "distribution": {
+    "@type": "DataDownload",
+    "contentUrl": "https://example.com/download.zip",
+    "encodingFormat": "application/x-zip-compressed"
+  }
+}

--- a/packages/core/test/validator.test.ts
+++ b/packages/core/test/validator.test.ts
@@ -305,6 +305,50 @@ describe('Validator', () => {
     `);
   });
 
+  it('warns on a bare compression encodingFormat and on a non-IANA x- prefix', async () => {
+    // A dump declared as a bare zip container names how the bytes are packed but
+    // not the RDF serialization inside, so it cannot be imported; and the
+    // x- prefixed type is not registered with IANA. Both fire as warnings, so the
+    // dataset stays valid while the provider is told to declare, for example,
+    // application/rdf+xml+zip.
+    const report = (await validate(
+      'dataset-schema-org-bare-compression-distribution.jsonld',
+    )) as Valid;
+    expect(report.state).toEqual('valid');
+
+    const encodingFormatResults = [
+      ...report.errors.match(
+        null,
+        shacl('resultPath'),
+        rdf.namedNode('https://schema.org/encodingFormat'),
+      ),
+    ].map((quad) => quad.subject);
+    // One result per warning shape: bare-compression and non-IANA x- prefix.
+    expect(encodingFormatResults).toHaveLength(2);
+
+    for (const result of encodingFormatResults) {
+      expect(
+        [...report.errors.match(result, shacl('resultSeverity'), null)][0]
+          ?.object.value,
+      ).toEqual('http://www.w3.org/ns/shacl#Warning');
+    }
+
+    const messages = encodingFormatResults.flatMap((result) =>
+      [...report.errors.match(result, shacl('resultMessage'), null)]
+        .filter(
+          (quad) =>
+            quad.object.termType === 'Literal' && quad.object.language === 'en',
+        )
+        .map((quad) => quad.object.value),
+    );
+    expect(messages).toContain(
+      'A bare compression type (such as application/zip or application/gzip) does not indicate the media type of the packaged file(s). Declare the actual media type with a compression suffix, such as application/rdf+xml+zip or text/csv+gzip',
+    );
+    expect(messages).toContain(
+      'Use a registered IANA media type. Media types with the x- prefix (such as application/x-zip-compressed) are not registered with IANA; use the registered type, such as application/zip',
+    );
+  });
+
   it('accepts ISO 8601 shortened-end temporal coverage notation', async () => {
     const report = (await validate(
       'dataset-schema-org-temporal-shortened.jsonld',

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -553,6 +553,39 @@ nde-dataset:DistributionShape
             ] ;
             sh:message "Verwijder het SPARQL MIME-type uit schema:encodingFormat; SPARQL-endpoints worden gedeclareerd via schema:usageInfo"@nl, "Remove the SPARQL MIME type from schema:encodingFormat; SPARQL endpoints are declared via schema:usageInfo"@en ;
         ] ,
+        # A bare compression container (zip/gzip) names how the bytes are packed
+        # but not the media type of the file(s) inside, so consumers cannot know
+        # how to parse the download. The inner format need not be RDF (it may be
+        # CSV, XML, etc.). Declare the packaged media type together with the
+        # compression as a suffix, e.g. application/rdf+xml+zip or text/csv+gzip.
+        [
+            sh:path schema:encodingFormat ;
+            sh:not [ sh:in (
+                "application/zip"
+                "application/x-zip-compressed"
+                "application/gzip"
+                "application/x-gzip"
+            ) ] ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "Een kaal compressietype (zoals application/zip of application/gzip) geeft niet aan welk mediatype de ingepakte bestanden hebben. Declareer het werkelijke mediatype met een compressiesuffix, bijvoorbeeld application/rdf+xml+zip of text/csv+gzip"@nl, "A bare compression type (such as application/zip or application/gzip) does not indicate the media type of the packaged file(s). Declare the actual media type with a compression suffix, such as application/rdf+xml+zip or text/csv+gzip"@en ;
+        ] ,
+        # Media types with an x- prefix (e.g. application/x-zip-compressed) are
+        # not registered with IANA; the x- convention was deprecated by RFC 6648.
+        # Use the registered type so consumers recognise it.
+        [
+            sh:path schema:encodingFormat ;
+            sh:not [ sh:pattern "^[a-zA-Z]+/x-" ] ;
+            sh:severity sh:Warning ;
+            nde:futureChange [
+                nde:version "2.0" ;
+                sh:severity sh:Violation ;
+            ] ;
+            sh:message "Gebruik een geregistreerd IANA-mediatype. Mediatypes met het voorvoegsel x- (zoals application/x-zip-compressed) zijn niet geregistreerd bij IANA; gebruik het geregistreerde type, bijvoorbeeld application/zip"@nl, "Use a registered IANA media type. Media types with the x- prefix (such as application/x-zip-compressed) are not registered with IANA; use the registered type, such as application/zip"@en ;
+        ] ,
         # Recommended properties
         [
             sh:path schema:description ;


### PR DESCRIPTION
## Why

A dataset can declare a data dump whose media type names only the compression
container, not the format of the file inside — e.g. `application/zip` or the
non-standard `application/x-zip-compressed`. A consumer then cannot know how to
parse the download, yet nothing flagged it: the description passed validation and
the dataset showed as **valid**. The provider got no signal that their dump is
effectively opaque to downstream tooling (e.g. the Dataset Knowledge Graph),
which then falls back to the SPARQL endpoint only — and shows empty results when
that endpoint is unreliable.

Observed on RMO (`application/x-zip-compressed`), Huis van Hilde
(`application/x-zip-compressed`) and Verhaal van Utrecht (`application/zip`).

## What

Two SHACL warnings on `schema:encodingFormat` in the distribution shape:

1. **Bare compression container** — `application/zip`, `application/x-zip-compressed`,
   `application/gzip`, `application/x-gzip`. Message asks the provider to declare
   the packaged media type with a compression suffix. The inner format need not be
   RDF (it may be CSV, XML, etc.), matching the register's own `text/csv+gzip`
   example — e.g. `application/rdf+xml+zip` or `text/csv+gzip`.
2. **Non-IANA `x-` prefix** — media types whose subtype starts with `x-` are not
   registered with IANA (the convention was deprecated by RFC 6648). Message asks
   for the registered type, e.g. `application/zip`.

Both are `sh:Warning` now and escalate to `sh:Violation` in profile v2.0, mirroring
the existing SPARQL-MIME warning. They do not invalidate a dataset today.

This is declaration-level and complements the existing probe-based checks
(`probeReachable`, `probeFormatMatch`): those only fire on an unreachable URL or a
served-vs-declared mismatch, so a reachable dump whose server sends exactly the
declared (but opaque) type slips through — which is precisely the RMO case.

## Test

Adds `dataset-schema-org-bare-compression-distribution.jsonld`
(`application/x-zip-compressed`, which trips both rules) and a validator test
asserting the dataset stays valid with both warnings on `schema:encodingFormat`.
Full `@dataset-register/core` suite passes.
