### PR TITLE
fix(browser): stop /graphql pulling comunica via the core barrel

### DIFF
--- a/apps/browser/src/lib/services/search/engine.server.ts
+++ b/apps/browser/src/lib/services/search/engine.server.ts
@@ -12,7 +12,7 @@ import {
   SEARCH_COLLECTION_ALIAS,
   SEARCH_SCHEMA,
   TERMINOLOGY_SOURCE_COLLECTION_ALIAS,
-} from '@dataset-register/core';
+} from '@dataset-register/core/search';
 
 /**
  * The server-side search engine + GraphQL schema behind the `/graphql` endpoint.

--- a/apps/browser/src/lib/services/search/graphql-schema.test.ts
+++ b/apps/browser/src/lib/services/search/graphql-schema.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { printGraphQLSchema } from '@lde/search-api-graphql';
 import { buildSchema, GraphQLInputObjectType, parse, validate } from 'graphql';
-import { SEARCH_SCHEMA } from '@dataset-register/core';
+import { SEARCH_SCHEMA } from '@dataset-register/core/search';
 import type { SearchRequest } from '../datasets';
 import { buildWhere, DATASET_SEARCH_QUERY } from './datasets';
 

--- a/packages/core/src/search/index.ts
+++ b/packages/core/src/search/index.ts
@@ -2,4 +2,5 @@ export * from './class-groups.ts';
 export * from './collections.ts';
 export * from './compatibility.ts';
 export * from './media-types.ts';
+export * from './schema.ts';
 export * from './synonyms.ts';


### PR DESCRIPTION
## Problem

On merged `main`, every request to the new `/graphql` search endpoint returns **500**:

```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '.../node_modules/graphql/language'
is not supported resolving ES modules imported from .../build/server/chunks/.../graphql/_server.ts.js
```

`engine.server.ts` imported `SEARCH_SCHEMA` (and the collection-alias constants) from the top-level `@dataset-register/core` barrel. That barrel also re-exports the SPARQL query layer (`query.ts` / `sparql.ts` / `validator.ts`), so the `/graphql` endpoint transitively pulls in comunica’s `graphql-to-sparql`. That package does a directory import of `graphql/language`, which graphql 15 (no `exports` map) cannot resolve under Node’s ESM loader in the adapter-node server bundle – so the endpoint crashes at request time.

`docker:smoke` did not catch it because it never fires a real `/graphql` POST; the crash only surfaces when the resolver module is first loaded.

The production browser is currently **pinned** (image held ahead of this migration), so prod search is not yet broken – but this must land before the browser is unpinned.

## Fix

- Import the search symbols from the node-builtin-free `@dataset-register/core/search` subpath – the same subpath the rest of the browser already uses (see the `project_browser_no_node_builtins` precedent). This keeps comunica out of the `/graphql` bundle entirely.
- Add the missing `export * from './schema.ts';` to that subpath barrel (`packages/core/src/search/index.ts`) so `SEARCH_SCHEMA` is reachable there (it was only re-exported from the top-level barrel).

Three lines changed across three files.

## Verification

- Built the browser and ran `node build`; the server bundle now contains only `from 'graphql'` (resolves to `graphql/index.mjs`) – no `graphql/language`, no `graphql-to-sparql`.
- **`/graphql` end-to-end against the live prod typed collections** (local server → prod Typesense): `total: 2656`, publisher labels resolved (`organizations`), terminology labels resolved (`terminology-sources`), status facet counts across all statuses (valid 2656 / gone 12 / invalid 8), `format`/`class` facets carry both granular and `group:*` tokens. `/datasets` renders 200 through the same path.
- `@dataset-register/core` tests (407) and `@dataset-register/browser` tests (187) pass; lint + `svelte-check` clean on both.

## Rollout

Land this → the new `apps-browser` image builds with the fix → **then** unpin the browser so Flux deploys it onto the already-reindexed backend (typed collections built by the new crawler as of the 18:00 UTC run).
