### PR TITLE
fix(search): return all facet values, not just the top 10

### DIFF
--- a/apps/browser/src/lib/services/search/engine.server.ts
+++ b/apps/browser/src/lib/services/search/engine.server.ts
@@ -28,6 +28,23 @@ import {
  *  matching the previous client-side label cache TTL. */
 const LABEL_CACHE_TTL_MS = 5 * 60 * 1000;
 
+/**
+ * Cap on the number of buckets returned per facet (Typesense `max_facet_values`).
+ * Typesense defaults to 10, which truncated every sidebar facet – the class,
+ * keyword and publisher facets each carry far more values than that, so the
+ * sidebar could neither show nor search past the top 10. The browser filters the
+ * facet search box client-side over the returned buckets, so the full list must
+ * come back for search to cover it.
+ *
+ * This is a ceiling, not a fixed cost: a response carries only as many buckets as
+ * the facet actually has, and facet queries are hit-less (`per_page: 0`) with
+ * labels served from the in-memory cache, so raising it is free until a facet
+ * grows past it. The highest-cardinality facet today is `class` at ~800 distinct
+ * values (`keyword` ~680, `publisher` ~310); 2000 leaves comfortable headroom for
+ * growth. A facet that ever approaches this wants server-side facet-value search
+ * (Typesense `facet_query`) rather than a still-higher cap. */
+const MAX_FACET_VALUES = 2000;
+
 let engineSingleton: SearchEngine | undefined;
 let schemaSingleton: GraphQLSchema | undefined;
 
@@ -80,6 +97,7 @@ function engine(): SearchEngine {
         TerminologySource: TERMINOLOGY_SOURCE_COLLECTION_ALIAS,
       },
       labelCacheTtlMs: LABEL_CACHE_TTL_MS,
+      maxFacetValues: MAX_FACET_VALUES,
       // A label lookup failure degrades a reference to its bare IRI rather than
       // failing the whole search; log it so the cause is visible.
       onLabelError: (error) => console.error('Label resolution failed:', error),


### PR DESCRIPTION
Fix #2250

## Problem

Every sidebar facet was capped at 10 values. The class, keyword and publisher facets carry far more than that, so users could neither see nor search past the top 10 – e.g. finding datasets of type `pico:PersonReconstruction` in the class facet was impossible from the UI (only the direct `?class=…` link worked).

The cap is Typesense’s `max_facet_values` default of 10. The browser’s facet search box filters client-side over the returned buckets, so the truncated list also truncated what could be searched.

## Fix

Set the engine’s `maxFacetValues` option (forwarded to Typesense `max_facet_values`) in the `/graphql` search engine so every facet value is returned and the full list becomes searchable.

Sized at **2000** against measured distinct-value counts in the live index (2676 datasets):

| Facet | Distinct values |
|-------|-----------------|
| class | ~800 |
| keyword | ~680 |
| publisher | ~310 |
| format | ~40 |
| terminology_source | ~26 |

The cap is a ceiling, not a fixed cost: a response carries only as many buckets as the facet actually has, and facet queries are hit-less (`per_page: 0`) with labels served from the in-memory cache, so 2000 only leaves headroom for growth – it costs nothing until a facet grows past its current size.

## Verification

- Reproduced against a local Typesense v30 (the deployed version): a facet with 15 distinct values returns 10 buckets by default and all 15 with the cap raised. Against the full local index, all ~800 class values return at the 2000 cap.
- `nx build` and the full `nx test @dataset-register/browser` suite pass.

## Follow-up

The client-side facet search now covers the complete list up to the cap. A facet that ever approaches 2000 (keyword is the only realistic candidate) wants server-side facet-value search (Typesense `facet_query`) wired through `@lde/search` and `@lde/search-api-graphql` – a larger cross-package change left out of this fix.
