### PR TITLE
feat(browser): show keywords on the dataset detail page

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -110,6 +110,7 @@
   "rss_filter_size": "Size",
   "rss_triples": "triples",
   "dataset_status_archived": "Archived",
+  "detail_keywords": "Keywords",
   "detail_triples": "Triples",
   "detail_distributions": "Distributions",
   "detail_linked_data_summary": "Linked Data Summary",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -110,6 +110,7 @@
   "rss_filter_size": "Grootte",
   "rss_triples": "triples",
   "dataset_status_archived": "Gearchiveerd",
+  "detail_keywords": "Trefwoorden",
   "detail_triples": "Feiten",
   "detail_distributions": "Distributies",
   "detail_linked_data_summary": "Linked Data-samenvatting",

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -110,6 +110,15 @@ const DetailContactPointSchema = {
 // Extended dataset schema for detail page
 export const DatasetDetailSchema = {
   ...BaseDatasetSchema,
+  // Keywords are no longer part of the dataset requirements and are neither
+  // indexed nor facetable, so they exist only here: a read-only echo of what a
+  // publisher happens to still supply, shown on the detail page alone.
+  keyword: {
+    '@id': dcat.keyword,
+    '@optional': true,
+    '@array': true,
+    '@multilang': true,
+  },
   theme: {
     '@id': dcat.theme,
     '@optional': true,

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -229,11 +229,12 @@
     ),
   );
 
-  // Extract subject matter for current locale. dcat:theme is the canonical
-  // target for subject/material classification; dct:type is kept for datasets
-  // registered before the schema:about → dcat:theme transition.
+  // Extract keywords and subject matter for current locale. dcat:theme is the
+  // canonical target for subject/material classification; dct:type is kept for
+  // datasets registered before the schema:about → dcat:theme transition.
   const EDUC_DEFAULT_THEME =
     'http://publications.europa.eu/resource/authority/data-theme/EDUC';
+  const localizedKeywords = $derived(getLocalizedArray(dataset.keyword));
   const localizedAbout = $derived([
     ...(dataset.theme?.filter((value) => value !== EDUC_DEFAULT_THEME) ?? []),
     ...getLocalizedArray(dataset.type),
@@ -737,7 +738,7 @@
   </div>
 
   <!-- Dataset Details Section (compact) -->
-  {#if dataset.publisher?.name || dataset.license || (dataset.spatial && dataset.spatial.length > 0) || temporalCoverages.length > 0 || localizedAbout.length > 0 || (dataset.language && dataset.language.length > 0)}
+  {#if localizedKeywords.length > 0 || dataset.publisher?.name || dataset.license || (dataset.spatial && dataset.spatial.length > 0) || temporalCoverages.length > 0 || localizedAbout.length > 0 || (dataset.language && dataset.language.length > 0)}
     <div class="mb-8">
       <div
         class="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
@@ -1302,6 +1303,42 @@
                     {/if}
                   {/each}
                 {/await}
+              </dd>
+            </div>
+          {/if}
+
+          <!-- Keywords. Plain chips, not links: keywords are no longer indexed
+               or facetable, so there is no keyword filter to link them to. -->
+          {#if localizedKeywords.length > 0}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
+                  />
+                </svg>
+                {m.detail_keywords()}
+              </dt>
+              <dd class="flex flex-wrap gap-1.5">
+                {#each localizedKeywords as keyword (keyword)}
+                  <span
+                    class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800 dark:bg-gray-700 dark:text-gray-200"
+                  >
+                    {keyword}
+                  </span>
+                {/each}
               </dd>
             </div>
           {/if}

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -22,6 +22,7 @@ const datePublished = 'datePublished';
 const dateModified = 'dateModified';
 const language = 'language';
 const source = 'source';
+const keyword = 'keyword';
 const spatialCoverage = 'spatialCoverage';
 const temporalCoverage = 'temporalCoverage';
 const genre = 'genre';
@@ -172,6 +173,12 @@ function schemaOrgMultiValuedUnions(prefix: string): string {
     multiValuedUnion(type, `${prefix}:isBasedOnUrl`, source),
     multiValuedUnion(
       type,
+      `${prefix}:keywords`,
+      keyword,
+      `FILTER(!REGEX(STR(?${keyword}), "^https?://"))`,
+    ),
+    multiValuedUnion(
+      type,
       `${prefix}:spatialCoverage`,
       spatialCoverage,
       `FILTER(!isBlank(?${spatialCoverage}))`,
@@ -196,6 +203,12 @@ function dcatMultiValuedUnions(): string {
   return [
     multiValuedUnion(type, `dct:description`, description),
     multiValuedUnion(type, `dct:source`, source),
+    multiValuedUnion(
+      type,
+      `dcat:keyword`,
+      keyword,
+      `FILTER(!REGEX(STR(?${keyword}), "^https?://"))`,
+    ),
     multiValuedUnion(
       type,
       `dct:spatial`,
@@ -234,6 +247,7 @@ export const constructQuery = `
       dct:modified ?${dateModified} ;
       dct:language ?${language} ;
       dct:source ?${source} ;
+      dcat:keyword ?${keyword} ;
       dcat:landingPage ?${mainEntityOfPage} ;
       dct:spatial ?${spatialCoverage} ;
       dct:temporal ?${temporalCoverage} ;

--- a/packages/core/src/transform.ts
+++ b/packages/core/src/transform.ts
@@ -42,6 +42,7 @@ export function addDefaultLanguageTags(quads: Quad[], lang = 'nl'): DatasetExt {
 const languageTagPredicates = new Set([
   dct('title').value,
   dct('description').value,
+  dcat('keyword').value,
   foaf('name').value,
   vcard('fn').value,
 ]);

--- a/packages/core/test/datasets/dataset-schema-org-keyword-uri.jsonld
+++ b/packages/core/test/datasets/dataset-schema-org-keyword-uri.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/keyword-uri",
+  "name": "Dataset with an http(s) URI as a keyword",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "keywords": ["photographs", "http://vocab.getty.edu/aat/300046300"],
+  "about": { "@id": "http://vocab.getty.edu/aat/300046300" },
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://example.com/publisher",
+    "name": "Koninklijke Bibliotheek"
+  }
+}

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -490,6 +490,28 @@ describe('Fetch', () => {
     expect((literalTheme?.object as Literal).language).toEqual('nl');
   });
 
+  it('drops URI-shaped schema:keywords from dcat:keyword output', async () => {
+    const response = await file('dataset-schema-org-keyword-uri.jsonld');
+    nock('http://data.bibliotheken.nl')
+      .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
+      .get('/id/dataset/keyword-uri')
+      .reply(200, response);
+
+    const datasets = await fetchDatasetsAsArray(
+      new URL('http://data.bibliotheken.nl/id/dataset/keyword-uri'),
+    );
+
+    expect(datasets).toHaveLength(1);
+    const dataset = datasets[0];
+    const datasetUri = factory.namedNode(
+      'http://data.bibliotheken.nl/id/dataset/keyword-uri',
+    );
+    const keywordValues = [
+      ...dataset.match(datasetUri, dcat('keyword'), null),
+    ].map((quad) => quad.object.value);
+    expect(keywordValues).toEqual(['photographs']);
+  });
+
   it('preserves user-provided themes alongside default EDUC theme', async () => {
     const response = await file('dataset-dcat-valid-minimal.jsonld');
     const datasetWithTheme = response.replace(
@@ -632,9 +654,10 @@ describe('Fetch', () => {
     // Schema.org input now that the contactPoint is the canonical email channel).
     // Fetch also replaces the `dct:temporal "..."` literal with a PeriodOfTime
     // blank node (1 → 4 quads: dct:temporal link + rdf:type + startDate + endDate).
-    // Finally, the raw DCAT equivalent still carries one dcat:keyword quad, but
-    // keywords are no longer part of the model, so fetch emits none from the
-    // Schema.org input – one fewer quad than the DCAT baseline (#1412).
+    // Finally, the DCAT equivalent still carries one dcat:keyword quad, while the
+    // Schema.org example no longer advertises keywords (they are no longer part of
+    // the requirements, only echoed on the detail page when supplied) – one fewer
+    // quad than the DCAT baseline.
     expect(dataset.size).toEqual(dcatEquivalent.size + 8 - 10 + 3 - 1);
 
     // Check that SPARQL endpoint has conformsTo triple

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 97.85,
+        lines: 97.86,
         functions: 96.63,
         branches: 91.83,
-        statements: 97.36,
+        statements: 97.37,
       },
     },
   },


### PR DESCRIPTION
Keywords were dropped from the dataset requirements in #2256, which is the right call: they are free text that overlaps with title, description and the `schema:about` subject slot without adding discovery value. But that drop also removed the last place a publisher’s keywords were visible at all. This shows them again on the detail page only – a read-only echo of what a publisher happens to supply, with no claim that they are recommended and no discovery surface built on them.

## Restoring the display alone would have rendered nothing

The drop also stopped `query.ts` projecting `dcat:keyword` into the canonical graph, so keywords no longer reached the store. The ingest path therefore comes back with the display:

- `query.ts` – project `schema:keywords` and `dcat:keyword` into the canonical graph again, keeping the filter that drops URI-shaped values
- `transform.ts` – restore the default language tag on `dcat:keyword`, so the detail page can pick the value for the current locale
- `dataset-detail.ts` – read `dcat:keyword` into the detail schema (the detail CONSTRUCT’s first branch is a wildcard `<dataset> ?p ?o`, so no query change was needed)
- `dataset/+page.svelte` – render the keywords row
- `messages` – restore `detail_keywords` (en + nl)

## Deliberately left dropped

The SHACL requirements, the rating penalty in `rate.ts`, the search schema and indexer, facets, active filters, RSS, the GraphQL `where` field, the `keywords` URL parameter, and the requirements example. Keywords stay out of every discovery surface.

## Notes for review

- **Chips are plain, not links.** The previous chips linked to `/datasets?keywords=…`, a filter that no longer exists, so they render as non-interactive gray chips rather than blue links.
- **The `- 1` quad-count assertion in `fetch.test.ts` stays.** `validSchemaOrgDataset()` reads `requirements/examples/dataset-schema-org-valid.jsonld`, which correctly no longer advertises keywords, while the DCAT baseline fixture still carries one `dcat:keyword` quad. Only the rationale is rewritten.
- **Coverage thresholds** in `packages/core/vite.config.ts` return to their pre-drop values, because the restored regression test restores the covered lines exactly.
- **Operational:** datasets re-crawled since #2256 merged had their stored keywords stripped, and regain them only on the next crawl after this deploys.
- **Docs:** no change needed. `data-model.md` still lists `dcat:keyword` (`rdf:langString`, 0..n) and `discover.md` still describes narrowing by keyword over SPARQL – both accurate again under this change.

Verified end-to-end against the production SPARQL endpoint: the Anne Frank dataset renders its English keywords on `/en/dataset` and its Dutch ones on `/dataset`, with no keyword references on the listing page.
