### PR TITLE
fix(requirements): describe the datacatalog description in its own words

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -44,7 +44,26 @@ nde-dataset:DatacatalogShape
         nde-dataset:SchemaNameUniqueLangProperty,
         nde-dataset:SchemaNameLangStringProperty,
         nde-dataset:SchemaDescriptionPropertyShouldExist,
-        nde-dataset:SchemaDescriptionProperty,
+        # The datacatalog describes itself, not the datasets it lists, so it carries its own
+        # wording rather than reusing nde-dataset:SchemaDescriptionProperty, which is written
+        # for datasets. Mirrors dcat:CatalogShape, which already describes its own dc:description.
+        [
+            sh:path schema:description ;
+            sh:or (
+                [ sh:datatype xsd:string ]
+                [ sh:datatype rdf:langString ]
+            ) ;
+            sh:description """Een beschrijving van de inhoud van de datacatalogus.
+                Deze is bij voorkeur minimaal drie zinnen en maximaal één alinea lang (2000 karakters).
+                De vindbaarheid van de datacatalogus wordt onder andere bepaald door de kwaliteit van de beschrijving.
+                Denk hierbij aan verschillende gebruikers, vakgenoten maar ook anderen,
+                waarvoor de tekst begrijpelijk moet zijn."""@nl,
+                """A description of the contents of the data catalog.
+                Preferably at least three sentences and at most one paragraph (2,000 characters).
+                The discoverability of the data catalog depends in part on the quality of the description.
+                Consider different audiences – both domain experts and others –
+                for whom the text should be understandable."""@en ;
+        ] ,
         nde-dataset:SchemaDescriptionUniqueLangProperty,
         nde-dataset:SchemaDescriptionLangStringProperty,
         [


### PR DESCRIPTION
Follow-up to #2263, from the investigation of #2260.

`nde-dataset:DatacatalogShape` reused `nde-dataset:SchemaDescriptionProperty` for `schema:description`, but that shape's `sh:description` is written for datasets. The requirements therefore told publishers describing a **catalog** to write “een beschrijving van de inhoud van de dataset”, which is the wrong subject: what needs describing there is the catalog itself.

The DCAT mirror already gets this right – `dcat:CatalogShape` carries its own `Een beschrijving van de catalogus.` rather than borrowing the dataset text. This brings the schema.org side in line, using the wording DCAT-AP-NL 3.0 §4.4.6 uses for a catalog description.

## Scope

Only the human-readable `sh:description` changes. The constraint is identical (`sh:or` of `xsd:string` / `rdf:langString`), and `SchemaDescriptionPropertyShouldExist`, `SchemaDescriptionUniqueLangProperty` and `SchemaDescriptionLangStringProperty` are still shared with the dataset shape. **No validation result changes** – nothing that validates today starts or stops failing.

The shape is inlined rather than named, matching how `DatacatalogShape` already inlines its catalog-specific `schema:name` shape (“Naam van de datacatalogus”), and matching `dcat:CatalogShape`.

Verified that the generated spec picks it up: `npx @lde/docgen from-shacl …` now renders “A description of the contents of the data catalog.” for `DataCatalog`, alongside the unchanged “A description of the contents of the dataset.” for `Dataset`. `index.bs` / `index.html` are untracked and regenerated by `requirements-publish.yml`, so nothing generated needs committing here.

## Known gap

This corrects the requirements, but the validation UI will **not** show the new text yet. `selectShape` in the browser resolves a result's description via `sh:sourceShape` through a `byId` map, and `SchemaDescriptionPropertyShouldExist` is referenced by both `DatacatalogShape` and `DatasetShape` – so `indexShapes` writes that key twice and the later shape (`DatasetShape`) wins. A catalog finding therefore still inherits the dataset description regardless of this change.

Fixing that needs a separate browser change: `selectShape` must not trust an ambiguous `byId` entry, and the focus node's type has to be standardized to `https://schema.org/` first (types are read from the unmodified source, which may use `http://schema.org/`) or the `targetClass` fallback will not match either. Worth doing on its own so it can be verified end-to-end.
