### PR TITLE
fix(browser): describe a finding by its own subject's shape

### DIFF
--- a/apps/browser/src/lib/components/validation/focus-node-types.test.ts
+++ b/apps/browser/src/lib/components/validation/focus-node-types.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { buildFocusNodeTypes } from './focus-node-types.js';
+
+describe('buildFocusNodeTypes', () => {
+  it('standardizes the http schema.org prefix that sources publish', async () => {
+    // A source may publish either prefix, while the shapes and the report only use
+    // https. Without standardizing here, a focus node's type never matches a shape's
+    // sh:class and the reader gets no description at all.
+    const source = JSON.stringify({
+      '@graph': [
+        { '@id': '_:autos1', '@type': 'http://schema.org/DataCatalog' },
+        { '@id': '_:autos2', '@type': 'http://schema.org/DataDownload' },
+      ],
+    });
+    const types = await buildFocusNodeTypes(source, 'application/ld+json');
+    expect(types.get('_:autos1')).toBe('https://schema.org/DataCatalog');
+    expect(types.get('_:autos2')).toBe('https://schema.org/DataDownload');
+  });
+
+  it('leaves an https schema.org type and other vocabularies untouched', async () => {
+    const source = JSON.stringify({
+      '@graph': [
+        { '@id': '_:a', '@type': 'https://schema.org/Dataset' },
+        { '@id': '_:b', '@type': 'http://www.w3.org/ns/dcat#Catalog' },
+      ],
+    });
+    const types = await buildFocusNodeTypes(source, 'application/ld+json');
+    expect(types.get('_:a')).toBe('https://schema.org/Dataset');
+    expect(types.get('_:b')).toBe('http://www.w3.org/ns/dcat#Catalog');
+  });
+
+  it('standardizes types parsed from Turtle too', async () => {
+    const source = `
+      @prefix schema: <http://schema.org/> .
+      <https://example.org/c> a schema:DataCatalog .
+    `;
+    const types = await buildFocusNodeTypes(source, 'text/turtle');
+    expect(types.get('https://example.org/c')).toBe(
+      'https://schema.org/DataCatalog',
+    );
+  });
+});

--- a/apps/browser/src/lib/components/validation/focus-node-types.ts
+++ b/apps/browser/src/lib/components/validation/focus-node-types.ts
@@ -3,6 +3,7 @@ import {
   expandTerm,
   parseN3Quads,
   safeParseJson,
+  standardizeSchemaOrgPrefix,
   walkJsonLd,
 } from './rdf-helpers.js';
 
@@ -11,8 +12,12 @@ const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 /**
  * Build a Map<focusNode IRI, rdf:type IRI> by parsing the inline source.
  * Used to resolve shape-name ambiguity when two shapes share a path
- * (e.g. Dataset vs DataCatalog for `schema:name`). Best effort — unknown
+ * (e.g. Dataset vs DataCatalog for `schema:name`). Best effort – unknown
  * formats or parse errors return an empty map.
+ *
+ * Types are standardized to the https://schema.org prefix: a source may publish
+ * either prefix, while the shapes and the validation report only use https, and
+ * every consumer here compares these types against those.
  */
 export async function buildFocusNodeTypes(
   sourceText: string,
@@ -28,14 +33,20 @@ export async function buildFocusNodeTypes(
       if (typeof id !== 'string' || result.has(id)) return;
       const typeStr = Array.isArray(type) ? type[0] : type;
       if (typeof typeStr !== 'string') return;
-      result.set(id, expandTerm(typeStr, context) ?? typeStr);
+      result.set(
+        id,
+        standardizeSchemaOrgPrefix(expandTerm(typeStr, context) ?? typeStr),
+      );
     });
     return result;
   }
 
   for (const quad of await parseN3Quads(sourceText, contentType)) {
     if (quad.predicate.value === RDF_TYPE && !result.has(quad.subject.value)) {
-      result.set(quad.subject.value, quad.object.value);
+      result.set(
+        quad.subject.value,
+        standardizeSchemaOrgPrefix(quad.object.value),
+      );
     }
   }
   return result;

--- a/apps/browser/src/lib/components/validation/rdf-helpers.ts
+++ b/apps/browser/src/lib/components/validation/rdf-helpers.ts
@@ -11,6 +11,19 @@ export function joinIri(base: string, suffix: string): string {
 }
 
 /**
+ * Convert the http://schema.org prefix to https://schema.org, mirroring what the
+ * Register does server-side before validating.
+ *
+ * Terms read from an unmodified source may use either prefix, while the shapes and
+ * the validation report only ever use https, so comparing the two needs one form.
+ */
+export function standardizeSchemaOrgPrefix(iri: string): string {
+  return iri.startsWith('http://schema.org/')
+    ? iri.replace('http://schema.org/', 'https://schema.org/')
+    : iri;
+}
+
+/**
  * Resolve a bare term, CURIE (`prefix:local`), or absolute IRI to its IRI
  * using the surrounding JSON-LD `@context`. Returns `null` when the term
  * cannot be resolved; callers that prefer the input back on miss can use

--- a/apps/browser/src/lib/components/validation/subject-label.ts
+++ b/apps/browser/src/lib/components/validation/subject-label.ts
@@ -1,4 +1,5 @@
 import * as m from '$lib/paraglide/messages';
+import { standardizeSchemaOrgPrefix } from './rdf-helpers.js';
 
 /**
  * Human-readable label for the class of a validation result's focus node.
@@ -41,9 +42,3 @@ const labelByClass: Record<string, () => string> = {
   [`${VCARD}Individual`]: m.validate_subject_contact_point,
   [`${SCHEMA}PropertyValue`]: m.validate_subject_identifier,
 };
-
-function standardizeSchemaOrgPrefix(classIri: string): string {
-  return classIri.startsWith('http://schema.org/')
-    ? classIri.replace('http://schema.org/', SCHEMA)
-    : classIri;
-}

--- a/apps/browser/src/lib/services/shacl-shapes.test.ts
+++ b/apps/browser/src/lib/services/shacl-shapes.test.ts
@@ -57,6 +57,52 @@ describe('selectShape', () => {
       selectShape(index, `${SCHEMA}name`, `${SCHEMA}ContactPoint`),
     ).toBeUndefined();
   });
+
+  it('ignores a sourceShape hit describing a different class than the focus node', () => {
+    // `SchemaDescriptionPropertyShouldExist` is owned by both the catalog and the
+    // dataset shape, so indexShapes keeps a single byId entry won by whichever was
+    // indexed last. Taking it would tell someone describing a catalog to describe
+    // the dataset instead.
+    const dataCatalogMeta = {
+      description: 'Een beschrijving van de inhoud van de datacatalogus.',
+      targetClass: `${SCHEMA}DataCatalog`,
+    };
+    const datasetMeta = {
+      description: 'Een beschrijving van de inhoud van de dataset.',
+      targetClass: `${SCHEMA}Dataset`,
+    };
+    const sharedShape = 'https://def.nde.nl/dataset#SchemaDescriptionProperty';
+    const index: ShapesIndex = {
+      byPath: new Map([
+        [`${SCHEMA}description`, [dataCatalogMeta, datasetMeta]],
+      ]),
+      byId: new Map([[sharedShape, datasetMeta]]),
+    };
+    expect(
+      selectShape(index, `${SCHEMA}description`, `${SCHEMA}DataCatalog`, sharedShape),
+    ).toEqual(dataCatalogMeta);
+  });
+
+  it('keeps a sourceShape hit that is bound to no class', () => {
+    // A distribution shape is targeted via sh:targetObjectsOf and carries no
+    // sh:class, so it constrains no particular class and contradicts nothing.
+    const distributionMeta = {
+      description: 'Beschrijving van de distributie',
+      targetClass: undefined,
+    };
+    const index: ShapesIndex = {
+      byPath: new Map([[`${SCHEMA}description`, [distributionMeta]]]),
+      byId: new Map([['_:df_15_191', distributionMeta]]),
+    };
+    expect(
+      selectShape(
+        index,
+        `${SCHEMA}description`,
+        `${SCHEMA}DataDownload`,
+        '_:df_15_191',
+      ),
+    ).toEqual(distributionMeta);
+  });
 });
 
 describe('indexShapes', () => {

--- a/apps/browser/src/lib/services/shacl-shapes.ts
+++ b/apps/browser/src/lib/services/shacl-shapes.ts
@@ -47,6 +47,12 @@ export function fetchShapes(signal?: AbortSignal): Promise<ShapesIndex> {
  * rdf:type when that is known: descriptions on shared paths like
  * `schema:name` belong to a specific class, and inheriting one from another
  * NodeShape would mislead the reader.
+ *
+ * A property shape reused across class shapes (`SchemaDescriptionPropertyShouldExist`
+ * is owned by both the catalog and the dataset) has a single `byId` entry, won by
+ * whichever NodeShape was indexed last. Taking that hit would attribute the last
+ * owner's description to every subject – exactly what the path lookup exists to
+ * prevent – so it is only trusted when it cannot belong to a different subject.
  */
 export function selectShape(
   index: ShapesIndex,
@@ -56,7 +62,7 @@ export function selectShape(
 ): ShapeMetadata | undefined {
   if (sourceShapeIri) {
     const direct = index.byId.get(sourceShapeIri);
-    if (direct) return direct;
+    if (direct && !contradictsFocusNode(direct, focusNodeType)) return direct;
   }
   if (!pathIri) return undefined;
   const candidates = index.byPath.get(pathIri);
@@ -66,6 +72,20 @@ export function selectShape(
   }
   if (candidates.length === 1) return candidates[0];
   return candidates.find((c) => c.description) ?? undefined;
+}
+
+/**
+ * Whether this metadata describes a different subject than the focus node.
+ *
+ * A shape without a `targetClass` (such as a distribution's, which is targeted via
+ * `sh:targetObjectsOf`) constrains no particular class and so contradicts nothing.
+ */
+function contradictsFocusNode(
+  metadata: ShapeMetadata,
+  focusNodeType: string | undefined,
+): boolean {
+  if (!focusNodeType || !metadata.targetClass) return false;
+  return metadata.targetClass !== focusNodeType;
 }
 
 export function indexShapes(json: unknown, locale: string): ShapesIndex {


### PR DESCRIPTION
Closes the gap documented in #2264, reported again on #2260: the catalog row is correctly headed “Datacatalogus” since #2263, and #2264 gave the catalog its own wording, but the row still read “Een beschrijving van de inhoud van de **dataset**”.

Neither the reporter's registration nor a deploy delay was at fault. The correct text is live and indexed – `selectShape` just never reached it. Reproduced against the deployed `/shacl` payload:

```
byId[SchemaDescriptionPropertyShouldExist] -> owner: DatasetShape
                                             description: "…van de dataset."
byPath[schema:description] candidates:
  - https://schema.org/DataCatalog :: "…van de datacatalogus."   <- correct one, never consulted
  - https://schema.org/Dataset     :: "…van de dataset."
selectShape(catalog finding) -> "Een beschrijving van de inhoud van de dataset."
```

`indexShapes` collapses a property shape shared by N node shapes into a single `byId` entry, won by whichever was indexed last. `SchemaDescriptionPropertyShouldExist` is owned by both the catalog and the dataset, and `DatasetShape` is defined later, so every catalog finding inherited the dataset's description. `selectShape` preferred that hit and never fell through to the path lookup that already narrows by class – the very thing its docstring says it exists to do.

## Changes

- `selectShape` takes the `sh:sourceShape` hit only when it cannot describe a different subject than the focus node. An ambiguous hit falls through to the existing class-narrowed path lookup. Shapes bound to no class (a distribution, targeted via `sh:targetObjectsOf`) still resolve through it – they constrain no class, so they contradict nothing.
- `buildFocusNodeTypes` standardizes types to the `https://schema.org` prefix. Types are read from the unmodified source, which may publish `http://schema.org` (this catalog does), while shapes only ever use `https`. **Without this the fix does nothing**: the class narrowing matches nothing and the reader gets no description at all – worse than the wrong one. The helper is shared with `subject-label.ts`, which had its own copy.

## Why not fix the SHACL instead

Un-sharing the shape would fix one case and leave eight: nine named property shapes are shared across multiple node shapes (`SchemaNameUniqueLangProperty`, `SchemaDescriptionUniqueLangProperty`, `DcTitleLangStringProperty`, …). Sharing is deliberate – `sh:focusNode` and `sh:resultPath` provide the context – so the index is what needed fixing, and fixing it once covers all nine.

## Verified end-to-end

Against the live `catalog.jsonld`, each subject now gets its own wording, and all 20 rows still carry a description (the regression risk, since the guard can reject a `byId` hit):

| Subject | Description |
|---|---|
| Dataset | Een beschrijving van de inhoud van de **dataset** |
| Datacatalogus | Een beschrijving van de inhoud van de **datacatalogus** |
| Distributie | Beschrijving van de **distributie** |

## Known gap, not addressed here

The three `schema:name` rows (Dataset, Organisatie, Datacatalogus) all show the Agent's “De volledige naam van de uitgever of maker.”. `byId[SchemaNameLangStringProperty]` is won by `AgentShape`, which declares no `sh:class`, so the guard treats it as contradicting nothing and trusts it – as the old code did. This predates this PR.

Tightening the guard to reject every shared shape would fix Dataset and Datacatalogus but delete the Organisatie row's description, since nothing in `byPath` can match `schema:Organization` while `AgentShape` is classless. Closing it properly means deciding whether these shapes should declare a class, which changes constraints – worth its own issue.
