### PR TITLE
fix(core): read a declared dcat:compressFormat on ingest

### DIFF
--- a/packages/core/src/literal.ts
+++ b/packages/core/src/literal.ts
@@ -68,9 +68,19 @@ export const bindIriLicense = (rawVar: string, outVar: string) =>
       )`;
 
 /**
+ * A media type in `type/subtype` form. Mirrors the sh:pattern that shacl.ttl
+ * applies to schema:encodingFormat, so the query accepts exactly what the shapes
+ * describe as a media type.
+ */
+const mediaTypePattern = '^[a-zA-Z]+/[a-zA-Z0-9][a-zA-Z0-9!#$&\\\\-^_.+]*$';
+
+/**
  * Normalize mediaType to IANA URI format.
  *
- * DCAT-3 requires dcat:mediaType to be URIs pointing to the IANA media type registry.
+ * DCAT gives dcat:mediaType the range dcterms:MediaType and says the value SHOULD
+ * come from the IANA media types registry. DCAT-AP-NL narrows that to IANA only.
+ * We stay lenient about what publishers send but store the IANA URI form.
+ *
  * This function converts:
  * - Text literals like "application/ld+json" to https://www.iana.org/assignments/media-types/application/ld+json
  * - Already-formed IANA URIs pass through unchanged
@@ -80,25 +90,39 @@ export const bindIriLicense = (rawVar: string, outVar: string) =>
  *   "application/n-triples"); the compression format is captured separately by
  *   compressFormat()
  *
+ * A literal that is not a media type at all (e.g. "text turtle", "gzip") is left
+ * unbound rather than concatenated onto the IANA prefix. Minting an IRI from it
+ * produces either a space-bearing IRI, which serializes to N-Triples the store
+ * rejects – losing the whole registration over one bad value – or a well-formed
+ * URI into the IANA registry that denotes nothing. Dropping the one property is
+ * lenient enough to keep the dataset and strict enough to keep the store valid;
+ * the shapes are where a publisher gets told about it.
+ *
  * Also used to normalize dcat:compressFormat itself, whose values are media types
  * too (e.g. "application/gzip"). The +g?zip suffix strip is a no-op on those: it
  * only matches a "+"-separated suffix, which a bare compression media type lacks.
  */
-export const normalizeMediaType = (variable: string) =>
-  `?${variable}Raw ;
+export const normalizeMediaType = (variable: string) => {
+  const cleaned = `REPLACE(REPLACE(STR(?${variable}Raw), ";.*$", ""), "\\\\+g?zip$", "")`;
+  return `?${variable}Raw ;
         BIND(
           IF(
             isIRI(?${variable}Raw),
             IRI(REPLACE(REPLACE(STR(?${variable}Raw), "\\\\+g?zip$", ""), "^http://", "https://")),
-            IRI(
-              CONCAT(
-                "https://www.iana.org/assignments/media-types/",
-                REPLACE(REPLACE(STR(?${variable}Raw), ";.*$", ""), "\\\\+g?zip$", "")
-              )
+            IF(
+              REGEX(${cleaned}, "${mediaTypePattern}"),
+              IRI(
+                CONCAT(
+                  "https://www.iana.org/assignments/media-types/",
+                  ${cleaned}
+                )
+              ),
+              ?unbound
             )
           )
           AS ?${variable}
         )`;
+};
 
 /**
  * Bind the distribution’s compression format URI.

--- a/packages/core/src/literal.ts
+++ b/packages/core/src/literal.ts
@@ -78,7 +78,11 @@ export const bindIriLicense = (rawVar: string, outVar: string) =>
  * - Strips parameters (e.g., "text/html; charset=utf-8" becomes "text/html")
  * - Strips +gzip or +zip suffix (e.g., "application/n-triples+gzip" becomes
  *   "application/n-triples"); the compression format is captured separately by
- *   compressFormatFromMediaType()
+ *   compressFormat()
+ *
+ * Also used to normalize dcat:compressFormat itself, whose values are media types
+ * too (e.g. "application/gzip"). The +g?zip suffix strip is a no-op on those: it
+ * only matches a "+"-separated suffix, which a bare compression media type lacks.
  */
 export const normalizeMediaType = (variable: string) =>
   `?${variable}Raw ;
@@ -97,19 +101,29 @@ export const normalizeMediaType = (variable: string) =>
         )`;
 
 /**
- * Detect +gzip or +zip in the raw media type and bind a compress format URI.
+ * Bind the distribution’s compression format URI.
  *
- * Returns a SPARQL BIND that sets the compress format variable to
- * <https://www.iana.org/assignments/media-types/application/gzip> for +gzip,
- * <https://www.iana.org/assignments/media-types/application/zip> for +zip,
- * or leaves it unbound otherwise.
+ * A publisher can express compression in two ways, and we accept both:
+ *
+ * 1. dcat:compressFormat, DCAT’s own property for it. Pass its (already
+ *    normalized) variable as declaredVariable; it takes precedence.
+ * 2. A +gzip or +zip suffix on the media type, e.g. "application/n-triples+gzip".
+ *    normalizeMediaType() strips that suffix, so we recover it from the raw value
+ *    here.
+ *
+ * Binds <https://www.iana.org/assignments/media-types/application/gzip> for +gzip,
+ * <https://www.iana.org/assignments/media-types/application/zip> for +zip, and is
+ * left unbound when neither source says anything – an unbound variable makes the
+ * surrounding COALESCE/IF raise an error, which leaves the BIND target unbound.
+ *
+ * https://github.com/netwerk-digitaal-erfgoed/dataset-register/issues/2251
  */
-export const compressFormatFromMediaType = (
+export const compressFormat = (
   mediaTypeVariable: string,
   compressFormatVariable: string,
-) =>
-  `BIND(
-    IF(
+  declaredVariable?: string,
+) => {
+  const fromMediaTypeSuffix = `IF(
       REGEX(STR(?${mediaTypeVariable}Raw), "\\\\+gzip$"),
       <https://www.iana.org/assignments/media-types/application/gzip>,
       IF(
@@ -117,6 +131,14 @@ export const compressFormatFromMediaType = (
         <https://www.iana.org/assignments/media-types/application/zip>,
         ?unbound
       )
-    ) AS ?${compressFormatVariable}
+    )`;
+
+  return `BIND(
+    ${
+      declaredVariable === undefined
+        ? fromMediaTypeSuffix
+        : `COALESCE(?${declaredVariable}, ${fromMediaTypeSuffix})`
+    } AS ?${compressFormatVariable}
   )`;
+};
 

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -1,7 +1,7 @@
 import factory from 'rdf-ext';
 import {
   bindIriLicense,
-  compressFormatFromMediaType,
+  compressFormat,
   convertToIri,
   convertToXsdDate,
   normalizeLicense,
@@ -61,6 +61,8 @@ const distributionLicense = 'distribution_license';
 const distributionName = 'distribution_name';
 const distributionSize = 'distribution_size';
 const distributionCompressFormat = 'distribution_compressFormat';
+const distributionCompressFormatDeclared =
+  'distribution_compressFormat_declared';
 const distributionDownloadUrl = 'distribution_downloadUrl';
 const distributionMediaTypeForDownload = 'distribution_mediaType_download';
 const distributionCompressFormatForDownload =
@@ -363,6 +365,9 @@ export const constructQuery = `
           OPTIONAL {
             ?${distribution} dcat:mediaType ${normalizeMediaType(distributionMediaType)} .
           }
+          OPTIONAL {
+            ?${distribution} dcat:compressFormat ${normalizeMediaType(distributionCompressFormatDeclared)} .
+          }
           OPTIONAL { ?${distribution} dct:conformsTo ?${distributionConformsTo} . }
           OPTIONAL {
             ?${distribution} dct:conformsTo ?${distributionConformsToProtocol} .
@@ -379,7 +384,7 @@ export const constructQuery = `
               ?unbound
             ) AS ?${distributionConformsToSparql}
           )
-          ${compressFormatFromMediaType(distributionMediaType, distributionCompressFormat)}
+          ${compressFormat(distributionMediaType, distributionCompressFormat, distributionCompressFormatDeclared)}
           OPTIONAL { ?${distribution} dct:issued ${convertToXsdDate(
             distributionDatePublished,
           )} }
@@ -513,7 +518,9 @@ function schemaOrgQuery(prefix: string): string {
           ?unbound
         ) AS ?${distributionConformsToSparql}
       )
-      ${compressFormatFromMediaType(distributionMediaType, distributionCompressFormat)}
+      # schema.org has no compressFormat equivalent, so a +gzip/+zip suffix on
+      # encodingFormat is the only thing to go on here.
+      ${compressFormat(distributionMediaType, distributionCompressFormat)}
 
       OPTIONAL { ?${distribution} ${prefix}:datePublished ${convertToXsdDate(
         distributionDatePublished,

--- a/packages/core/test/datasets/dataset-dcat-invalid-media-types.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-invalid-media-types.jsonld
@@ -1,0 +1,43 @@
+{
+  "@context": {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "@type": "dcat:Dataset",
+  "@id": "http://example.com/id/dataset/junk-media-types",
+  "dct:title": { "@value": "Dataset with unusable media type values", "@language": "en" },
+  "dct:description": { "@value": "Distributions whose media type and compress format are not media types", "@language": "en" },
+  "dct:identifier": "http://example.com/id/dataset/junk-media-types",
+  "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" },
+  "dct:publisher": {
+    "@id": "https://example.com/publisher",
+    "@type": "foaf:Organization",
+    "foaf:name": { "@value": "Test", "@language": "nl" }
+  },
+  "dcat:distribution": [
+    {
+      "@type": "dcat:Distribution",
+      "dct:title": "compressFormat that is not a media type",
+      "dcat:mediaType": { "@id": "https://www.iana.org/assignments/media-types/application/n-triples" },
+      "dcat:compressFormat": "ZIP file",
+      "dcat:accessURL": { "@id": "https://example.com/a.nt.zip" },
+      "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" }
+    },
+    {
+      "@type": "dcat:Distribution",
+      "dct:title": "bare compression name, not a media type",
+      "dcat:mediaType": { "@id": "https://www.iana.org/assignments/media-types/application/n-triples" },
+      "dcat:compressFormat": "gzip",
+      "dcat:accessURL": { "@id": "https://example.com/b.nt.gz" },
+      "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" }
+    },
+    {
+      "@type": "dcat:Distribution",
+      "dct:title": "mediaType that is not a media type",
+      "dcat:mediaType": "text turtle",
+      "dcat:accessURL": { "@id": "https://example.com/c.ttl" },
+      "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" }
+    }
+  ]
+}

--- a/packages/core/test/datasets/dataset-dcat-valid-compress-format.jsonld
+++ b/packages/core/test/datasets/dataset-dcat-valid-compress-format.jsonld
@@ -1,0 +1,50 @@
+{
+  "@context": {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "@type": "dcat:Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/persons",
+  "dct:title": { "@value": "Dataset with a declared compress format", "@language": "en" },
+  "dct:description": { "@value": "Dataset whose distribution declares dcat:compressFormat rather than a +gzip media type suffix", "@language": "en" },
+  "dct:identifier": "http://data.bibliotheken.nl/id/dataset/persons",
+  "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" },
+  "dct:publisher": {
+    "@id": "https://example.com/publisher",
+    "@type": "foaf:Organization",
+    "foaf:name": { "@value": "Koninklijke Bibliotheek", "@language": "nl" }
+  },
+  "dcat:distribution": [
+    {
+      "@type": "dcat:Distribution",
+      "dcat:mediaType": {
+        "@id": "https://www.iana.org/assignments/media-types/application/trig"
+      },
+      "dcat:compressFormat": {
+        "@id": "https://www.iana.org/assignments/media-types/application/gzip"
+      },
+      "dcat:accessURL": {
+        "@id": "https://data.bibliotheken.nl/id/dataset/persons.trig.gz"
+      },
+      "dcat:downloadURL": {
+        "@id": "https://data.bibliotheken.nl/id/dataset/persons.trig.gz"
+      },
+      "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" }
+    },
+    {
+      "@type": "dcat:Distribution",
+      "dcat:mediaType": {
+        "@id": "https://www.iana.org/assignments/media-types/application/n-triples"
+      },
+      "dcat:compressFormat": "application/zip",
+      "dcat:accessURL": {
+        "@id": "https://data.bibliotheken.nl/id/dataset/persons.nt.zip"
+      },
+      "dcat:downloadURL": {
+        "@id": "https://data.bibliotheken.nl/id/dataset/persons.nt.zip"
+      },
+      "dct:license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" }
+    }
+  ]
+}

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -244,6 +244,54 @@ describe('Fetch', () => {
     ).toBe(true);
   });
 
+  it('reads a declared dcat:compressFormat and normalizes it to an IANA URI', async () => {
+    const response = await file('dataset-dcat-valid-compress-format.jsonld');
+    nock('https://example.com')
+      .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
+      .get('/valid-dcat-dataset-compress-format')
+      .reply(200, response);
+
+    const datasets = await fetchDatasetsAsArray(
+      new URL('https://example.com/valid-dcat-dataset-compress-format'),
+    );
+
+    expect(datasets).toHaveLength(1);
+    const dataset = datasets[0];
+    const distributions = [
+      ...dataset.match(
+        factory.namedNode('http://data.bibliotheken.nl/id/dataset/persons'),
+        dcat('distribution'),
+        null,
+      ),
+    ];
+    expect(distributions).toHaveLength(2);
+
+    const compressFormatOf = (distribution: BlankNode) =>
+      [...dataset.match(distribution, dcat('compressFormat'))].map(
+        (quad) => quad.object.value,
+      );
+    const mediaTypeOf = (distribution: BlankNode) =>
+      [...dataset.match(distribution, dcat('mediaType'))].map(
+        (quad) => quad.object.value,
+      );
+
+    // An IRI compressFormat passes through, and the media type it accompanies
+    // must be left alone – it carries no +gzip suffix to strip.
+    const gzipDist = distributions[0].object as BlankNode;
+    expect(mediaTypeOf(gzipDist)).toEqual([
+      'https://www.iana.org/assignments/media-types/application/trig',
+    ]);
+    expect(compressFormatOf(gzipDist)).toEqual([
+      'https://www.iana.org/assignments/media-types/application/gzip',
+    ]);
+
+    // A literal compressFormat is normalized to its IANA URI, like mediaType.
+    const zipDist = distributions[1].object as BlankNode;
+    expect(compressFormatOf(zipDist)).toEqual([
+      'https://www.iana.org/assignments/media-types/application/zip',
+    ]);
+  });
+
   it('preserves ODRL policy on DCAT distributions', async () => {
     const response = await file('dataset-dcat-valid-with-policy.jsonld');
     nock('https://example.com')

--- a/packages/core/test/fetch.test.ts
+++ b/packages/core/test/fetch.test.ts
@@ -292,6 +292,61 @@ describe('Fetch', () => {
     ]);
   });
 
+  // A value that is not a media type cannot become an IANA URI. Minting one
+  // anyway yields an IRI with a space in it, which serializes to N-Triples that
+  // the store rejects – failing the whole registration over one bad value. Drop
+  // the property instead: lenient enough not to reject the dataset, strict
+  // enough to keep the stored IRI valid.
+  it('drops media type values that cannot become an IANA URI', async () => {
+    const response = await file('dataset-dcat-invalid-media-types.jsonld');
+    nock('https://example.com')
+      .defaultReplyHeaders({ 'Content-Type': 'application/ld+json' })
+      .get('/junk-media-types')
+      .reply(200, response);
+
+    const datasets = await fetchDatasetsAsArray(
+      new URL('https://example.com/junk-media-types'),
+    );
+
+    expect(datasets).toHaveLength(1);
+    const dataset = datasets[0];
+
+    // The dataset itself must still be ingested, distributions and all.
+    const distributions = [
+      ...dataset.match(
+        factory.namedNode('http://example.com/id/dataset/junk-media-types'),
+        dcat('distribution'),
+        null,
+      ),
+    ];
+    expect(distributions).toHaveLength(3);
+
+    // Nothing unusable is stored, under either property.
+    for (const predicate of [dcat('mediaType'), dcat('compressFormat')]) {
+      for (const quad of dataset.match(null, predicate, null)) {
+        expect(quad.object.termType).toBe('NamedNode');
+        expect(quad.object.value).not.toContain(' ');
+        expect(quad.object.value).toMatch(
+          /^https:\/\/www\.iana\.org\/assignments\/media-types\/[a-zA-Z]+\/|^(?!https:\/\/www\.iana\.org)/,
+        );
+      }
+    }
+
+    // Specifically: the three unusable values are gone, and the good one stays.
+    const compressFormats = [
+      ...dataset.match(null, dcat('compressFormat'), null),
+    ].map((quad) => quad.object.value);
+    expect(compressFormats).toEqual([]);
+
+    const mediaTypes = [...dataset.match(null, dcat('mediaType'), null)].map(
+      (quad) => quad.object.value,
+    );
+    expect(mediaTypes).toEqual([
+      'https://www.iana.org/assignments/media-types/application/n-triples',
+      'https://www.iana.org/assignments/media-types/application/n-triples',
+    ]);
+  });
+
   it('preserves ODRL policy on DCAT distributions', async () => {
     const response = await file('dataset-dcat-valid-with-policy.jsonld');
     nock('https://example.com')

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -22,10 +22,10 @@ export default defineConfig(() => ({
       exclude: ['src/mock.ts'],
       thresholds: {
         autoUpdate: true,
-        lines: 97.86,
+        lines: 97.87,
         functions: 96.63,
         branches: 91.86,
-        statements: 97.37,
+        statements: 97.38,
       },
     },
   },

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig(() => ({
         autoUpdate: true,
         lines: 97.86,
         functions: 96.63,
-        branches: 91.83,
+        branches: 91.86,
         statements: 97.37,
       },
     },

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -1568,8 +1568,8 @@ dcat:DistributionShape
     # +gzip/+zip suffix on dcat:mediaType.
     [
         sh:path dcat:compressFormat ;
-        sh:description "Het compressieformaat van de distributie, als mediatype uit de IANA media types-lijst (bijv. `application/gzip`). Dit is in DCAT de gebruikelijke manier om compressie aan te geven; een achtervoegsel op `dcat:mediaType` (bijv. `text/turtle+gzip`) wordt ook geaccepteerd. Zijn beide opgegeven, dan heeft `dcat:compressFormat` voorrang."@nl ,
-                       "The compression format of the distribution, as a media type from the IANA media types list (such as `application/gzip`). This is the usual way to declare compression in DCAT; a suffix on `dcat:mediaType` (such as `text/turtle+gzip`) is accepted as well. If both are given, `dcat:compressFormat` takes precedence."@en ;
+        sh:description "Het compressieformaat van de distributie, als mediatype uit de IANA media types-lijst (bijv. `application/gzip`). Dit is in DCAT de gebruikelijke manier om compressie aan te geven; een achtervoegsel op `dcat:mediaType` (bijv. `text/turtle+gzip`) wordt ook geaccepteerd. Zijn beide opgegeven, dan heeft `dcat:compressFormat` voorrang. Een waarde die geen mediatype is (bijv. `gzip` in plaats van `application/gzip`) wordt niet opgenomen."@nl ,
+                       "The compression format of the distribution, as a media type from the IANA media types list (such as `application/gzip`). This is the usual way to declare compression in DCAT; a suffix on `dcat:mediaType` (such as `text/turtle+gzip`) is accepted as well. If both are given, `dcat:compressFormat` takes precedence. A value that is not a media type (such as `gzip` rather than `application/gzip`) is not recorded."@en ;
     ] ,
     # Metadata-only property shape so the UI can surface a description for the
     # dct:conformsTo path emitted by DistributionSparqlMediaTypeRequiresProtocolShape

--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -1563,6 +1563,14 @@ dcat:DistributionShape
         ] ;
         sh:message "Verwijder het SPARQL MIME-type uit dcat:mediaType; SPARQL-endpoints worden gedeclareerd via dct:conformsTo"@nl, "Remove the SPARQL MIME type from dcat:mediaType; SPARQL endpoints are declared via dct:conformsTo"@en ;
     ] ,
+    # Metadata-only property shape: dcat:compressFormat carries no constraints of
+    # its own, but publishers need to be told it is read and preferred over a
+    # +gzip/+zip suffix on dcat:mediaType.
+    [
+        sh:path dcat:compressFormat ;
+        sh:description "Het compressieformaat van de distributie, als mediatype uit de IANA media types-lijst (bijv. `application/gzip`). Dit is in DCAT de gebruikelijke manier om compressie aan te geven; een achtervoegsel op `dcat:mediaType` (bijv. `text/turtle+gzip`) wordt ook geaccepteerd. Zijn beide opgegeven, dan heeft `dcat:compressFormat` voorrang."@nl ,
+                       "The compression format of the distribution, as a media type from the IANA media types list (such as `application/gzip`). This is the usual way to declare compression in DCAT; a suffix on `dcat:mediaType` (such as `text/turtle+gzip`) is accepted as well. If both are given, `dcat:compressFormat` takes precedence."@en ;
+    ] ,
     # Metadata-only property shape so the UI can surface a description for the
     # dct:conformsTo path emitted by DistributionSparqlMediaTypeRequiresProtocolShape
     # (which is SPARQL-bound and therefore not indexed by sh:path).


### PR DESCRIPTION
Fix #2251

Two commits: the reported bug, and an invalid-IRI hole found while checking how lenient the fix actually was.

## 1. Read a declared `dcat:compressFormat`

The register only ever inferred compression from a `+gzip`/`+zip` suffix on `dcat:mediaType`. It never read `dcat:compressFormat` – DCAT's own property for it, and the more common way to express it – so a publisher declaring the two separately had the compression silently dropped. The KB's catalog does exactly that:

```
<..> dcat:mediaType      <https://www.iana.org/assignments/media-types/application/trig> .
<..> dcat:compressFormat <https://www.iana.org/assignments/media-types/application/gzip> .
```

Everything downstream was already in place – the CONSTRUCT emits `dcat:compressFormat`, and the probe reads it back off the stored graph to decide which Content-Types to accept. Only the ingest read was missing, so the property was dropped before any of it ran.

- Read `dcat:compressFormat` in the DCAT branch, normalized to an IANA URI the same way as `dcat:mediaType`, so a literal `"application/zip"` is accepted alongside the IRI form.
- Prefer a declared `dcat:compressFormat` over the media-type suffix, keeping the suffix as fallback. `compressFormatFromMediaType()` becomes `compressFormat()`, as it no longer derives from the media type alone.
- Leave the schema.org branch suffix-only: schema.org has no `compressFormat` equivalent, and `schema:encodingFormat`'s own description already documents the suffix as the way to declare compression there.
- Describe `dcat:compressFormat` in `dcat:DistributionShape`. Description-only, no new constraints, so nothing that currently validates starts failing.

## 2. Only mint an IANA URI from a value that is a media type

`normalizeMediaType()` concatenated **any** literal onto the IANA prefix. A value that is not a media type became an IRI that either denotes nothing, or is not a valid IRI at all:

```
dcat:compressFormat "gzip"        ->  <.../media-types/gzip>          # no such media type
dcat:mediaType      "text turtle" ->  <.../media-types/text turtle>   # space: not a valid IRI
```

The second is the damaging one. It serializes through the project's own `quadsToNTriples` – the SPARQL-update path – into N-Triples a parser rejects (`Unexpected "<https://www.iana.org/assignments/media-types/text"`), because a space is excluded from `<IRIREF>`. The n3 `Writer` doesn't validate, so it goes out silently and the store rejects the update, failing the publisher's whole registration over one bad value. `dcat:mediaType` has no positive `sh:pattern` in the shapes (only the negative `application/sparql-` one), so such a value passes validation and reaches ingest.

This was pre-existing in `dcat:mediaType`; commit 1 extended the same helper to a second property, so it is fixed here for both.

- Guard the literal branch with the media-type pattern the shapes already apply to `schema:encodingFormat`, tested after parameters and any `+gzip`/`+zip` suffix are stripped.
- Leave a non-media-type value unbound rather than minting an IRI from it. The dataset and its other distributions still ingest, so leniency on input is unchanged – only the unusable property is dropped.

Behaviour on awkward input, all four distributions still ingesting:

| declared | stored |
| --- | --- |
| `"gzip"` | dropped (was `.../media-types/gzip`) |
| `"ZIP file"` | dropped (was `.../media-types/ZIP file`, invalid) |
| `<http://example.org/formats/bzip2>` | `https://example.org/formats/bzip2` (unchanged) |
| `"text/turtle; charset=utf-8"` | `.../media-types/text/turtle` (unchanged) |

## Verification

Beyond the unit tests, I ran the live KB catalog from the issue through the real ingest path. Before: **0** `dcat:compressFormat` triples. After: **16**, no invalid IRIs, with `http://data.bibliotheken.nl/id/dataset/persons` yielding

```json
{"downloadURL": ["https://data.bibliotheken.nl/KB/Production/download.trig.gz?graph=..."],
 "mediaType": ["https://www.iana.org/assignments/media-types/application/trig"],
 "compressFormat": ["https://www.iana.org/assignments/media-types/application/gzip"]}
```

## Notes for review

- The Dutch/English wording of the new `sh:description` is mine – worth a look.
- **Still open, deliberately not touched:** `normalizeMediaType()` rewrites `http:`->`https:` on *any* IRI, so a non-IANA `<http://example.org/formats/bzip2>` silently becomes `https://example.org/...`. That rewrite makes sense for iana.org; on someone else's host it edits their identifier.
- **Suggested follow-up:** add the same media-type `sh:pattern` to `dcat:mediaType` in the shapes, so a publisher is told rather than silently having the value dropped. That is a requirements change with `nde:futureChange` implications, so it does not belong here.
- Not included: the browser detail page still does not display `compressFormat` – a separate presentation question rather than the ingest bug reported here.
