### PR TITLE
fix(browser): show the register CTA on a deep-linked validation

### DIFF
--- a/apps/browser/src/lib/components/validation/UrlValidationForm.svelte
+++ b/apps/browser/src/lib/components/validation/UrlValidationForm.svelte
@@ -51,10 +51,7 @@
   let url = $state('');
   let submitting = $state(false);
   let progress = $state<ValidationProgress | null>(null);
-  let domainAllowed = $state<boolean | 'unknown'>('unknown');
   let submitController: AbortController | null = null;
-  let checkController: AbortController | null = null;
-  let checkTimer: ReturnType<typeof setTimeout> | undefined;
   let hasSubmitted = $state(false);
   let sourceOpen = $state(false);
   let hideFetched = $state(false);
@@ -76,9 +73,7 @@
 
   onDestroy(() => {
     submitController?.abort();
-    checkController?.abort();
     fetchController?.abort();
-    clearTimeout(checkTimer);
   });
 
   let fetchedText = $state<string | null>(null);
@@ -160,28 +155,6 @@
     });
   });
 
-  $effect(() => {
-    const current = url;
-    clearTimeout(checkTimer);
-    checkController?.abort();
-    const parsed = parseUrl(current);
-    if (!parsed) {
-      domainAllowed = 'unknown';
-      return;
-    }
-    checkTimer = setTimeout(() => {
-      const controller = new AbortController();
-      checkController = controller;
-      checkDomainAllowed(current, controller.signal)
-        .then((ok) => {
-          if (!controller.signal.aborted) domainAllowed = ok;
-        })
-        .catch(() => {
-          if (!controller.signal.aborted) domainAllowed = 'unknown';
-        });
-    }, 400);
-  });
-
   async function dereference(targetUrl: string) {
     fetchController?.abort();
     const controller = new AbortController();
@@ -232,12 +205,11 @@
     // while the SHACL validation runs.
     void dereference(url);
     const submittedUrl = url;
-    const allowedNow =
-      domainAllowed === true
-        ? true
-        : domainAllowed === false
-          ? false
-          : undefined;
+    // Only the outcome needs this, so ask alongside validation rather than
+    // before it. A failed check reads as ‘unknown’, never as ‘not allowed’.
+    const allowed = checkDomainAllowed(submittedUrl, controller.signal).catch(
+      () => undefined,
+    );
     try {
       const outcome = await validateByUrl(
         submittedUrl,
@@ -248,7 +220,7 @@
       );
       if (!controller.signal.aborted) {
         hideFetched = outcome.kind === 'no-dataset';
-        onOutcome(outcome, submittedUrl, allowedNow);
+        onOutcome(outcome, submittedUrl, await allowed);
       }
     } catch (error) {
       if (!controller.signal.aborted) {
@@ -259,7 +231,7 @@
               error instanceof Error ? error.message : 'Validation failed',
           },
           submittedUrl,
-          allowedNow,
+          await allowed,
         );
       }
     } finally {


### PR DESCRIPTION
The validate page offers “Aanmelden bij het Dataset Register” only once it knows the submitted URL’s domain is allowed. That answer came from a 400ms-debounced call to `GET /allowed-domains` that `submit()` read synchronously, before awaiting validation – so the CTA reflected whatever the check happened to know at submit time, not the answer for the URL actually submitted.

Typing a URL by hand hid the bug: the check resolved while the user reached for the button. Arriving at `/validate?url=…` did not. The form auto-submits on mount, the debounce had not yet fired its request, and the captured value stayed `undefined` even though the answer arrived a moment later while validation was still streaming. A valid, allow-listed description rendered its green summary with no way forward – which also made every shared validator link a dead end.

## Changes

- Call `GET /allowed-domains` for the submitted URL alongside validation, and await it when reporting the outcome. Validation is much the slower of the two, so this costs no perceptible time.
- Drop the debounced check, its timer and its abort controller. Nothing else read `domainAllowed`, so the request per keystroke pause only ever fed this one gate.
- A failed check still reads as “unknown” rather than “not allowed”, as before.

## Verification

Component tests would need a jsdom/client vitest project that this app does not have yet, so this was verified against the running app and the production API:

- `/validate?url=http://data.beeldengeluid.nl/id/dataset/0001` (allow-listed, validates without violations) renders the CTA, with the submitted URL threaded into the href.
- Stashing the fix and reloading the same URL reproduces the reported symptom exactly: the same green summary, no CTA.
- Non-allow-listed domains still resolve to `false` (`GET /allowed-domains` returns 404) and remain without a CTA.

## Related

#2272 covers the separate question of registering in-page via `POST /datasets` rather than handing off to the legacy `viaurl.php` demonstrator.
