### PR TITLE
feat(browser): say why a valid description cannot be submitted yet

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -472,6 +472,7 @@
   "validate_summary_submit_cta": "Submit to the Dataset Register",
   "validate_summary_domain_not_allowed_before": "Your domain name is not yet on the list of allowed domain names, so you cannot submit the dataset description yet. Contact ",
   "validate_summary_domain_not_allowed_after": " to have your domain name added.",
+  "validate_summary_domain_not_allowed_subject": "Please add {domain} to the list of allowed domain names",
   "validate_summary_invalid": "Invalid",
   "validate_summary_invalid_body": "Your dataset description has issues that need to be fixed before it can be registered.",
   "validate_summary_warnings_only": "Valid with recommendations",

--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -470,6 +470,8 @@
   "validate_summary_valid": "Valid",
   "validate_summary_valid_body": "Your dataset description meets the requirements.",
   "validate_summary_submit_cta": "Submit to the Dataset Register",
+  "validate_summary_domain_not_allowed_before": "Your domain name is not yet on the list of allowed domain names, so you cannot submit the dataset description yet. Contact ",
+  "validate_summary_domain_not_allowed_after": " to have your domain name added.",
   "validate_summary_invalid": "Invalid",
   "validate_summary_invalid_body": "Your dataset description has issues that need to be fixed before it can be registered.",
   "validate_summary_warnings_only": "Valid with recommendations",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -472,6 +472,7 @@
   "validate_summary_submit_cta": "Aanmelden bij het Dataset Register",
   "validate_summary_domain_not_allowed_before": "Je domeinnaam staat nog niet op de lijst met toegestane domeinnamen, dus je kunt de datasetbeschrijving nog niet aanmelden. Neem contact op via ",
   "validate_summary_domain_not_allowed_after": " om je domeinnaam te laten toevoegen.",
+  "validate_summary_domain_not_allowed_subject": "Graag {domain} toevoegen aan de lijst met toegestane domeinnamen",
   "validate_summary_invalid": "Ongeldig",
   "validate_summary_invalid_body": "Je datasetbeschrijving heeft fouten die opgelost moeten worden voordat registratie mogelijk is.",
   "validate_summary_warnings_only": "Geldig met aanbevelingen",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -470,6 +470,8 @@
   "validate_summary_valid": "Geldig",
   "validate_summary_valid_body": "Je datasetbeschrijving voldoet aan de vereisten.",
   "validate_summary_submit_cta": "Aanmelden bij het Dataset Register",
+  "validate_summary_domain_not_allowed_before": "Je domeinnaam staat nog niet op de lijst met toegestane domeinnamen, dus je kunt de datasetbeschrijving nog niet aanmelden. Neem contact op via ",
+  "validate_summary_domain_not_allowed_after": " om je domeinnaam te laten toevoegen.",
   "validate_summary_invalid": "Ongeldig",
   "validate_summary_invalid_body": "Je datasetbeschrijving heeft fouten die opgelost moeten worden voordat registratie mogelijk is.",
   "validate_summary_warnings_only": "Geldig met aanbevelingen",

--- a/apps/browser/src/lib/components/validation/ValidationSummary.svelte
+++ b/apps/browser/src/lib/components/validation/ValidationSummary.svelte
@@ -27,6 +27,8 @@
     /** Focus node -> rdf:type, built by the page so these counts match the report rows. */
     focusNodeTypes?: Map<string, string>;
     submitHref?: string;
+    /** The domain is known to be off the allow list, so registration would be refused. */
+    domainNotAllowed?: boolean;
     onExpand?: (section: 'warnings' | 'infos') => void;
   }
 
@@ -34,6 +36,7 @@
     state,
     focusNodeTypes = new Map(),
     submitHref,
+    domainNotAllowed = false,
     onExpand,
   }: Props = $props();
 
@@ -151,6 +154,14 @@
           {m.validate_summary_submit_cta()}
           <span class="sr-only">({m.opens_in_new_tab()})</span>
         </a>
+      </p>
+    {:else if status !== 'invalid' && domainNotAllowed}
+      <p class="mt-3 text-sm">
+        {m.validate_summary_domain_not_allowed_before()}<a
+          href="mailto:tech@netwerkdigitaalerfgoed.nl"
+          class="text-blue-700 underline hover:no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:text-blue-400"
+          >tech@netwerkdigitaalerfgoed.nl</a
+        >{m.validate_summary_domain_not_allowed_after()}
       </p>
     {/if}
   {:else if state.kind === 'parse-error'}

--- a/apps/browser/src/lib/components/validation/ValidationSummary.svelte
+++ b/apps/browser/src/lib/components/validation/ValidationSummary.svelte
@@ -27,8 +27,8 @@
     /** Focus node -> rdf:type, built by the page so these counts match the report rows. */
     focusNodeTypes?: Map<string, string>;
     submitHref?: string;
-    /** The domain is known to be off the allow list, so registration would be refused. */
-    domainNotAllowed?: boolean;
+    /** Host of the validated URL, set only when the allow list refused it. */
+    contactDomain?: string;
     onExpand?: (section: 'warnings' | 'infos') => void;
   }
 
@@ -36,9 +36,23 @@
     state,
     focusNodeTypes = new Map(),
     submitHref,
-    domainNotAllowed = false,
+    contactDomain,
     onExpand,
   }: Props = $props();
+
+  const contactEmail = 'tech@netwerkdigitaalerfgoed.nl';
+
+  // Name the domain in the subject: the reader has to add that specific one, and
+  // asking them to dig it out of the body wastes the one thing we already know.
+  const contactHref = $derived(
+    contactDomain
+      ? `mailto:${contactEmail}?subject=${encodeURIComponent(
+          m.validate_summary_domain_not_allowed_subject({
+            domain: contactDomain,
+          }),
+        )}`
+      : undefined,
+  );
 
   const counts = $derived.by(() => {
     if (state.kind !== 'report') {
@@ -155,12 +169,12 @@
           <span class="sr-only">({m.opens_in_new_tab()})</span>
         </a>
       </p>
-    {:else if status !== 'invalid' && domainNotAllowed}
+    {:else if status !== 'invalid' && contactHref}
       <p class="mt-3 text-sm">
         {m.validate_summary_domain_not_allowed_before()}<a
-          href="mailto:tech@netwerkdigitaalerfgoed.nl"
+          href={contactHref}
           class="text-blue-700 underline hover:no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:text-blue-400"
-          >tech@netwerkdigitaalerfgoed.nl</a
+          >{contactEmail}</a
         >{m.validate_summary_domain_not_allowed_after()}
       </p>
     {/if}

--- a/apps/browser/src/routes/validate/+page.svelte
+++ b/apps/browser/src/routes/validate/+page.svelte
@@ -94,7 +94,14 @@
 
   // Only when the allow list actually answered ‘no’. An unanswered check stays
   // undefined, and the Paste tab has no URL to judge – neither may claim this.
-  const domainNotAllowed = $derived(validatedUrlAllowed === false);
+  const notAllowedDomain = $derived.by(() => {
+    if (validatedUrlAllowed !== false || !validatedUrl) return undefined;
+    try {
+      return new URL(validatedUrl).host;
+    } catch {
+      return undefined;
+    }
+  });
 
   function handleStart() {
     summaryState = { kind: 'running' };
@@ -274,7 +281,7 @@
         state={summaryState}
         {focusNodeTypes}
         {submitHref}
-        {domainNotAllowed}
+        contactDomain={notAllowedDomain}
         onExpand={expandSection}
       />
     {/if}

--- a/apps/browser/src/routes/validate/+page.svelte
+++ b/apps/browser/src/routes/validate/+page.svelte
@@ -92,6 +92,10 @@
       : base;
   });
 
+  // Only when the allow list actually answered ‘no’. An unanswered check stays
+  // undefined, and the Paste tab has no URL to judge – neither may claim this.
+  const domainNotAllowed = $derived(validatedUrlAllowed === false);
+
   function handleStart() {
     summaryState = { kind: 'running' };
   }
@@ -270,6 +274,7 @@
         state={summaryState}
         {focusNodeTypes}
         {submitHref}
+        {domainNotAllowed}
         onExpand={expandSection}
       />
     {/if}


### PR DESCRIPTION
A dataset description on a domain that is not on the allow list validates cleanly and then offers nothing. The CTA is correctly hidden – `POST /datasets` would refuse the URL with a 403 – but the page never says why, so the publisher reads “Je datasetbeschrijving voldoet aan de vereisten” and hits a dead end.

That silence lands on exactly the publishers who are not registered yet, and the instruction they need is already in the API spec: *“Only URLs that are on the allow list can be registered. Please contact us to have your domain added.”* The page now says it, pointing at tech@netwerkdigitaalerfgoed.nl with the refused domain already in the subject line.

Reported against `https://beeldbank.hellendoorn.nl/opendata.php`: `sh:conforms: true` with zero findings, and `GET /allowed-domains` returns 404 for `hellendoorn.nl`.

## Wording

Dutch follows [netwerkdigitaalerfgoed.nl/datasetregister](https://netwerkdigitaalerfgoed.nl/datasetregister/): “de lijst met toegestane domeinnamen”, “aanmelden” (matching the existing CTA “Aanmelden bij het Dataset Register”), and the informal “je”.

> Je domeinnaam staat nog niet op de lijst met toegestane domeinnamen, dus je kunt de datasetbeschrijving nog niet aanmelden. Neem contact op via tech@netwerkdigitaalerfgoed.nl om je domeinnaam te laten toevoegen.

> Your domain name is not yet on the list of allowed domain names, so you cannot submit the dataset description yet. Contact tech@netwerkdigitaalerfgoed.nl to have your domain name added.

The `mailto:` carries a localised subject naming the domain, so the request arrives actionable rather than empty:

> Graag beeldbank.hellendoorn.nl toevoegen aan de lijst met toegestane domeinnamen

> Please add beeldbank.hellendoorn.nl to the list of allowed domain names

## Three states, not two

- **Allowed** → CTA, as before.
- **Not allowed** → the new note.
- **Unanswered** (the allow-list call failed) stays silent, and the Paste tab has no URL to judge. Neither may claim the domain is disallowed, so the note is gated on a definite `false` and the CTA on a definite `true`.

The remaining silent case is therefore only an unreachable allow list. Worth a follow-up if we would rather show a soft “couldn’t check” note there, but it seemed wrong to guess.

## Verification

Driven against the running app and the production API, in both locales:

- `/validate?url=https://beeldbank.hellendoorn.nl/opendata.php` renders the note, and the link resolves to `mailto:tech@netwerkdigitaalerfgoed.nl?subject=…beeldbank.hellendoorn.nl…` in the page’s language.
- `/validate?url=http://data.beeldengeluid.nl/id/dataset/0001` (allow-listed) still renders the CTA and no note.

Link contrast holds in both themes: `blue-700` on `green-50`/`yellow-50` and `blue-400` on `green-950`/`amber-950` are all well above the 4.5:1 AA threshold, and the link is underlined rather than distinguished by colour alone.

## Related

- Builds on #2271, which made the allow-list answer reliable for deep-linked validations. Without it this note could not appear on a shared `?url=` link.
- #2272 covers registering in-page rather than handing off to `viaurl.php`.
