### PR TITLE
feat(browser): show dct:source on the dataset detail page

### DIFF
--- a/apps/browser/messages/en.json
+++ b/apps/browser/messages/en.json
@@ -233,6 +233,8 @@
   "detail_is_part_of": "Part of",
   "detail_is_part_of_description": "The data catalog this dataset belongs to.",
   "detail_browse_catalog": "Browse catalog",
+  "detail_source": "Based on",
+  "detail_source_description": "The dataset this dataset is derived from.",
   "license_cc0_1_0": "CC0 1.0 Universal",
   "license_cc_by_4_0": "CC BY 4.0 International",
   "license_cc_by_3_0": "CC BY 3.0 Unported",

--- a/apps/browser/messages/nl.json
+++ b/apps/browser/messages/nl.json
@@ -233,6 +233,8 @@
   "detail_is_part_of": "Onderdeel van",
   "detail_is_part_of_description": "De datacatalogus waar deze dataset bij hoort.",
   "detail_browse_catalog": "Doorzoek catalogus",
+  "detail_source": "Gebaseerd op",
+  "detail_source_description": "De dataset waarvan deze dataset is afgeleid.",
   "license_cc0_1_0": "CC0 1.0 Universeel",
   "license_cc_by_4_0": "CC BY 4.0 Internationaal",
   "license_cc_by_3_0": "CC BY 3.0 Unported",

--- a/apps/browser/src/lib/services/dataset-detail.ts
+++ b/apps/browser/src/lib/services/dataset-detail.ts
@@ -199,6 +199,14 @@ export const DatasetDetailSchema = {
     '@id': dcterms.isPartOf,
     '@optional': true,
   },
+  // The dataset(s) this dataset is derived from. Harvested from dct:source for
+  // DCAT input and from schema:isBasedOn / schema:isBasedOnUrl for schema.org
+  // input, both of which the crawler stores as dct:source.
+  source: {
+    '@id': dcterms.source,
+    '@optional': true,
+    '@array': true,
+  },
   contentRating: {
     '@id': schema.contentRating,
     '@optional': true,

--- a/apps/browser/src/routes/dataset/+page.svelte
+++ b/apps/browser/src/routes/dataset/+page.svelte
@@ -1012,6 +1012,62 @@
             </div>
           {/if}
 
+          <!-- Source (the dataset this one is derived from) -->
+          {#if dataset.source && dataset.source.length > 0}
+            <div
+              class="grid grid-cols-1 gap-1 px-4 py-3 sm:grid-cols-[12rem_1fr] sm:gap-4"
+            >
+              <dt
+                class="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2"
+              >
+                <svg
+                  class="h-5 w-5 text-gray-500 dark:text-gray-400 flex-shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M13.828 10.172a4 4 0 010 5.656l-3 3a4 4 0 01-5.656-5.656l1.5-1.5M10.172 13.828a4 4 0 010-5.656l3-3a4 4 0 015.656 5.656l-1.5 1.5"
+                  />
+                </svg>
+                {m.detail_source()}
+                <span id="tooltip-source" class="cursor-pointer">
+                  <InfoCircleSolid
+                    class="h-4.5 w-4.5 text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400"
+                  />
+                </span>
+                <Tooltip triggeredBy="#tooltip-source"
+                  >{m.detail_source_description()}</Tooltip
+                >
+              </dt>
+              <dd class="text-sm text-gray-700 dark:text-gray-300 space-y-1">
+                {#each dataset.source as source (source)}
+                  <div>
+                    {#if source.startsWith('http://') || source.startsWith('https://')}
+                      <a
+                        href={source}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="inline-flex items-center gap-1 break-all text-blue-600 hover:underline dark:text-blue-400"
+                      >
+                        {source}
+                        <ArrowUpRightFromSquareOutline
+                          class="h-3 w-3 shrink-0"
+                        />
+                        <span class="sr-only"> ({m.opens_in_new_tab()})</span>
+                      </a>
+                    {:else}
+                      <span class="break-all">{source}</span>
+                    {/if}
+                  </div>
+                {/each}
+              </dd>
+            </div>
+          {/if}
+
           <!-- Landing Page -->
           {#if dataset.landingPage}
             <div


### PR DESCRIPTION
The register already harvests `dct:source` – and maps `schema:isBasedOn` / `schema:isBasedOnUrl` onto it – so the values are in the triple store, but the detail page never read or rendered them.

- `dataset-detail.ts`: added an optional, multi-valued `source` (`dct:source`) to `DatasetDetailSchema`. The detail CONSTRUCT already selects every predicate of the dataset, so the query is unchanged.
- `dataset/+page.svelte`: a “Based on” row between “Part of” and “Landing page”, with an info tooltip. Values that are http(s) URIs render as external links; anything else (some publishers supply literals) renders as plain text.
- English and Dutch labels.

Checked against the production SPARQL endpoint: `https://dc4eu.nl/id/datasets/nafotos` shows both of its archief.nl sources, and the literal-valued case (`https://dc4eu.nl/id/datasets/denbosch`) renders as text.

Not included: the SHACL requirements document `schema:isBasedOn` but have no `dct:source` property shape on the DCAT dataset shape, so DCAT publishers get no documentation that the property is supported. That is a spec change and belongs in its own PR.

Fix #2298
