### PR TITLE
feat(requirements): document dct:source on the DCAT dataset shape

### DIFF
--- a/requirements/shacl.ttl
+++ b/requirements/shacl.ttl
@@ -1514,6 +1514,12 @@ dcat:DatasetShape
         sh:nodeKind sh:IRI ;
         sh:pattern "^https?://" ;
         sh:description """Een webpagina die toegang biedt tot de dataset, zijn distributies of aanvullende informatie. Niet nodig als de URI van de dataset zelf al naar een HTML-pagina leidt. De menselijk leesbare beschrijving MOET consistent zijn met en minstens alle details (zoals distributies) uit de RDF-datasetbeschrijving bevatten."""@nl, """A web page that provides access to the Dataset, its Distributions and/or additional information. Not needed when the dataset URI itself resolves to an HTML page. The human-readable description MUST be consistent with and include at least all details (such as distributions) from the RDF dataset description."""@en ;
+    ] ,
+    [
+        a sh:PropertyShape ;
+        sh:path dc:source ;
+        sh:minCount 0 ;
+        sh:description "De URI van een dataset waarop deze dataset is gebaseerd."@nl, "The URI of a dataset this dataset is based on."@en ;
     ] ;
     sh:targetClass dcat:Dataset ;
 .


### PR DESCRIPTION
Follow-up to #2299, which shows `dct:source` on the detail page.

The crawler already reads `dct:source` from DCAT input (and maps `schema:isBasedOn` / `schema:isBasedOnUrl` onto it), but only the schema.org shape documented `schema:isBasedOn`. DCAT publishers – DC4EU among them – had no sign from the shape graph that the property is supported.

This adds a property shape for `dct:source` to `dcat:DatasetShape`, with the same description as `schema:isBasedOn`. It is documentation only: no `sh:nodeKind`, no cardinality beyond `sh:minCount 0`, so it produces no validation results and existing registrations keep their current outcome and completeness rating.

Note that the published requirements document builds its attribute tables from the schema.org shapes only, so this shows up in the served shape graph (`/api/shacl`) rather than in the HTML spec – the same as the other DCAT-side properties such as `dcat:landingPage`.

Deliberately not included: a `sh:nodeKind sh:IRI` check. Some registrations currently supply `dct:source` as a literal, so adding one would change their validation outcome; worth deciding separately.

Related to #2298.
