### PR TITLE
fix(browser): return a platform Response from /graphql

### DIFF
--- a/apps/browser/src/routes/graphql/+server.ts
+++ b/apps/browser/src/routes/graphql/+server.ts
@@ -17,8 +17,26 @@ import { searchGraphQLHandler } from '$lib/services/search/engine.server';
  * `Accept-Language` header, which the handler negotiates (q-values respected)
  * into the query’s output-language preference.
  */
-export const POST: RequestHandler = ({ request }) =>
-  searchGraphQLHandler()(request);
+/**
+ * Re-wrap the handler's response in the platform `Response`.
+ *
+ * graphql-yoga answers with `@whatwg-node/fetch`'s ponyfilled `Response`, which
+ * is a different class from the global one even where the shapes match.
+ * SvelteKit endpoint results are checked with `instanceof Response` against the
+ * global, so returning yoga's object directly fails that check and the route 500s
+ * with “handler should return a Response object” – for every request, including
+ * the playground. Copying it across the realm boundary is the whole fix; the body
+ * is passed through as a stream, so this buffers nothing.
+ */
+async function respond(request: Request): Promise<Response> {
+  const response = await searchGraphQLHandler()(request);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
 
-export const GET: RequestHandler = ({ request }) =>
-  searchGraphQLHandler()(request);
+export const POST: RequestHandler = ({ request }) => respond(request);
+
+export const GET: RequestHandler = ({ request }) => respond(request);

--- a/apps/browser/src/routes/graphql/server.test.ts
+++ b/apps/browser/src/routes/graphql/server.test.ts
@@ -1,0 +1,63 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { GET, POST } from './+server';
+
+/**
+ * The endpoint is exercised for real rather than against a mocked handler: the
+ * bug this guards against lives in the boundary between graphql-yoga's
+ * ponyfilled `Response` and the platform one, which only a real handler
+ * reproduces. Neither request below reaches Typesense – `?sdl` prints the
+ * schema and the playground is static – so a dummy connection suffices.
+ */
+beforeAll(() => {
+  process.env.TYPESENSE_HOST ??= 'localhost';
+  process.env.TYPESENSE_API_KEY ??= 'test';
+});
+
+/** SvelteKit checks an endpoint result with `instanceof Response` against the
+ *  global; anything else fails the route with a 500 at runtime, which no
+ *  type-level check catches. */
+function expectPlatformResponse(
+  response: unknown,
+): asserts response is Response {
+  expect(response).toBeInstanceOf(Response);
+}
+
+describe('/graphql', () => {
+  it('answers a query with a platform Response', async () => {
+    const response = await POST({
+      request: new Request('http://localhost/graphql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: '{__typename}' }),
+      }),
+    } as Parameters<typeof POST>[0]);
+
+    expectPlatformResponse(response);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      data: { __typename: 'Query' },
+    });
+  });
+
+  it('serves the SDL as a platform Response', async () => {
+    const response = await GET({
+      request: new Request('http://localhost/graphql?sdl'),
+    } as Parameters<typeof GET>[0]);
+
+    expectPlatformResponse(response);
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain('type Query {');
+  });
+
+  it('serves the playground as a platform Response', async () => {
+    const response = await GET({
+      request: new Request('http://localhost/graphql', {
+        headers: { Accept: 'text/html' },
+      }),
+    } as Parameters<typeof GET>[0]);
+
+    expectPlatformResponse(response);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+  });
+});


### PR DESCRIPTION
**Prod is down on `/graphql`** — every request has 500'd with `handler should return a Response object` since #2285 moved the endpoint onto the LDE handler.

graphql-yoga answers with `@whatwg-node/fetch`'s `Response`. That package is a *ponyfill* ("Cross Platform Smart Fetch Ponyfill" — its own description): it exports its classes instead of assigning to `globalThis`. A polyfill would have replaced the global and both sides would agree; a ponyfill leaves it alone, so there are two distinct `Response` classes. SvelteKit checks endpoint results with `instanceof Response` against the global, so yoga's object fails and the route never answers.

Fix: copy the response across the realm boundary. The body passes through as a stream, so nothing is buffered.

## Why nothing caught it

- **Types can't**: both classes satisfy `Response`, so `svelte-check` is happy.
- **Unit tests didn't**: nothing exercised the route. The new test drives the real `GET`/`POST` rather than a mocked handler — the mismatch exists only between yoga's ponyfill and the platform, so a double cannot reproduce it. Confirmed it fails without the fix.
- **`docker:smoke` didn't**: it asserts the image boots, not that a route answers.

Verified against `node build` locally: POST executes, `?sdl` returns the schema, the playground serves `text/html`.