### PR TITLE
docs(browser): correct the stale search-subdomain claim

### DIFF
--- a/apps/browser/src/lib/services/search/client.ts
+++ b/apps/browser/src/lib/services/search/client.ts
@@ -7,8 +7,11 @@ interface GraphQLError {
 
 /**
  * The GraphQL search endpoint the browser posts to. Defaults to the same-origin
- * `/graphql` route (no CORS, resolvable server-side via `event.fetch`); a
- * deployment can point it at the dedicated search subdomain instead.
+ * `/graphql` route, which needs no CORS and which `event.fetch` resolves
+ * in-process server-side rather than over the network. Set
+ * `PUBLIC_SEARCH_GRAPHQL_ENDPOINT` to point a deployment at a dedicated endpoint
+ * instead – the seam for serving the API from its own pod, which would trade
+ * that in-process resolution for a network hop per server-rendered page.
  */
 function endpoint(): string {
   return env.PUBLIC_SEARCH_GRAPHQL_ENDPOINT || '/graphql';

--- a/apps/browser/src/routes/graphql/+server.ts
+++ b/apps/browser/src/routes/graphql/+server.ts
@@ -3,8 +3,10 @@ import { searchGraphQLHandler } from '$lib/services/search/engine.server';
 
 /**
  * The GraphQL search endpoint. The browser’s dataset listing queries it
- * same-origin (`/graphql`); the same handler is also reachable at the public
- * search subdomain (an ingress alias to this pod) for external consumers.
+ * same-origin (`/graphql`), and it is the Register’s public search API: the
+ * ingress routes `/graphql` on the main host to this pod. (There is no separate
+ * search subdomain – the former `search.datasetregister…` served the retired
+ * client-direct-to-Typesense path, and Typesense now has no ingress at all.)
  *
  * The endpoint itself is `@lde/search-api-graphql`’s framework-agnostic `fetch`
  * handler, mounted as-is: `POST` executes, `GET` serves the self-contained


### PR DESCRIPTION
Two comments described `/graphql` as "also reachable at the public search subdomain (an ingress alias to this pod) for external consumers". There is no such ingress.

`infrastructure/k8s/dataset-register/typesense.yaml` records why: the former `search.datasetregister…` subdomain and its search-only key served the retired client-direct-to-Typesense path, and Typesense now has no ingress at all. The public API is `/graphql` on the main host, which the browser ingress does route.

I inherited the claim rather than checking it, then repeated it as fact while reasoning about whether to split the endpoint onto its own pod — so it was actively misleading a design discussion.

Also names what `PUBLIC_SEARCH_GRAPHQL_ENDPOINT` is the seam for, and what taking it would cost: `event.fetch` resolves the same-origin relative URL **in-process** server-side, so pointing it at a separate pod trades that for a real network hop on every server-rendered listing. Worth having written down next to the switch.