### PR TITLE
build(deps): bump env-schema from 7 to 8

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,7 @@
     "@fastify/swagger-ui": "^6.1.1",
     "@lde/fastify-rdf": "^0.5.1",
     "@rdfjs/types": "2.0.1",
-    "env-schema": "^7.0.0",
+    "env-schema": "^8.0.0",
     "fastify": "^5.11.3",
     "psl": "1.15.0",
     "rdf-ext": "2.6.0"

--- a/apps/crawler/package.json
+++ b/apps/crawler/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@dataset-register/core": "*",
     "@dataset-register/search-indexer": "*",
-    "env-schema": "^7.0.0",
+    "env-schema": "^8.0.0",
     "pino": "^10.2.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@fastify/swagger-ui": "^6.1.1",
         "@lde/fastify-rdf": "^0.5.1",
         "@rdfjs/types": "2.0.1",
-        "env-schema": "^7.0.0",
+        "env-schema": "^8.0.0",
         "fastify": "^5.11.3",
         "psl": "1.15.0",
         "rdf-ext": "2.6.0"
@@ -136,7 +136,7 @@
       "dependencies": {
         "@dataset-register/core": "*",
         "@dataset-register/search-indexer": "*",
-        "env-schema": "^7.0.0",
+        "env-schema": "^8.0.0",
         "pino": "^10.2.0"
       },
       "devDependencies": {
@@ -19324,9 +19324,9 @@
       }
     },
     "node_modules/env-schema": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/env-schema/-/env-schema-7.0.0.tgz",
-      "integrity": "sha512-b8rdAwdFpekDxNAUNuT6KbV/QEX/pTBs0gjehEPmBUUteh9zBDm9zxFSQt55D29odo3rJt4feoWRqn4U/tzicw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/env-schema/-/env-schema-8.0.0.tgz",
+      "integrity": "sha512-BBF/xWtTC9MeNfJONdC//oL5Gjl+rVN5lvrSVEltWjh5uJ/UXoSLN/ddn5k023yYC68mCqhGIuu5CXNTAF8CPA==",
       "funding": [
         {
           "type": "github",
@@ -29436,7 +29436,7 @@
         "@lde/search": "^0.21.1",
         "@lde/search-typesense": "^0.24.1",
         "@rdfjs/types": "2.0.1",
-        "env-schema": "^7.0.0",
+        "env-schema": "^8.0.0",
         "n3": "^2.2.0",
         "pino": "^10.2.0",
         "tslib": "^2.3.0",

--- a/packages/search-indexer/package.json
+++ b/packages/search-indexer/package.json
@@ -20,7 +20,7 @@
     "@lde/search": "^0.21.1",
     "@lde/search-typesense": "^0.24.1",
     "@rdfjs/types": "2.0.1",
-    "env-schema": "^7.0.0",
+    "env-schema": "^8.0.0",
     "n3": "^2.2.0",
     "pino": "^10.2.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
Supersedes #2315, rebuilt on current `main` — and takes only one of its three updates.

**`env-schema` 7 → 8** lands. All three consumers (`apps/api`, `apps/crawler`, `packages/search-indexer`) use the same `envSchema` + `JSONSchemaType` surface and compile and pass unchanged.

**graphql stays on `^16`**, as it did in #2297. `@lde/search-api-graphql` 0.23.1 still depends on `graphql@^16.9.0`, and `graphql-yoga` peers `^15 || ^16`, so graphql 17 nests a second copy beside the hoisted one — visible in #2315's own lockfile diff as `node_modules/@lde/search-api-graphql/node_modules/graphql`.

That is worth refusing rather than working around. graphql-js does nominal checks across its schema and AST types, so two copies in one process fail them the same way yoga's ponyfilled `Response` failed SvelteKit's `instanceof` check — the outage in #2306. We have just paid for that lesson once.

graphql moves when `@lde/search-api-graphql` does.

Verified: lint, typecheck, check, build, the full suite, `docker:build` and `docker:smoke`. One hoisted `graphql@16.14.2`, with 17.0.2 nested only under `graphql-to-sparql`, which requires it.
