### PR TITLE
ci: retry the contract label instead of failing on a GitHub blip

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -169,12 +169,27 @@ jobs:
           MOVED: ${{ steps.surface.outputs.moved }}
           PR: ${{ github.event.pull_request.number }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           gh label create "$LABEL" --color 1d76db \
             --description 'Changes the published GraphQL surface consumers query' \
             2>/dev/null || true
           if [ "$MOVED" = 'true' ]; then
-            gh pr edit "$PR" --add-label "$LABEL"
+            action=--add-label
           else
-            gh pr edit "$PR" --remove-label "$LABEL"
+            action=--remove-label
           fi
+          # Retry: the label is a signal, and a GitHub blip is not news about
+          # this branch. #2320 went red purely because `gh pr edit` met a 503
+          # during an API incident, minutes after the contract itself had been
+          # written and found current.
+          for attempt in 1 2 3; do
+            if gh pr edit "$PR" "$action" "$LABEL"; then
+              exit 0
+            fi
+            sleep $((attempt * 10))
+          done
+          # Warn rather than fail. The committed contract is the substance of
+          # this job and it is already correct by here; a job that goes red on a
+          # transient API error teaches everyone to ignore it, which costs more
+          # than a stale label.
+          echo "::warning::Could not ${action#--} ${LABEL} on #${PR}; the committed contract is unaffected."


### PR DESCRIPTION
#2320's `graphql-contract` job went red for a reason that says nothing about the branch: `gh pr edit` met an `HTTP 503` during last night's GitHub API incident — minutes *after* the job had already regenerated the contract, found it current, and determined the surface had not moved.

```
MOVED: false
HTTP 503: No server is currently available to service your request.
##[error]Process completed with exit code 1.
```

The label is a signal *about the branch*. An API outage is not.

Retry three times with backoff, then `::warning::` instead of failing. By the time labelling runs, the committed contract — this job's actual substance — is already correct, so a red mark there reports nothing true. And a job that goes red on transient infrastructure is a job people learn to skim past, which costs more than a stale label.

Also replaces the `if`/`else` around two near-identical `gh pr edit` calls with one call and an `action` variable, so the retry wraps a single command.
