### PR TITLE
build(deps): bump ldkit from 2.6.0 to 2.7.2

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -44,7 +44,7 @@
     "flowbite-svelte-icons": "^3.1.0",
     "graphql": "^16.14.2",
     "ioredis": "^6.0.0",
-    "ldkit": "^2.6.0",
+    "ldkit": "^2.7.2",
     "lz-string": "^1.5.0",
     "marked": "^18.0.9",
     "n3": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "flowbite-svelte-icons": "^3.1.0",
         "graphql": "^16.14.2",
         "ioredis": "^6.0.0",
-        "ldkit": "^2.6.0",
+        "ldkit": "^2.7.2",
         "lz-string": "^1.5.0",
         "marked": "^18.0.9",
         "n3": "^2.2.0",
@@ -23270,9 +23270,9 @@
       }
     },
     "node_modules/ldkit": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/ldkit/-/ldkit-2.7.1.tgz",
-      "integrity": "sha512-NxDjMcPzd0fCd4ltpBV2uFvYuAMALvK2WXdc20Vz3itrLM5Egax00p5esR3crch5L4Vh3XcBJkhy+rF2njEj1A==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/ldkit/-/ldkit-2.7.2.tgz",
+      "integrity": "sha512-h/dxmLTLUr85XjYI3NLsCDjiA1aB+ibsQIIsLfxp96dxemJ98awcSbzZcMJ424pPgRRcX6x5pkcdse8/cDABgw==",
       "license": "MIT",
       "dependencies": {
         "@comunica/types": "^5",


### PR DESCRIPTION
The remaining new item from #2320. `env-schema` landed in #2319, and graphql stays on `^16` for the reason recorded there — `@lde/search-api-graphql` 0.23.1 still needs `^16.9.0`, so 17 nests a second copy.

ldkit drives the detail page's RDF read, so beyond the unit suite I checked the failure it could plausibly cause. It pulls in **27 further packages**, and a node builtin reaching the client bundle would break hydration in a way no unit test or `svelte-check` sees — the trap recorded from #2120.

- Client bundle carries **zero** `node:` imports.
- The full e2e suite passes (12/12), including the production-hydration test that loads the real built bundle.
- Plus lint, typecheck, check, build, the unit suite, `docker:build` and `docker:smoke`.
